### PR TITLE
Add viewport culling and increase max zoom to 1000x

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -349,9 +349,6 @@ class _ChartViewerScreenState extends State<ChartViewerScreen> {
       coastlineLods: _regionalLods,
       globalLods: _globalLods,
       viewBounds: _viewBounds,
-      initialZoom: 1.0,
-      minZoom: 0.1,
-      maxZoom: 50.0,
     );
   }
 

--- a/lib/models/geo_types.dart
+++ b/lib/models/geo_types.dart
@@ -49,6 +49,14 @@ class GeoBounds {
         point.latitude <= maxLat;
   }
 
+  /// Returns true if this bounds intersects (overlaps) with the other bounds.
+  bool intersects(GeoBounds other) {
+    return minLon <= other.maxLon &&
+        maxLon >= other.minLon &&
+        minLat <= other.maxLat &&
+        maxLat >= other.minLat;
+  }
+
   /// Expands bounds to include another point.
   GeoBounds expand(GeoPoint point) {
     return GeoBounds(


### PR DESCRIPTION
Changes:

- Increase maxZoom default from 50 to 1000

- Add GeoBounds.intersects() for bounds overlap testing

- Add canvas clipping rect for efficiency

- Add polygon-level viewport culling in _buildLandPath()

- Add _screenToGeo() inverse projection and _getVisibleBounds()

- Remove explicit zoom params from main.dart (use defaults)