### PR TITLE
Fix Mapsui surface rendering

### DIFF
--- a/src/Navtool.App/Models/RouteMapSelection.cs
+++ b/src/Navtool.App/Models/RouteMapSelection.cs
@@ -18,4 +18,3 @@ public sealed record RouteMapSelection(
     public DateTimeOffset TimelineTimestamp => Point.Timestamp;
     public Coordinate FocusCoordinate => Point.Location;
 }
-}

--- a/src/Navtool.App/Services/RouteHitTester.cs
+++ b/src/Navtool.App/Services/RouteHitTester.cs
@@ -115,4 +115,3 @@ public static class RouteHitTester
     }
     private sealed record ProjectedRoute(RouteResult Route, ScreenPoint[] Points);
 }
-}

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -13,8 +13,7 @@ namespace Navtool.App.Services;
 
 public sealed record OsmTileOptions(
     bool Enabled = true,
-    string UserAgent = "Navtool/1.0",
-    string Attribution = "© OpenStreetMap contributors");
+    string UserAgent = "Navtool/1.0");
 
 public sealed class RouteMapLayers
 {

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -135,7 +135,6 @@ public partial class MainViewModel : ViewModelBase
         Map.Layers.Add(osmLayer);
 
         _mapLayers = new RouteMapLayers(Map);
-        OsmAttribution = tileOptions.Attribution;
         UtcOffsetDisplay = FormatUtcOffset(localTimeZone.GetUtcOffset(timeProvider.GetLocalNow()));
         Map.Navigator.CenterOnAndZoomTo(
             MapProjection.ToMapPoint(new Coordinate(35, -55)),
@@ -145,8 +144,6 @@ public partial class MainViewModel : ViewModelBase
     public event EventHandler<RouteMapSelection?>? RouteSelectionChanged;
 
     public Map Map { get; }
-
-    public string OsmAttribution { get; }
 
     public string UtcOffsetDisplay { get; }
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -277,8 +277,7 @@
                         ClipToBounds="True">
                     <Grid>
                         <mapsui:MapControl x:Name="MapView"
-                                           Map="{Binding Map}"
-                                           Background="#DDE7EC" />
+                                           Map="{Binding Map}" />
 
                         <Border HorizontalAlignment="Center"
                                 VerticalAlignment="Top"
@@ -375,16 +374,6 @@
                             </StackPanel>
                         </Border>
 
-                        <Border HorizontalAlignment="Right"
-                                VerticalAlignment="Bottom"
-                                Margin="14"
-                                Background="#EFFFFFFF"
-                                CornerRadius="4"
-                                Padding="7,4">
-                            <TextBlock Text="{Binding OsmAttribution}"
-                                       Foreground="#435660"
-                                       FontSize="10" />
-                        </Border>
                     </Grid>
                 </Border>
 

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -1,0 +1,67 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Mapsui.Tiling.Layers;
+using Mapsui.UI.Avalonia;
+using Navtool.App.Services;
+using Navtool.App.ViewModels;
+using Navtool.App.Views;
+
+namespace Navtool.App.Tests;
+
+public sealed class MapRenderingTests
+{
+    [AvaloniaFact]
+    public void MainWindowLeavesMapsuiSurfaceUncovered()
+    {
+        var viewModel = CreateViewModel(tilesEnabled: false);
+        var window = new MainWindow
+        {
+            DataContext = viewModel
+        };
+
+        try
+        {
+            window.Show();
+            var mapControl = window.FindControl<MapControl>("MapView");
+
+            Assert.NotNull(mapControl);
+            Assert.Same(viewModel.Map, mapControl.Map);
+            Assert.Null(mapControl.Background);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [Fact]
+    public void MapCompositionPlacesOpenStreetMapBelowRouteOverlays()
+    {
+        var viewModel = CreateViewModel(tilesEnabled: true);
+        var layers = viewModel.Map.Layers.ToArray();
+
+        var baseLayer = Assert.IsType<TileLayer>(layers[0]);
+        Assert.True(baseLayer.Enabled);
+        Assert.Equal("OpenStreetMap", baseLayer.Name);
+        Assert.Equal("© OpenStreetMap contributors", baseLayer.Attribution.Text);
+        Assert.Equal(
+            [
+                "Wind speed",
+                "Wind direction",
+                "NOAA GFS routes",
+                "ECMWF IFS routes",
+                "Route endpoints",
+                "Timeline route points",
+                "Selected route point"
+            ],
+            layers.Skip(1).Select(layer => layer.Name));
+    }
+
+    private static MainViewModel CreateViewModel(bool tilesEnabled) =>
+        new(
+            null,
+            null,
+            TimeProvider.System,
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: tilesEnabled));
+}

--- a/tests/Navtool.App.Tests/Navtool.App.Tests.csproj
+++ b/tests/Navtool.App.Tests/Navtool.App.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/tests/Navtool.App.Tests/TestAppBuilder.cs
+++ b/tests/Navtool.App.Tests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+using Navtool.App;
+
+[assembly: AvaloniaTestApplication(typeof(Navtool.App.Tests.TestAppBuilder))]
+
+namespace Navtool.App.Tests;
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<App>()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}


### PR DESCRIPTION
## Summary
- remove the opaque Avalonia `MapControl.Background` that covered Mapsui's custom Skia output
- rely on the OpenStreetMap tile layer's built-in attribution instead of rendering a duplicate badge
- repair two stray braces that blocked clean builds
- add headless window and map-layer regression coverage

## Validation
- `dotnet build Navtool.sln --nologo --verbosity:minimal`
- `dotnet test Navtool.sln --no-build --nologo --verbosity:minimal` (46 passed)
- desktop app launches with the fixed map surface