### PR TITLE
Visualize streamed route and isochrone progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It targets macOS, Windows, and Linux.
 - Choose a local departure date/time, converted to UTC with DST validation.
 - Download geographically subsetted NOAA GFS 0.25-degree 10 m wind fields.
 - Calculate routes through the native `router-lib` bridge.
+- Watch retained isochrone frontiers and the closest provisional route stream
+  onto the map while each model calculates.
 - Compare model routes with distinct map colors. ECMWF is shown as an
   experimental option and currently fails explicitly because official indexed
   retrieval is not implemented.
@@ -61,6 +63,33 @@ dotnet run --project src/Navtool.App
 The application discovers the development bridge automatically. For a custom
 location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
 directory.
+
+## Streaming route visualization
+
+Navtool uses router-lib's `RoutingProgressCallback` contract. After each
+completed search step with a retained frontier, the native bridge synchronously
+copies the callback-scoped isochrone, provisional route, and cumulative
+diagnostics into immutable managed data. The callback returns promptly; Mapsui
+updates are posted through the application's progress pipeline to the Avalonia
+UI context.
+
+Each model uses its normal route color. Completed isochrone frontiers accumulate
+as thin low-opacity lines, while the model's provisional route is replaced by
+the latest snapshot. Successful search overlays remain visible with the final
+route. Failed model overlays and all cancelled-calculation overlays are cleared.
+Frontiers, routes, and map-fit bounds are unwrapped safely at the antimeridian.
+
+The final route result remains authoritative and may differ from the last
+provisional route. Router-lib progress is notification-only: cancelling in
+Navtool prevents stale updates and results from being accepted, but it does not
+interrupt an optimization already executing inside the native library.
+
+The additive C ABI entry point
+`navtool_router_calculate_route_streaming_v1` preserves the existing v1
+final-route function. Progress array pointers are valid only for the duration
+of the synchronous callback and must be copied by consumers. Navtool falls back
+to final-only route calculation when it loads an older ABI-v1 bridge that does
+not export the streaming entry point.
 
 ## Publish
 

--- a/native/Navtool.RouterBridge/include/navtool_router_bridge.h
+++ b/native/Navtool.RouterBridge/include/navtool_router_bridge.h
@@ -56,6 +56,45 @@ typedef struct navtool_router_wind_sample_v1 {
     uint8_t reserved[7];
 } navtool_router_wind_sample_v1;
 
+typedef struct navtool_router_coordinate_v1 {
+    double latitude_degrees;
+    double longitude_degrees;
+} navtool_router_coordinate_v1;
+
+typedef struct navtool_router_route_point_v1 {
+    navtool_router_coordinate_v1 position;
+    int64_t utc_epoch_seconds;
+    double heading_degrees;
+    double boat_speed_knots;
+    double true_wind_speed_knots;
+    double true_wind_direction_degrees;
+    double cumulative_distance_nautical_miles;
+} navtool_router_route_point_v1;
+
+typedef struct navtool_router_diagnostics_v1 {
+    uint64_t expanded_nodes;
+    uint64_t generated_candidates;
+    uint64_t retained_candidates;
+    uint64_t time_steps;
+} navtool_router_diagnostics_v1;
+
+typedef struct navtool_router_progress_v1 {
+    int64_t isochrone_utc_epoch_seconds;
+    const navtool_router_coordinate_v1* isochrone_points;
+    uint64_t isochrone_point_count;
+    const navtool_router_route_point_v1* provisional_route_points;
+    uint64_t provisional_route_point_count;
+    navtool_router_diagnostics_v1 diagnostics;
+} navtool_router_progress_v1;
+
+/*
+ * Progress views and their arrays are valid only for the duration of the
+ * callback. The callback is synchronous and must return promptly.
+ */
+typedef void (*navtool_router_progress_callback_v1)(
+    const navtool_router_progress_v1* progress,
+    void* user_data);
+
 NAVTOOL_ROUTER_BRIDGE_API uint32_t
 navtool_router_bridge_abi_version_v1(void);
 
@@ -95,6 +134,19 @@ navtool_router_calculate_route_v1(
     double destination_latitude_degrees,
     double destination_longitude_degrees,
     const int64_t* departure_utc_epoch_seconds,
+    char** out_route_json_utf8,
+    size_t* out_route_json_length);
+
+NAVTOOL_ROUTER_BRIDGE_API navtool_router_status_v1
+navtool_router_calculate_route_streaming_v1(
+    const navtool_router_forecast_v1* forecast,
+    double start_latitude_degrees,
+    double start_longitude_degrees,
+    double destination_latitude_degrees,
+    double destination_longitude_degrees,
+    const int64_t* departure_utc_epoch_seconds,
+    navtool_router_progress_callback_v1 on_progress,
+    void* progress_user_data,
     char** out_route_json_utf8,
     size_t* out_route_json_length);
 

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <utility>
+#include <vector>
 
 struct navtool_router_forecast_v1 {
     explicit navtool_router_forecast_v1(sailroute::WeatherDataset value)
@@ -172,6 +173,125 @@ navtool_router_status_v1 load_forecast(
         NAVTOOL_ROUTER_STATUS_OK_V1);
 }
 
+navtool_router_coordinate_v1 copy_coordinate(
+    sailroute::Coordinate coordinate) noexcept {
+    return {
+        coordinate.latitude_degrees,
+        coordinate.longitude_degrees};
+}
+
+navtool_router_route_point_v1 copy_route_point(
+    const sailroute::RoutePoint& point) noexcept {
+    return {
+        copy_coordinate(point.position),
+        to_epoch(point.time),
+        point.heading_degrees,
+        point.boat_speed_knots,
+        point.true_wind_speed_knots,
+        point.true_wind_direction_degrees,
+        point.cumulative_distance_nautical_miles};
+}
+
+navtool_router_diagnostics_v1 copy_diagnostics(
+    const sailroute::RouteDiagnostics& diagnostics) noexcept {
+    return {
+        static_cast<uint64_t>(diagnostics.expanded_nodes),
+        static_cast<uint64_t>(diagnostics.generated_candidates),
+        static_cast<uint64_t>(diagnostics.retained_candidates),
+        static_cast<uint64_t>(diagnostics.time_steps)};
+}
+
+navtool_router_status_v1 calculate_route(
+    const navtool_router_forecast_v1* forecast,
+    double start_latitude_degrees,
+    double start_longitude_degrees,
+    double destination_latitude_degrees,
+    double destination_longitude_degrees,
+    const int64_t* departure_utc_epoch_seconds,
+    navtool_router_progress_callback_v1 on_progress,
+    void* progress_user_data,
+    char** out_route_json_utf8,
+    size_t* out_route_json_length) {
+    if (out_route_json_utf8 != nullptr) {
+        *out_route_json_utf8 = nullptr;
+    }
+    if (out_route_json_length != nullptr) {
+        *out_route_json_length = 0U;
+    }
+    if (forecast == nullptr || out_route_json_utf8 == nullptr ||
+        out_route_json_length == nullptr) {
+        return fail(
+            NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "forecast and route JSON outputs must not be null");
+    }
+    if (!valid_coordinate(
+            start_latitude_degrees,
+            start_longitude_degrees) ||
+        !valid_coordinate(
+            destination_latitude_degrees,
+            destination_longitude_degrees)) {
+        return fail(
+            NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "route coordinates must be finite canonical latitude/longitude values");
+    }
+
+    sailroute::RouteRequest request;
+    request.start = {
+        start_latitude_degrees,
+        start_longitude_degrees};
+    request.destination = {
+        destination_latitude_degrees,
+        destination_longitude_degrees};
+    if (departure_utc_epoch_seconds != nullptr) {
+        request.departure_time =
+            from_epoch(*departure_utc_epoch_seconds);
+    }
+
+    sailroute::RoutingProgressCallback progress_callback;
+    if (on_progress != nullptr) {
+        progress_callback =
+            [on_progress, progress_user_data](
+                const sailroute::RoutingProgress& progress) {
+                std::vector<navtool_router_coordinate_v1> isochrone_points;
+                isochrone_points.reserve(progress.isochrone.points.size());
+                for (const sailroute::Coordinate point :
+                     progress.isochrone.points) {
+                    isochrone_points.push_back(copy_coordinate(point));
+                }
+
+                std::vector<navtool_router_route_point_v1> route_points;
+                route_points.reserve(progress.provisional_route.size());
+                for (const sailroute::RoutePoint& point :
+                     progress.provisional_route) {
+                    route_points.push_back(copy_route_point(point));
+                }
+
+                const navtool_router_progress_v1 bridge_progress{
+                    to_epoch(progress.isochrone.time),
+                    isochrone_points.data(),
+                    static_cast<uint64_t>(isochrone_points.size()),
+                    route_points.data(),
+                    static_cast<uint64_t>(route_points.size()),
+                    copy_diagnostics(progress.diagnostics)};
+                on_progress(&bridge_progress, progress_user_data);
+            };
+    }
+
+    const sailroute::Router router{forecast->weather};
+    auto route = router.optimize(request, progress_callback);
+    if (!route) {
+        return map_error(route.error());
+    }
+    auto json = sailroute::route_to_json(route.value());
+    if (!json) {
+        return map_error(json.error());
+    }
+    return copy_utf8(
+        json.value(),
+        out_route_json_utf8,
+        out_route_json_length);
+}
+
 }  // namespace
 
 extern "C" {
@@ -289,51 +409,41 @@ navtool_router_status_v1 navtool_router_calculate_route_v1(
     char** out_route_json_utf8,
     size_t* out_route_json_length) {
     return protect([&] {
-        if (out_route_json_utf8 != nullptr) {
-            *out_route_json_utf8 = nullptr;
-        }
-        if (out_route_json_length != nullptr) {
-            *out_route_json_length = 0U;
-        }
-        if (forecast == nullptr || out_route_json_utf8 == nullptr ||
-            out_route_json_length == nullptr) {
-            return fail(
-                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
-                "forecast and route JSON outputs must not be null");
-        }
-        if (!valid_coordinate(
-                start_latitude_degrees,
-                start_longitude_degrees) ||
-            !valid_coordinate(
-                destination_latitude_degrees,
-                destination_longitude_degrees)) {
-            return fail(
-                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
-                "route coordinates must be finite canonical latitude/longitude values");
-        }
-
-        sailroute::RouteRequest request;
-        request.start = {
+        return calculate_route(
+            forecast,
             start_latitude_degrees,
-            start_longitude_degrees};
-        request.destination = {
+            start_longitude_degrees,
             destination_latitude_degrees,
-            destination_longitude_degrees};
-        if (departure_utc_epoch_seconds != nullptr) {
-            request.departure_time =
-                from_epoch(*departure_utc_epoch_seconds);
-        }
-        const sailroute::Router router{forecast->weather};
-        auto route = router.optimize(request);
-        if (!route) {
-            return map_error(route.error());
-        }
-        auto json = sailroute::route_to_json(route.value());
-        if (!json) {
-            return map_error(json.error());
-        }
-        return copy_utf8(
-            json.value(),
+            destination_longitude_degrees,
+            departure_utc_epoch_seconds,
+            nullptr,
+            nullptr,
+            out_route_json_utf8,
+            out_route_json_length);
+    });
+}
+
+navtool_router_status_v1 navtool_router_calculate_route_streaming_v1(
+    const navtool_router_forecast_v1* forecast,
+    double start_latitude_degrees,
+    double start_longitude_degrees,
+    double destination_latitude_degrees,
+    double destination_longitude_degrees,
+    const int64_t* departure_utc_epoch_seconds,
+    navtool_router_progress_callback_v1 on_progress,
+    void* progress_user_data,
+    char** out_route_json_utf8,
+    size_t* out_route_json_length) {
+    return protect([&] {
+        return calculate_route(
+            forecast,
+            start_latitude_degrees,
+            start_longitude_degrees,
+            destination_latitude_degrees,
+            destination_longitude_degrees,
+            departure_utc_epoch_seconds,
+            on_progress,
+            progress_user_data,
             out_route_json_utf8,
             out_route_json_length);
     });
@@ -444,3 +554,6 @@ void navtool_router_bridge_free_v1(void* bridge_owned_memory) {
 static_assert(sizeof(navtool_router_status_v1) == 4U);
 static_assert(sizeof(navtool_router_forecast_metadata_v1) == 40U);
 static_assert(sizeof(navtool_router_wind_sample_v1) == 24U);
+static_assert(sizeof(navtool_router_coordinate_v1) == 16U);
+static_assert(sizeof(navtool_router_route_point_v1) == 64U);
+static_assert(sizeof(navtool_router_diagnostics_v1) == 32U);

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -25,6 +25,39 @@ void require_ok(navtool_router_status_v1 status, const char* operation) {
     }
 }
 
+struct ProgressCapture {
+    size_t count{};
+    int64_t previous_time{};
+    uint64_t previous_time_steps{};
+    bool valid{true};
+};
+
+void capture_progress(
+    const navtool_router_progress_v1* progress,
+    void* user_data) {
+    auto* capture = static_cast<ProgressCapture*>(user_data);
+    if (capture == nullptr || progress == nullptr) {
+        return;
+    }
+    capture->valid =
+        capture->valid &&
+        progress->isochrone_points != nullptr &&
+        progress->isochrone_point_count > 0U &&
+        progress->provisional_route_points != nullptr &&
+        progress->provisional_route_point_count > 0U &&
+        (capture->count == 0U ||
+         progress->isochrone_utc_epoch_seconds > capture->previous_time) &&
+        progress->diagnostics.time_steps ==
+            capture->previous_time_steps + 1U &&
+        progress->provisional_route_points[
+            progress->provisional_route_point_count - 1U]
+                .utc_epoch_seconds ==
+            progress->isochrone_utc_epoch_seconds;
+    capture->previous_time = progress->isochrone_utc_epoch_seconds;
+    capture->previous_time_steps = progress->diagnostics.time_steps;
+    ++capture->count;
+}
+
 }  // namespace
 
 int main() {
@@ -127,6 +160,30 @@ int main() {
         require(
             std::string{route_json}.find("\"points\"") != std::string::npos,
             "route JSON does not contain points");
+        navtool_router_bridge_free_v1(route_json);
+
+        route_json = nullptr;
+        route_json_length = 0U;
+        ProgressCapture progress_capture;
+        require_ok(
+            navtool_router_calculate_route_streaming_v1(
+                forecast,
+                48.25,
+                -123.65,
+                48.25,
+                -123.35,
+                &departure,
+                capture_progress,
+                &progress_capture,
+                &route_json,
+                &route_json_length),
+            "calculate streaming route");
+        require(progress_capture.count > 0U, "streaming route reported no progress");
+        require(progress_capture.valid, "streaming route progress was invalid");
+        require(route_json != nullptr, "streaming route JSON was not allocated");
+        require(
+            route_json_length == std::strlen(route_json),
+            "streaming route JSON length mismatch");
         navtool_router_bridge_free_v1(route_json);
 
         route_json = nullptr;

--- a/src/Navtool.App/Services/MapProjection.cs
+++ b/src/Navtool.App/Services/MapProjection.cs
@@ -6,10 +6,64 @@ namespace Navtool.App.Services;
 
 public static class MapProjection
 {
+    public const double WebMercatorWorldWidth = 40_075_016.68557849;
+
     public static MPoint ToMapPoint(Coordinate coordinate)
     {
         var (x, y) = SphericalMercator.FromLonLat(coordinate.Longitude, coordinate.Latitude);
         return new MPoint(x, y);
+    }
+
+    public static MPoint ToMapPointNear(Coordinate coordinate, double referenceX)
+    {
+        var point = ToMapPoint(coordinate);
+        var x = point.X;
+        while (x - referenceX > WebMercatorWorldWidth / 2)
+        {
+            x -= WebMercatorWorldWidth;
+        }
+
+        while (referenceX - x > WebMercatorWorldWidth / 2)
+        {
+            x += WebMercatorWorldWidth;
+        }
+
+        return new MPoint(x, point.Y);
+    }
+
+    public static IReadOnlyList<MPoint> ToContinuousMapPoints(
+        IEnumerable<Coordinate> coordinates)
+    {
+        ArgumentNullException.ThrowIfNull(coordinates);
+        var projected = new List<MPoint>();
+        foreach (var coordinate in coordinates)
+        {
+            projected.Add(projected.Count == 0
+                ? ToMapPoint(coordinate)
+                : ToMapPointNear(coordinate, projected[^1].X));
+        }
+
+        return projected;
+    }
+
+    public static IReadOnlyList<MPoint> ToContinuousMapPointsNear(
+        IEnumerable<Coordinate> coordinates,
+        double referenceX)
+    {
+        var projected = ToContinuousMapPoints(coordinates);
+        if (projected.Count == 0)
+        {
+            return projected;
+        }
+
+        var centerX = (projected.Min(point => point.X) +
+                       projected.Max(point => point.X)) / 2;
+        var worldOffset = Math.Round(
+            (referenceX - centerX) / WebMercatorWorldWidth) *
+            WebMercatorWorldWidth;
+        return projected
+            .Select(point => new MPoint(point.X + worldOffset, point.Y))
+            .ToArray();
     }
 
     public static Coordinate ToCoordinate(MPoint point)

--- a/src/Navtool.App/Services/RouteHitTester.cs
+++ b/src/Navtool.App/Services/RouteHitTester.cs
@@ -17,14 +17,51 @@ public static class RouteHitTester
         ValidateTolerance(routeTolerancePixels, nameof(routeTolerancePixels));
         ValidateTolerance(pointTolerancePixels, nameof(pointTolerancePixels));
 
+        return FindNearest(
+            routes,
+            route => route.Points
+                .Select(point => projectToScreen(point.Location))
+                .ToArray(),
+            click,
+            routeTolerancePixels,
+            pointTolerancePixels);
+    }
+
+    public static RouteMapSelection? FindNearest(
+        IEnumerable<RouteResult> routes,
+        Func<RouteResult, IReadOnlyList<ScreenPoint>> projectToScreen,
+        ScreenPoint click,
+        double routeTolerancePixels = 10,
+        double pointTolerancePixels = 14)
+    {
+        ArgumentNullException.ThrowIfNull(routes);
+        ArgumentNullException.ThrowIfNull(projectToScreen);
+        ValidateTolerance(routeTolerancePixels, nameof(routeTolerancePixels));
+        ValidateTolerance(pointTolerancePixels, nameof(pointTolerancePixels));
+
         var projectedRoutes = routes
             .Select(route => new ProjectedRoute(
                 route,
-                route.Points.Select(point => projectToScreen(point.Location)).ToArray()))
+                ValidateProjectedPoints(route, projectToScreen(route))))
             .ToArray();
 
         var pointHit = FindNearestPoint(projectedRoutes, click, pointTolerancePixels);
         return pointHit ?? FindNearestSegment(projectedRoutes, click, routeTolerancePixels);
+    }
+
+    private static ScreenPoint[] ValidateProjectedPoints(
+        RouteResult route,
+        IReadOnlyList<ScreenPoint> projected)
+    {
+        ArgumentNullException.ThrowIfNull(projected);
+        if (projected.Count != route.Points.Length)
+        {
+            throw new ArgumentException(
+                "A projected route must contain one screen point per route point.",
+                nameof(projected));
+        }
+
+        return projected.ToArray();
     }
 
     private static RouteMapSelection? FindNearestPoint(

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -86,16 +86,15 @@ public sealed class RouteMapLayers
 
     public void FitRoutes()
     {
-        var points = Routes.SelectMany(route => route.Points).ToArray();
-        if (points.Length == 0)
-        {
-            return;
-        }
-
         var projected = Routes
             .SelectMany(route => MapProjection.ToContinuousMapPoints(
                 route.Points.Select(point => point.Location)))
             .ToArray();
+        if (projected.Length == 0)
+        {
+            return;
+        }
+
         var extent = new MRect(
             projected.Min(point => point.X),
             projected.Min(point => point.Y),

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -1,7 +1,9 @@
+using System.Collections.Immutable;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
 using Mapsui.Styles;
+using Navtool.App.Models;
 using Navtool.Core;
 using Navtool.Infrastructure;
 using NetTopologySuite.Geometries;
@@ -22,6 +24,19 @@ public sealed class RouteMapLayers
 
     private readonly MemoryLayer _noaaRoutes = CreateRouteLayer("NOAA GFS routes", NoaaColor);
     private readonly MemoryLayer _ecmwfRoutes = CreateRouteLayer("ECMWF IFS routes", EcmwfColor);
+    private readonly MemoryLayer _noaaIsochrones = CreateIsochroneLayer("NOAA GFS isochrones", NoaaColor);
+    private readonly MemoryLayer _ecmwfIsochrones = CreateIsochroneLayer("ECMWF IFS isochrones", EcmwfColor);
+    private readonly MemoryLayer _noaaProvisionalRoute = CreateProvisionalRouteLayer(
+        "NOAA GFS provisional route",
+        NoaaColor);
+    private readonly MemoryLayer _ecmwfProvisionalRoute = CreateProvisionalRouteLayer(
+        "ECMWF IFS provisional route",
+        EcmwfColor);
+    private readonly Dictionary<ForecastModel, List<IFeature>> _isochroneFeatures = new()
+    {
+        [ForecastModel.NoaaGfs] = new List<IFeature>(),
+        [ForecastModel.EcmwfIfs] = new List<IFeature>()
+    };
     private readonly MemoryLayer _windCells = new("Wind speed");
     private readonly MemoryLayer _windArrows = new("Wind direction");
     private readonly MemoryLayer _endpoints = new("Route endpoints");
@@ -34,6 +49,10 @@ public sealed class RouteMapLayers
         Map = map;
         map.Layers.Add(_windCells);
         map.Layers.Add(_windArrows);
+        map.Layers.Add(_noaaIsochrones);
+        map.Layers.Add(_ecmwfIsochrones);
+        map.Layers.Add(_noaaProvisionalRoute);
+        map.Layers.Add(_ecmwfProvisionalRoute);
         map.Layers.Add(_noaaRoutes);
         map.Layers.Add(_ecmwfRoutes);
         map.Layers.Add(_endpoints);
@@ -46,6 +65,12 @@ public sealed class RouteMapLayers
     public IReadOnlyList<RouteResult> Routes { get; private set; } = Array.Empty<RouteResult>();
 
     public int WeatherCellCount { get; private set; }
+
+    public int GetIsochroneCount(ForecastModel model) =>
+        GetIsochroneFeatures(model).Count;
+
+    public bool HasProvisionalRoute(ForecastModel model) =>
+        GetProvisionalRouteLayer(model).Features.Any();
 
     public void SetRoutes(IEnumerable<RouteResult> routes)
     {
@@ -67,7 +92,10 @@ public sealed class RouteMapLayers
             return;
         }
 
-        var projected = points.Select(point => MapProjection.ToMapPoint(point.Location)).ToArray();
+        var projected = Routes
+            .SelectMany(route => MapProjection.ToContinuousMapPoints(
+                route.Points.Select(point => point.Location)))
+            .ToArray();
         var extent = new MRect(
             projected.Min(point => point.X),
             projected.Min(point => point.Y),
@@ -77,17 +105,51 @@ public sealed class RouteMapLayers
             Math.Max(extent.Width, extent.Height) * 0.08 + 1_000));
     }
 
+    public void AddCalculationSnapshot(
+        ForecastModel model,
+        RouteCalculationSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        var isochrones = GetIsochroneFeatures(model);
+        isochrones.Add(CreateIsochroneFeature(snapshot));
+        var isochroneLayer = GetIsochroneLayer(model);
+        isochroneLayer.Features = isochrones.ToArray();
+        isochroneLayer.FeaturesWereModified();
+
+        var provisionalLayer = GetProvisionalRouteLayer(model);
+        provisionalLayer.Features =
+            new[] { CreateRouteFeature(snapshot.ProvisionalRoute, snapshot) };
+        provisionalLayer.FeaturesWereModified();
+        Map.Refresh(ChangeType.Discrete);
+    }
+
+    public void ClearCalculationOverlays()
+    {
+        ClearCalculationOverlay(ForecastModel.NoaaGfs, refresh: false);
+        ClearCalculationOverlay(ForecastModel.EcmwfIfs, refresh: false);
+        Map.Refresh(ChangeType.Discrete);
+    }
+
+    public void ClearCalculationOverlay(ForecastModel model) =>
+        ClearCalculationOverlay(model, refresh: true);
+
     public void SetEndpoints(CoreCoordinate? start, CoreCoordinate? destination)
     {
         var features = new List<IFeature>();
         if (start is not null)
         {
-            features.Add(CreateMarker(start.Value, MapsuiColor.FromString("#009E73"), MapsuiColor.White));
+            features.AddRange(CreateWorldCopyMarkers(
+                start.Value,
+                MapsuiColor.FromString("#009E73"),
+                MapsuiColor.White));
         }
 
         if (destination is not null)
         {
-            features.Add(CreateMarker(destination.Value, MapsuiColor.FromString("#CC3311"), MapsuiColor.White));
+            features.AddRange(CreateWorldCopyMarkers(
+                destination.Value,
+                MapsuiColor.FromString("#CC3311"),
+                MapsuiColor.White));
         }
 
         _endpoints.Features = features;
@@ -95,11 +157,20 @@ public sealed class RouteMapLayers
         Map.Refresh(ChangeType.Discrete);
     }
 
-    public void SetSelectedPoint(CoreCoordinate? coordinate)
+    public void SetSelectedPoint(RouteMapSelection? selection)
     {
-        _selection.Features = coordinate is null
+        _selection.Features = selection is null
             ? Array.Empty<IFeature>()
-            : new[] { CreateMarker(coordinate.Value, MapsuiColor.FromString("#F0E442"), MapsuiColor.Black, 22) };
+            : new[]
+            {
+                CreateMarker(
+                    GetRouteMapPoint(
+                        selection.Route,
+                        selection.PointIndex),
+                    MapsuiColor.FromString("#F0E442"),
+                    MapsuiColor.Black,
+                    22)
+            };
         _selection.FeaturesWereModified();
         Map.Refresh(ChangeType.Discrete);
     }
@@ -112,11 +183,15 @@ public sealed class RouteMapLayers
         _timelinePoints.Features = selections
             .Select(selection =>
             {
+                var route = Routes.First(item =>
+                    item.Request.RouteId == selection.Route.RouteId &&
+                    item.Model == selection.Route.Model);
+                var pointIndex = route.Points.IndexOf(selection.Point);
                 var color = selection.Route.Model == ForecastModel.NoaaGfs
                     ? NoaaColor
                     : EcmwfColor;
                 return CreateMarker(
-                    selection.Point.Location,
+                    GetRouteMapPoint(route, Math.Max(0, pointIndex)),
                     color,
                     MapsuiColor.White,
                     selection.Route.Model == activeModel ? 18 : 13);
@@ -176,30 +251,151 @@ public sealed class RouteMapLayers
             }
         };
 
+    private static MemoryLayer CreateIsochroneLayer(string name, MapsuiColor color) =>
+        new(name)
+        {
+            Style = new VectorStyle
+            {
+                Line = new Pen(color, 1.5)
+                {
+                    PenStrokeCap = PenStrokeCap.Round
+                },
+                Opacity = 0.28f
+            }
+        };
+
+    private static MemoryLayer CreateProvisionalRouteLayer(string name, MapsuiColor color) =>
+        new(name)
+        {
+            Style = new VectorStyle
+            {
+                Line = new Pen(color, 2.5)
+                {
+                    PenStrokeCap = PenStrokeCap.Round
+                },
+                Opacity = 0.72f
+            }
+        };
+
     private static IEnumerable<IFeature> CreateRouteFeatures(IEnumerable<RouteResult> routes) =>
         routes.Select(CreateRouteFeature).ToArray();
 
-    private static IFeature CreateRouteFeature(RouteResult route)
+    private static IFeature CreateRouteFeature(RouteResult route) =>
+        CreateRouteFeature(route.Points, route);
+
+    private static IFeature CreateRouteFeature(
+        IEnumerable<RoutePoint> points,
+        object data)
     {
+        var routePoints = points.ToArray();
         IFeature feature;
-        if (route.Points.Length == 1)
+        if (routePoints.Length == 1)
         {
-            feature = new PointFeature(MapProjection.ToMapPoint(route.Points[0].Location));
+            feature = new PointFeature(MapProjection.ToMapPoint(routePoints[0].Location));
         }
         else
         {
-            var coordinates = route.Points
-                .Select(point =>
-                {
-                    var mapPoint = MapProjection.ToMapPoint(point.Location);
-                    return new NtsCoordinate(mapPoint.X, mapPoint.Y);
-                })
+            var coordinates = MapProjection.ToContinuousMapPoints(
+                    routePoints.Select(point => point.Location))
+                .Select(point => new NtsCoordinate(point.X, point.Y))
                 .ToArray();
             feature = new GeometryFeature(new LineString(coordinates));
         }
 
-        feature.Data = route;
+        feature.Data = data;
         return feature;
+    }
+
+    private static IFeature CreateIsochroneFeature(RouteCalculationSnapshot snapshot)
+    {
+        var ordered = OrderFrontier(snapshot.Frontier);
+        if (ordered.Length == 1)
+        {
+            var point = new PointFeature(MapProjection.ToMapPoint(ordered[0]))
+            {
+                Data = snapshot
+            };
+            return point;
+        }
+
+        var coordinates = MapProjection.ToContinuousMapPoints(ordered.Add(ordered[0]))
+            .Select(point => new NtsCoordinate(point.X, point.Y))
+            .ToArray();
+        var feature = new GeometryFeature(new LineString(coordinates))
+        {
+            Data = snapshot
+        };
+        return feature;
+    }
+
+    private static ImmutableArray<CoreCoordinate> OrderFrontier(
+        IEnumerable<CoreCoordinate> points)
+    {
+        var frontier = points.ToArray();
+        var latitudeCenter = frontier.Average(point => point.Latitude);
+        var longitudeSine = frontier.Sum(point =>
+            Math.Sin(point.Longitude * Math.PI / 180));
+        var longitudeCosine = frontier.Sum(point =>
+            Math.Cos(point.Longitude * Math.PI / 180));
+        var longitudeCenter =
+            Math.Abs(longitudeSine) > 1e-12 || Math.Abs(longitudeCosine) > 1e-12
+                ? Math.Atan2(longitudeSine, longitudeCosine) * 180 / Math.PI
+                : frontier[0].Longitude;
+        var longitudeScale = Math.Cos(latitudeCenter * Math.PI / 180);
+
+        return frontier
+            .Select((point, index) => new
+            {
+                Point = point,
+                Index = index,
+                Angle = Math.Atan2(
+                    point.Latitude - latitudeCenter,
+                    NormalizeLongitudeDelta(
+                        point.Longitude,
+                        longitudeCenter) * longitudeScale)
+            })
+            .OrderBy(item => item.Angle)
+            .ThenBy(item => item.Index)
+            .Select(item => item.Point)
+            .ToImmutableArray();
+    }
+
+    private static double NormalizeLongitudeDelta(double longitude, double origin) =>
+        (longitude - origin + 540) % 360 - 180;
+
+    private List<IFeature> GetIsochroneFeatures(ForecastModel model) =>
+        _isochroneFeatures.TryGetValue(model, out var features)
+            ? features
+            : throw new ArgumentOutOfRangeException(nameof(model));
+
+    private MemoryLayer GetIsochroneLayer(ForecastModel model) => model switch
+    {
+        ForecastModel.NoaaGfs => _noaaIsochrones,
+        ForecastModel.EcmwfIfs => _ecmwfIsochrones,
+        _ => throw new ArgumentOutOfRangeException(nameof(model))
+    };
+
+    private MemoryLayer GetProvisionalRouteLayer(ForecastModel model) => model switch
+    {
+        ForecastModel.NoaaGfs => _noaaProvisionalRoute,
+        ForecastModel.EcmwfIfs => _ecmwfProvisionalRoute,
+        _ => throw new ArgumentOutOfRangeException(nameof(model))
+    };
+
+    private void ClearCalculationOverlay(ForecastModel model, bool refresh)
+    {
+        var features = GetIsochroneFeatures(model);
+        features.Clear();
+        var isochroneLayer = GetIsochroneLayer(model);
+        isochroneLayer.Features = Array.Empty<IFeature>();
+        isochroneLayer.FeaturesWereModified();
+        var provisionalLayer = GetProvisionalRouteLayer(model);
+        provisionalLayer.Features = Array.Empty<IFeature>();
+        provisionalLayer.FeaturesWereModified();
+        if (refresh)
+        {
+            Map.Refresh(ChangeType.Discrete);
+        }
     }
 
     private static IFeature CreateWindCell(
@@ -327,9 +523,16 @@ public sealed class RouteMapLayers
         CoreCoordinate coordinate,
         MapsuiColor fill,
         MapsuiColor outline,
+        double size = 18) =>
+        CreateMarker(MapProjection.ToMapPoint(coordinate), fill, outline, size);
+
+    private static PointFeature CreateMarker(
+        MPoint point,
+        MapsuiColor fill,
+        MapsuiColor outline,
         double size = 18)
     {
-        var feature = new PointFeature(MapProjection.ToMapPoint(coordinate));
+        var feature = new PointFeature(point);
         feature.Styles.Add(new SymbolStyle
         {
             SymbolType = SymbolType.Ellipse,
@@ -338,5 +541,32 @@ public sealed class RouteMapLayers
             Outline = new Pen(outline, 3)
         });
         return feature;
+    }
+
+    private static IEnumerable<PointFeature> CreateWorldCopyMarkers(
+        CoreCoordinate coordinate,
+        MapsuiColor fill,
+        MapsuiColor outline)
+    {
+        var point = MapProjection.ToMapPoint(coordinate);
+        return new[]
+        {
+            CreateMarker(
+                new MPoint(point.X - MapProjection.WebMercatorWorldWidth, point.Y),
+                fill,
+                outline),
+            CreateMarker(point, fill, outline),
+            CreateMarker(
+                new MPoint(point.X + MapProjection.WebMercatorWorldWidth, point.Y),
+                fill,
+                outline)
+        };
+    }
+
+    private static MPoint GetRouteMapPoint(RouteResult route, int pointIndex)
+    {
+        var points = MapProjection.ToContinuousMapPoints(
+            route.Points.Select(point => point.Location));
+        return points[Math.Clamp(pointIndex, 0, points.Count - 1)];
     }
 }

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -250,11 +250,16 @@ public partial class MainViewModel : ViewModelBase
         var viewport = Map.Navigator.Viewport;
         var hit = RouteHitTester.FindNearest(
             _mapLayers.Routes,
-            point =>
-            {
-                var projected = viewport.WorldToScreen(MapProjection.ToMapPoint(point));
-                return new ScreenPoint(projected.X, projected.Y);
-            },
+            (RouteResult route) => MapProjection
+                .ToContinuousMapPointsNear(
+                    route.Points.Select(point => point.Location),
+                    worldPosition.X)
+                .Select(point =>
+                {
+                    var projected = viewport.WorldToScreen(point);
+                    return new ScreenPoint(projected.X, projected.Y);
+                })
+                .ToArray(),
             new ScreenPoint(screenPosition.X, screenPosition.Y),
             RouteHitTolerancePixels,
             RoutePointHitTolerancePixels);
@@ -311,6 +316,7 @@ public partial class MainViewModel : ViewModelBase
         IsCalculating = true;
         ProgressFraction = 0;
         StatusMessage = "Starting forecast acquisition and route calculations…";
+        _mapLayers.ClearCalculationOverlays();
         _modelProgress.Clear();
         foreach (var model in request!.Models)
         {
@@ -337,6 +343,14 @@ public partial class MainViewModel : ViewModelBase
                 $"{(value.Model == ForecastModel.EcmwfIfs ? "Experimental · " : string.Empty)}" +
                 $"{ProgressStageName(value.Stage)} {value.Fraction:P0}" +
                 $"{(string.IsNullOrWhiteSpace(value.Message) ? string.Empty : $" · {value.Message}")}");
+            if (value.Snapshot is not null)
+            {
+                _mapLayers.AddCalculationSnapshot(value.Model, value.Snapshot);
+            }
+            else if (value.Stage == RoutingProgressStage.Failed)
+            {
+                _mapLayers.ClearCalculationOverlay(value.Model);
+            }
         });
 
         try
@@ -362,6 +376,7 @@ public partial class MainViewModel : ViewModelBase
             {
                 ErrorMessage = $"Route calculation failed: {exception.Message}";
                 StatusMessage = "No route result was accepted.";
+                _mapLayers.ClearCalculationOverlays();
             }
         }
         finally
@@ -426,6 +441,7 @@ public partial class MainViewModel : ViewModelBase
         cancellation?.Cancel();
         cancellation?.Dispose();
         CancelWeather();
+        _mapLayers.ClearCalculationOverlays();
         IsCalculating = false;
         StatusMessage = "Calculation cancelled.";
     }
@@ -447,7 +463,9 @@ public partial class MainViewModel : ViewModelBase
         }
 
         Map.Navigator.CenterOnAndZoomTo(
-            MapProjection.ToMapPoint(SelectedRoutePoint.FocusCoordinate),
+            MapProjection.ToContinuousMapPoints(
+                SelectedRoutePoint.Route.Points.Select(point => point.Location))[
+                SelectedRoutePoint.PointIndex],
             Math.Min(resolution, 10_000));
     }
 
@@ -528,7 +546,7 @@ public partial class MainViewModel : ViewModelBase
 
     partial void OnSelectedRoutePointChanged(RouteMapSelection? value)
     {
-        _mapLayers.SetSelectedPoint(value?.FocusCoordinate);
+        _mapLayers.SetSelectedPoint(value);
         if (value is not null)
         {
             StatusMessage = $"{ModelName(value.Route.Model)} route selected at " +
@@ -625,6 +643,7 @@ public partial class MainViewModel : ViewModelBase
             }
             else
             {
+                _mapLayers.ClearCalculationOverlay(outcome.Model);
                 var experimental = outcome.Model == ForecastModel.EcmwfIfs
                     ? "Experimental ECMWF"
                     : ModelName(outcome.Model);

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -305,7 +305,7 @@
                                 <TextBlock Text="ROUTES"
                                            Classes="section-title" />
                                 <Grid ColumnDefinitions="24,*"
-                                      RowDefinitions="Auto,Auto"
+                                      RowDefinitions="Auto,Auto,Auto,Auto"
                                       RowSpacing="5">
                                     <Border Width="20"
                                             Height="4"
@@ -324,6 +324,28 @@
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="1"
                                                Text="ECMWF IFS"
+                                               FontSize="11" />
+                                    <Border Grid.Row="2"
+                                            Width="20"
+                                            Height="2"
+                                            Opacity="0.28"
+                                            Background="#355866"
+                                            CornerRadius="1"
+                                            VerticalAlignment="Center" />
+                                    <TextBlock Grid.Row="2"
+                                               Grid.Column="1"
+                                               Text="Accumulated isochrones"
+                                               FontSize="11" />
+                                    <Border Grid.Row="3"
+                                            Width="20"
+                                            Height="3"
+                                            Opacity="0.72"
+                                            Background="#355866"
+                                            CornerRadius="2"
+                                            VerticalAlignment="Center" />
+                                    <TextBlock Grid.Row="3"
+                                               Grid.Column="1"
+                                               Text="Latest provisional route"
                                                FontSize="11" />
                                 </Grid>
                             </StackPanel>

--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -257,6 +257,65 @@ public sealed record RouteDiagnostics
     public TimeSpan? CalculationDuration { get; }
 }
 
+public sealed record RouteCalculationSnapshot
+{
+    public RouteCalculationSnapshot(
+        DateTimeOffset frontierTime,
+        IEnumerable<Coordinate> frontier,
+        IEnumerable<RoutePoint> provisionalRoute,
+        RouteDiagnostics diagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(frontier);
+        ArgumentNullException.ThrowIfNull(provisionalRoute);
+        ArgumentNullException.ThrowIfNull(diagnostics);
+
+        var immutableFrontier = frontier.ToImmutableArray();
+        var immutableRoute = provisionalRoute.ToImmutableArray();
+        if (immutableFrontier.IsEmpty)
+        {
+            throw new ArgumentException("A routing frontier must contain at least one point.", nameof(frontier));
+        }
+
+        if (immutableRoute.IsEmpty)
+        {
+            throw new ArgumentException("A provisional route must contain at least one point.", nameof(provisionalRoute));
+        }
+
+        var utcFrontierTime = frontierTime.ToUniversalTime();
+        if (immutableRoute[^1].Timestamp != utcFrontierTime)
+        {
+            throw new ArgumentException(
+                "The provisional route must end at the frontier time.",
+                nameof(provisionalRoute));
+        }
+
+        for (var index = 1; index < immutableRoute.Length; index++)
+        {
+            if (immutableRoute[index].Timestamp < immutableRoute[index - 1].Timestamp ||
+                immutableRoute[index].CumulativeDistanceNauticalMiles <
+                immutableRoute[index - 1].CumulativeDistanceNauticalMiles)
+            {
+                throw new ArgumentException(
+                    "Provisional route points must be ordered by time and distance.",
+                    nameof(provisionalRoute));
+            }
+        }
+
+        FrontierTime = utcFrontierTime;
+        Frontier = immutableFrontier;
+        ProvisionalRoute = immutableRoute;
+        Diagnostics = diagnostics;
+    }
+
+    public DateTimeOffset FrontierTime { get; }
+
+    public ImmutableArray<Coordinate> Frontier { get; }
+
+    public ImmutableArray<RoutePoint> ProvisionalRoute { get; }
+
+    public RouteDiagnostics Diagnostics { get; }
+}
+
 public sealed record RouteResult
 {
     public RouteResult(
@@ -314,7 +373,10 @@ public sealed record RouteResult
 
 public sealed record RouteCalculationProgress
 {
-    public RouteCalculationProgress(double fraction, string? message = null)
+    public RouteCalculationProgress(
+        double fraction,
+        string? message = null,
+        RouteCalculationSnapshot? snapshot = null)
     {
         if (!double.IsFinite(fraction) || fraction is < 0 or > 1)
         {
@@ -323,11 +385,14 @@ public sealed record RouteCalculationProgress
 
         Fraction = fraction;
         Message = message;
+        Snapshot = snapshot;
     }
 
     public double Fraction { get; }
 
     public string? Message { get; }
+
+    public RouteCalculationSnapshot? Snapshot { get; }
 }
 
 public interface IRouteEngine

--- a/src/Navtool.Core/RoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutingWorkflow.cs
@@ -58,7 +58,8 @@ public sealed record RoutingProgress(
     ForecastModel Model,
     RoutingProgressStage Stage,
     double Fraction,
-    string? Message = null);
+    string? Message = null,
+    RouteCalculationSnapshot? Snapshot = null);
 
 public enum ModelRouteStatus
 {
@@ -270,7 +271,8 @@ public sealed class RoutingWorkflow
                     model,
                     RoutingProgressStage.CalculatingRoute,
                     0.5 + (value.Fraction * 0.5),
-                    value.Message));
+                    value.Message,
+                    value.Snapshot));
 
             var route = await _routeEngine
                 .CalculateAsync(request.Route, acquisition, routeProgress, cancellationToken)
@@ -313,8 +315,9 @@ public sealed class RoutingWorkflow
         ForecastModel model,
         RoutingProgressStage stage,
         double fraction,
-        string? message = null) =>
-        progress?.Report(new RoutingProgress(provider, model, stage, fraction, message));
+        string? message = null,
+        RouteCalculationSnapshot? snapshot = null) =>
+        progress?.Report(new RoutingProgress(provider, model, stage, fraction, message, snapshot));
 
     private sealed class SynchronousProgress<T>(Action<T> report) : IProgress<T>
     {

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -125,6 +125,7 @@ public sealed class NativeForecast : IDisposable
 public sealed class NativeRouterBridge
 {
     private readonly NativeRouterBridgeOptions _options;
+    private int _streamingProgressAvailability;
 
     public NativeRouterBridge(NativeRouterBridgeOptions? options = null)
     {
@@ -176,6 +177,14 @@ public sealed class NativeRouterBridge
     }
 
     public uint AbiVersion => NativeRouterBridgeOptions.SupportedAbiVersion;
+
+    public bool? StreamingProgressAvailable => Volatile.Read(
+        ref _streamingProgressAvailability) switch
+    {
+        > 0 => true,
+        < 0 => false,
+        _ => null
+    };
 
     public NativeForecast LoadForecast(
         string gribPath,
@@ -295,21 +304,7 @@ public sealed class NativeRouterBridge
                     callbackFailure = ExceptionDispatchInfo.Capture(exception);
                 }
             };
-            try
-            {
-                status = NativeMethods.CalculateRouteStreaming(
-                    forecast.Handle,
-                    request.Origin.Latitude,
-                    request.Origin.Longitude,
-                    request.Destination.Latitude,
-                    request.Destination.Longitude,
-                    ref departure,
-                    callback,
-                    IntPtr.Zero,
-                    out routePointer,
-                    out routeLength);
-            }
-            catch (EntryPointNotFoundException)
+            if (Volatile.Read(ref _streamingProgressAvailability) < 0)
             {
                 status = NativeMethods.CalculateRoute(
                     forecast.Handle,
@@ -320,6 +315,37 @@ public sealed class NativeRouterBridge
                     ref departure,
                     out routePointer,
                     out routeLength);
+            }
+            else
+            {
+                try
+                {
+                    status = NativeMethods.CalculateRouteStreaming(
+                        forecast.Handle,
+                        request.Origin.Latitude,
+                        request.Origin.Longitude,
+                        request.Destination.Latitude,
+                        request.Destination.Longitude,
+                        ref departure,
+                        callback,
+                        IntPtr.Zero,
+                        out routePointer,
+                        out routeLength);
+                    Volatile.Write(ref _streamingProgressAvailability, 1);
+                }
+                catch (EntryPointNotFoundException)
+                {
+                    Volatile.Write(ref _streamingProgressAvailability, -1);
+                    status = NativeMethods.CalculateRoute(
+                        forecast.Handle,
+                        request.Origin.Latitude,
+                        request.Origin.Longitude,
+                        request.Destination.Latitude,
+                        request.Destination.Longitude,
+                        ref departure,
+                        out routePointer,
+                        out routeLength);
+                }
             }
 
             GC.KeepAlive(callback);

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -17,6 +18,8 @@ public sealed record NativeRouterBridgeOptions
     public int MaximumTextBytes { get; init; } = 64 * 1024 * 1024;
 
     public int MaximumGridSamples { get; init; } = 1_000_000;
+
+    public int MaximumProgressPoints { get; init; } = 1_000_000;
 }
 
 public enum NativeRouterStatus
@@ -134,6 +137,11 @@ public sealed class NativeRouterBridge
             throw new ArgumentOutOfRangeException(nameof(options), "Maximum grid samples must be positive.");
         }
 
+        if (_options.MaximumProgressPoints <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Maximum progress points must be positive.");
+        }
+
         uint actualVersion;
         try
         {
@@ -215,7 +223,31 @@ public sealed class NativeRouterBridge
         NativeForecast forecast,
         RouteRequest request,
         ForecastModel model,
+        CancellationToken cancellationToken = default) =>
+        CalculateRouteCore(forecast, request, model, null, cancellationToken);
+
+    public RouteResult CalculateRoute(
+        NativeForecast forecast,
+        RouteRequest request,
+        ForecastModel model,
+        Action<RouteCalculationSnapshot> onProgress,
         CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(onProgress);
+        return CalculateRouteCore(
+            forecast,
+            request,
+            model,
+            onProgress,
+            cancellationToken);
+    }
+
+    private RouteResult CalculateRouteCore(
+        NativeForecast forecast,
+        RouteRequest request,
+        ForecastModel model,
+        Action<RouteCalculationSnapshot>? onProgress,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(forecast);
         ArgumentNullException.ThrowIfNull(request);
@@ -225,23 +257,155 @@ public sealed class NativeRouterBridge
         cancellationToken.ThrowIfCancellationRequested();
         var departure = request.DepartureTime.ToUnixTimeSeconds();
         var stopwatch = Stopwatch.StartNew();
-        var status = NativeMethods.CalculateRoute(
-            forecast.Handle,
-            request.Origin.Latitude,
-            request.Origin.Longitude,
-            request.Destination.Latitude,
-            request.Destination.Longitude,
-            ref departure,
-            out var routePointer,
-            out var routeLength);
+        ExceptionDispatchInfo? callbackFailure = null;
+        NativeMethods.RoutingProgressCallback? callback = null;
+        NativeRouterStatus status;
+        IntPtr routePointer;
+        nuint routeLength;
+        if (onProgress is null)
+        {
+            status = NativeMethods.CalculateRoute(
+                forecast.Handle,
+                request.Origin.Latitude,
+                request.Origin.Longitude,
+                request.Destination.Latitude,
+                request.Destination.Longitude,
+                ref departure,
+                out routePointer,
+                out routeLength);
+        }
+        else
+        {
+            callback = (progressPointer, _) =>
+            {
+                if (callbackFailure is not null)
+                {
+                    return;
+                }
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    onProgress(CopyProgress(progressPointer));
+                }
+                catch (Exception exception)
+                {
+                    callbackFailure = ExceptionDispatchInfo.Capture(exception);
+                }
+            };
+            try
+            {
+                status = NativeMethods.CalculateRouteStreaming(
+                    forecast.Handle,
+                    request.Origin.Latitude,
+                    request.Origin.Longitude,
+                    request.Destination.Latitude,
+                    request.Destination.Longitude,
+                    ref departure,
+                    callback,
+                    IntPtr.Zero,
+                    out routePointer,
+                    out routeLength);
+            }
+            catch (EntryPointNotFoundException)
+            {
+                status = NativeMethods.CalculateRoute(
+                    forecast.Handle,
+                    request.Origin.Latitude,
+                    request.Origin.Longitude,
+                    request.Destination.Latitude,
+                    request.Destination.Longitude,
+                    ref departure,
+                    out routePointer,
+                    out routeLength);
+            }
+
+            GC.KeepAlive(callback);
+        }
+
         stopwatch.Stop();
         using var routeBuffer = new NativeAllocatedBufferSafeHandle(routePointer);
+        callbackFailure?.Throw();
         cancellationToken.ThrowIfCancellationRequested();
         ThrowIfFailed(status, "Calculating route");
 
         var json = CopyUtf8(routePointer, routeLength, _options.MaximumTextBytes, "route JSON");
         cancellationToken.ThrowIfCancellationRequested();
         return NativeRouteJsonParser.Parse(json, request, model, stopwatch.Elapsed);
+    }
+
+    private RouteCalculationSnapshot CopyProgress(IntPtr progressPointer)
+    {
+        if (progressPointer == IntPtr.Zero)
+        {
+            throw new NativeRouteFormatException("The native progress callback returned a null snapshot.");
+        }
+
+        var progress = Marshal.PtrToStructure<NativeRoutingProgress>(progressPointer);
+        var frontier = CopyArray<NativeCoordinate>(
+                progress.IsochronePoints,
+                progress.IsochronePointCount,
+                "isochrone points")
+            .Select(point => new Coordinate(point.LatitudeDegrees, point.LongitudeDegrees));
+        var provisionalRoute = CopyArray<NativeRoutePoint>(
+                progress.ProvisionalRoutePoints,
+                progress.ProvisionalRoutePointCount,
+                "provisional route points")
+            .Select(point => new RoutePoint(
+                new Coordinate(
+                    point.Position.LatitudeDegrees,
+                    point.Position.LongitudeDegrees),
+                DateTimeOffset.FromUnixTimeSeconds(point.UtcEpochSeconds),
+                point.HeadingDegrees,
+                point.BoatSpeedKnots,
+                point.TrueWindSpeedKnots,
+                point.TrueWindDirectionDegrees,
+                point.CumulativeDistanceNauticalMiles));
+        var diagnostics = new RouteDiagnostics(
+            checked((long)progress.Diagnostics.ExpandedNodes),
+            checked((long)progress.Diagnostics.GeneratedCandidates),
+            checked((long)progress.Diagnostics.RetainedCandidates),
+            checked((int)progress.Diagnostics.TimeSteps));
+        return new RouteCalculationSnapshot(
+            DateTimeOffset.FromUnixTimeSeconds(progress.IsochroneUtcEpochSeconds),
+            frontier,
+            provisionalRoute,
+            diagnostics);
+    }
+
+    private ImmutableArray<T> CopyArray<T>(
+        IntPtr pointer,
+        ulong count,
+        string description)
+        where T : struct
+    {
+        if (count == 0)
+        {
+            throw new NativeRouteFormatException($"Native progress {description} must not be empty.");
+        }
+
+        if (count > (ulong)_options.MaximumProgressPoints || count > int.MaxValue)
+        {
+            throw new NativeRouteFormatException(
+                $"Native progress {description} exceeded the configured limit.");
+        }
+
+        if (pointer == IntPtr.Zero)
+        {
+            throw new NativeRouteFormatException(
+                $"Native progress {description} had a null pointer.");
+        }
+
+        var length = checked((int)count);
+        var itemSize = Marshal.SizeOf<T>();
+        var builder = ImmutableArray.CreateBuilder<T>(length);
+        for (var index = 0; index < length; index++)
+        {
+            builder.Add(Marshal.PtrToStructure<T>(
+                IntPtr.Add(pointer, checked(index * itemSize))));
+        }
+
+        return builder.MoveToImmutable();
     }
 
     public ImmutableArray<ViewportWindSample> SampleViewport(
@@ -431,11 +595,34 @@ public sealed class NativeRouteEngine : IRouteEngine
             cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         progress?.Report(new RouteCalculationProgress(0.2, "Optimizing route"));
-        var result = _bridge.CalculateRoute(
-            loaded,
-            request,
-            forecast.Request.Model,
-            cancellationToken);
+        var result = progress is null
+            ? _bridge.CalculateRoute(
+                loaded,
+                request,
+                forecast.Request.Model,
+                cancellationToken)
+            : _bridge.CalculateRoute(
+                loaded,
+                request,
+                forecast.Request.Model,
+                snapshot =>
+                {
+                    var requestedDuration =
+                        request.LatestArrivalTime - request.DepartureTime;
+                    var elapsed = snapshot.FrontierTime - request.DepartureTime;
+                    var fraction = requestedDuration <= TimeSpan.Zero
+                        ? 0
+                        : Math.Clamp(
+                            elapsed.TotalSeconds / requestedDuration.TotalSeconds,
+                            0,
+                            1);
+                    progress.Report(new RouteCalculationProgress(
+                        0.2 + (fraction * 0.79),
+                        $"Step {snapshot.Diagnostics.TimeSteps:N0} · " +
+                        $"{snapshot.Diagnostics.RetainedCandidates:N0} retained",
+                        snapshot));
+                },
+                cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();
         progress?.Report(new RouteCalculationProgress(1, "Route complete"));
         return ValueTask.FromResult(result);
@@ -648,6 +835,45 @@ internal struct NativeWindSample
     public byte Valid;
 }
 
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeCoordinate
+{
+    public double LatitudeDegrees;
+    public double LongitudeDegrees;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeRoutePoint
+{
+    public NativeCoordinate Position;
+    public long UtcEpochSeconds;
+    public double HeadingDegrees;
+    public double BoatSpeedKnots;
+    public double TrueWindSpeedKnots;
+    public double TrueWindDirectionDegrees;
+    public double CumulativeDistanceNauticalMiles;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeRoutingDiagnostics
+{
+    public ulong ExpandedNodes;
+    public ulong GeneratedCandidates;
+    public ulong RetainedCandidates;
+    public ulong TimeSteps;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeRoutingProgress
+{
+    public long IsochroneUtcEpochSeconds;
+    public IntPtr IsochronePoints;
+    public ulong IsochronePointCount;
+    public IntPtr ProvisionalRoutePoints;
+    public ulong ProvisionalRoutePointCount;
+    public NativeRoutingDiagnostics Diagnostics;
+}
+
 internal static class NativeMethods
 {
     private const string LibraryName = "navtool_router_bridge";
@@ -696,6 +922,24 @@ internal static class NativeMethods
         double destinationLatitude,
         double destinationLongitude,
         ref long departureEpochSeconds,
+        out IntPtr routeJson,
+        out nuint routeJsonLength);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void RoutingProgressCallback(
+        IntPtr progress,
+        IntPtr userData);
+
+    [DllImport(LibraryName, EntryPoint = "navtool_router_calculate_route_streaming_v1", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern NativeRouterStatus CalculateRouteStreaming(
+        NativeForecastSafeHandle forecast,
+        double startLatitude,
+        double startLongitude,
+        double destinationLatitude,
+        double destinationLongitude,
+        ref long departureEpochSeconds,
+        RoutingProgressCallback onProgress,
+        IntPtr progressUserData,
         out IntPtr routeJson,
         out nuint routeJsonLength);
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Mapsui.Layers;
 using Navtool.App.Models;
 using Navtool.App.Services;
 using Navtool.App.ViewModels;
@@ -68,6 +69,81 @@ public sealed class MainViewModelWorkflowTests
         Assert.Contains("complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Experimental ECMWF failed", viewModel.ErrorMessage);
         Assert.Contains("indexed ranges are unavailable", viewModel.EcmwfStatus);
+    }
+
+    [Fact]
+    public async Task StreamingOverlaysRetainSuccessfulModelAndClearFailedModel()
+    {
+        var providers = new[]
+        {
+            new DelegateForecastProvider(
+                ForecastModel.NoaaGfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request))),
+            new DelegateForecastProvider(
+                ForecastModel.EcmwfIfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request)))
+        };
+        var engine = new StreamingRouteEngine((request, forecast, progress, _) =>
+        {
+            progress?.Report(new RouteCalculationProgress(
+                0.5,
+                "frontier",
+                CreateSnapshot(request)));
+            return forecast.Request.Model == ForecastModel.EcmwfIfs
+                ? ValueTask.FromException<RouteResult>(
+                    new InvalidOperationException("ECMWF search failed"))
+                : ValueTask.FromResult(
+                    CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(providers, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.UseEcmwf = true;
+
+        await viewModel.CalculateRoutesAsync();
+        await Task.Delay(20);
+
+        Assert.Single(GetLayer(viewModel, "NOAA GFS isochrones").Features);
+        Assert.Single(GetLayer(viewModel, "NOAA GFS provisional route").Features);
+        Assert.Empty(GetLayer(viewModel, "ECMWF IFS isochrones").Features);
+        Assert.Empty(GetLayer(viewModel, "ECMWF IFS provisional route").Features);
+        Assert.Equal(1, viewModel.SuccessfulRouteCount);
+    }
+
+    [Fact]
+    public async Task CancellingCalculationClearsStreamingOverlays()
+    {
+        var provider = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var reported = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new StreamingRouteEngine(async (request, _, progress, cancellationToken) =>
+        {
+            progress?.Report(new RouteCalculationProgress(
+                0.5,
+                "frontier",
+                CreateSnapshot(request)));
+            reported.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Unreachable.");
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { provider }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        var calculation = viewModel.CalculateRoutesAsync();
+        await reported.Task;
+        await Task.Delay(20);
+        Assert.Single(GetLayer(viewModel, "NOAA GFS isochrones").Features);
+
+        viewModel.CancelCommand.Execute(null);
+        await calculation;
+
+        Assert.Empty(GetLayer(viewModel, "NOAA GFS isochrones").Features);
+        Assert.Empty(GetLayer(viewModel, "NOAA GFS provisional route").Features);
     }
 
     [Fact]
@@ -383,6 +459,23 @@ public sealed class MainViewModelWorkflowTests
         }
     }
 
+    private sealed class StreamingRouteEngine(
+        Func<
+            RouteRequest,
+            ForecastAcquisition,
+            IProgress<RouteCalculationProgress>?,
+            CancellationToken,
+            ValueTask<RouteResult>> calculate)
+        : IRouteEngine
+    {
+        public ValueTask<RouteResult> CalculateAsync(
+            RouteRequest request,
+            ForecastAcquisition forecast,
+            IProgress<RouteCalculationProgress>? progress,
+            CancellationToken cancellationToken) =>
+            calculate(request, forecast, progress, cancellationToken);
+    }
+
     private sealed class DelegateWeatherSampler(
         Func<
             ForecastAcquisition,
@@ -408,5 +501,32 @@ public sealed class MainViewModelWorkflowTests
                 longitudeCount,
                 validAt,
                 cancellationToken);
+    }
+
+    private static MemoryLayer GetLayer(MainViewModel viewModel, string name) =>
+        Assert.IsType<MemoryLayer>(
+            viewModel.Map.Layers.Single(layer => layer.Name == name));
+
+    private static RouteCalculationSnapshot CreateSnapshot(RouteRequest request)
+    {
+        var frontierTime = request.DepartureTime.AddHours(1);
+        var frontierPoint = new Coordinate(
+            request.Origin.Latitude + 0.25,
+            request.Origin.Longitude + 0.25);
+        return new RouteCalculationSnapshot(
+            frontierTime,
+            new[]
+            {
+                frontierPoint,
+                new Coordinate(
+                    request.Origin.Latitude - 0.25,
+                    request.Origin.Longitude + 0.1)
+            },
+            new[]
+            {
+                new RoutePoint(request.Origin, request.DepartureTime, 90, 6, 15, 180, 0),
+                new RoutePoint(frontierPoint, frontierTime, 90, 6, 15, 180, 10)
+            },
+            new RouteDiagnostics(10, 20, 5, 1));
     }
 }

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -1,10 +1,16 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Mapsui;
+using Mapsui.Layers;
+using Mapsui.Nts;
 using Mapsui.Tiling.Layers;
 using Mapsui.UI.Avalonia;
 using Navtool.App.Services;
 using Navtool.App.ViewModels;
+using Navtool.Core;
 using Navtool.App.Views;
+using LineString = NetTopologySuite.Geometries.LineString;
+using MultiLineString = NetTopologySuite.Geometries.MultiLineString;
 
 namespace Navtool.App.Tests;
 
@@ -48,6 +54,10 @@ public sealed class MapRenderingTests
             [
                 "Wind speed",
                 "Wind direction",
+                "NOAA GFS isochrones",
+                "ECMWF IFS isochrones",
+                "NOAA GFS provisional route",
+                "ECMWF IFS provisional route",
                 "NOAA GFS routes",
                 "ECMWF IFS routes",
                 "Route endpoints",
@@ -57,6 +67,81 @@ public sealed class MapRenderingTests
             layers.Skip(1).Select(layer => layer.Name));
     }
 
+    [Fact]
+    public void StreamingLayersAccumulateFrontiersReplaceProvisionalRoutesAndClearPerModel()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        var first = CreateSnapshot(
+            new DateTimeOffset(2026, 7, 15, 1, 0, 0, TimeSpan.Zero),
+            new[]
+            {
+                new Coordinate(10, 179),
+                new Coordinate(11, -179),
+                new Coordinate(9, -178)
+            });
+        var second = CreateSnapshot(
+            first.FrontierTime.AddHours(1),
+            new[]
+            {
+                new Coordinate(10, 178),
+                new Coordinate(12, -179),
+                new Coordinate(8, -177)
+            });
+
+        layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, first);
+        layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, second);
+
+        Assert.Equal(2, layers.GetIsochroneCount(ForecastModel.NoaaGfs));
+        Assert.True(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
+        var provisional = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS provisional route"));
+        Assert.Same(second, Assert.Single(provisional.Features).Data);
+
+        var isochrones = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS isochrones"));
+        var geometry = Assert.IsType<GeometryFeature>(isochrones.Features.First()).Geometry;
+        var lines = geometry is MultiLineString multi
+            ? multi.Geometries.Cast<LineString>()
+            : new[] { Assert.IsType<LineString>(geometry) };
+        Assert.All(lines, line =>
+        {
+            for (var index = 1; index < line.Coordinates.Length; index++)
+            {
+                Assert.True(
+                    Math.Abs(line.Coordinates[index].X - line.Coordinates[index - 1].X) <
+                    20_100_000);
+            }
+        });
+
+        layers.ClearCalculationOverlay(ForecastModel.NoaaGfs);
+
+        Assert.Equal(0, layers.GetIsochroneCount(ForecastModel.NoaaGfs));
+        Assert.False(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
+    }
+
+    [Fact]
+    public void ContinuousProjectionKeepsDatelinePointsInOneWorldCopy()
+    {
+        var points = MapProjection.ToContinuousMapPoints(
+            new[]
+            {
+                new Coordinate(10, 179),
+                new Coordinate(10, -179)
+            });
+        var nearWesternCopy = MapProjection.ToContinuousMapPointsNear(
+            new[]
+            {
+                new Coordinate(10, 179),
+                new Coordinate(10, -179)
+            },
+            -MapProjection.WebMercatorWorldWidth / 2);
+
+        Assert.True(Math.Abs(points[1].X - points[0].X) < 500_000);
+        Assert.True(Math.Abs(nearWesternCopy[1].X - nearWesternCopy[0].X) < 500_000);
+        Assert.True(nearWesternCopy.Average(point => point.X) < 0);
+    }
+
     private static MainViewModel CreateViewModel(bool tilesEnabled) =>
         new(
             null,
@@ -64,4 +149,20 @@ public sealed class MapRenderingTests
             TimeProvider.System,
             TimeZoneInfo.Utc,
             new OsmTileOptions(Enabled: tilesEnabled));
+
+    private static RouteCalculationSnapshot CreateSnapshot(
+        DateTimeOffset frontierTime,
+        IEnumerable<Coordinate> frontier)
+    {
+        var start = new Coordinate(10, 170);
+        return new RouteCalculationSnapshot(
+            frontierTime,
+            frontier,
+            new[]
+            {
+                new RoutePoint(start, frontierTime.AddHours(-1), 90, 6, 15, 180, 0),
+                new RoutePoint(frontier.First(), frontierTime, 90, 6, 15, 180, 10)
+            },
+            new RouteDiagnostics(10, 20, 5, (int)(frontierTime.Hour + 1)));
+    }
 }

--- a/tests/Navtool.App.Tests/RouteHitTesterTests.cs
+++ b/tests/Navtool.App.Tests/RouteHitTesterTests.cs
@@ -60,6 +60,37 @@ public sealed class RouteHitTesterTests
         Assert.Null(hit);
     }
 
+    [Fact]
+    public void RouteLevelProjectionDoesNotCreateFalseDatelineSegment()
+    {
+        var route = CreateRoute(ForecastModel.NoaaGfs, 0);
+
+        var miss = RouteHitTester.FindNearest(
+            new[] { route },
+            _ => new[]
+            {
+                new ScreenPoint(179, 0),
+                new ScreenPoint(181, 0)
+            },
+            new ScreenPoint(0, 0),
+            routeTolerancePixels: 10,
+            pointTolerancePixels: 10);
+        var hit = RouteHitTester.FindNearest(
+            new[] { route },
+            _ => new[]
+            {
+                new ScreenPoint(179, 0),
+                new ScreenPoint(181, 0)
+            },
+            new ScreenPoint(180, 5),
+            routeTolerancePixels: 10,
+            pointTolerancePixels: 4);
+
+        Assert.Null(miss);
+        Assert.NotNull(hit);
+        Assert.Equal(RouteHitKind.Route, hit.HitKind);
+    }
+
     private static ScreenPoint Project(Coordinate coordinate) =>
         new(coordinate.Longitude, coordinate.Latitude);
 

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -89,4 +89,46 @@ public sealed class NativeBridgeContractTests
         Assert.Equal(48, diagnostics.TimeSteps);
         Assert.Equal(TimeSpan.FromSeconds(2), diagnostics.CalculationDuration);
     }
+
+    [Fact]
+    public void Calculation_snapshot_preserves_frontier_route_and_diagnostics()
+    {
+        var time = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var diagnostics = new RouteDiagnostics(100, 400, 80, 3);
+        var snapshot = new RouteCalculationSnapshot(
+            time,
+            new[]
+            {
+                new Coordinate(42, -60),
+                new Coordinate(43, -59)
+            },
+            new[]
+            {
+                new RoutePoint(new Coordinate(41, -61), time.AddHours(-1), 90, 7, 20, 180, 0),
+                new RoutePoint(new Coordinate(42, -60), time, 90, 7, 20, 180, 7)
+            },
+            diagnostics);
+
+        Assert.Equal(time, snapshot.FrontierTime);
+        Assert.Equal(2, snapshot.Frontier.Length);
+        Assert.Equal(2, snapshot.ProvisionalRoute.Length);
+        Assert.Same(diagnostics, snapshot.Diagnostics);
+        Assert.Throws<NotSupportedException>(() =>
+            ((IList<Coordinate>)snapshot.Frontier).Add(new Coordinate(44, -58)));
+    }
+
+    [Fact]
+    public void Calculation_snapshot_rejects_empty_or_misaligned_native_data()
+    {
+        var time = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var point = new RoutePoint(new Coordinate(42, -60), time.AddMinutes(-1), 90, 7, 20, 180, 0);
+        var diagnostics = new RouteDiagnostics(1, 2, 1, 1);
+
+        Assert.Throws<ArgumentException>(() =>
+            new RouteCalculationSnapshot(time, Array.Empty<Coordinate>(), new[] { point }, diagnostics));
+        Assert.Throws<ArgumentException>(() =>
+            new RouteCalculationSnapshot(time, new[] { point.Location }, Array.Empty<RoutePoint>(), diagnostics));
+        Assert.Throws<ArgumentException>(() =>
+            new RouteCalculationSnapshot(time, new[] { point.Location }, new[] { point }, diagnostics));
+    }
 }

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -31,7 +31,32 @@ public sealed class RoutingWorkflowTests
 
         var engine = new StubRouteEngine((request, acquisition, progress, _) =>
         {
-            progress?.Report(new RouteCalculationProgress(1));
+            var frontierTime = request.DepartureTime.AddHours(1);
+            var snapshot = new RouteCalculationSnapshot(
+                frontierTime,
+                new[]
+                {
+                    request.Origin,
+                    new Coordinate(
+                        request.Origin.Latitude + 0.25,
+                        request.Origin.Longitude + 0.25)
+                },
+                new[]
+                {
+                    new RoutePoint(request.Origin, request.DepartureTime, 90, 6, 15, 180, 0),
+                    new RoutePoint(
+                        new Coordinate(
+                            request.Origin.Latitude + 0.25,
+                            request.Origin.Longitude + 0.25),
+                        frontierTime,
+                        90,
+                        6,
+                        15,
+                        180,
+                        10)
+                },
+                new RouteDiagnostics(10, 20, 5, 1));
+            progress?.Report(new RouteCalculationProgress(0.5, "frontier", snapshot));
             if (acquisition.Request.Model == ForecastModel.EcmwfIfs)
             {
                 throw new InvalidOperationException("ECMWF route calculation failed.");
@@ -64,6 +89,11 @@ public sealed class RoutingWorkflowTests
         Assert.Equal(ModelRouteFailureStage.RouteCalculation, ecmwf.Failure!.Stage);
         Assert.Contains("ECMWF", ecmwf.Failure!.Message);
         Assert.Single(result.SuccessfulRoutes);
+        Assert.Contains(reports, report =>
+            report.Model == ForecastModel.NoaaGfs &&
+            report.Stage == RoutingProgressStage.CalculatingRoute &&
+            report.Snapshot is { Diagnostics.TimeSteps: 1 } &&
+            report.Snapshot.Frontier.Length == 2);
         Assert.Contains(reports, report =>
             report.Model == ForecastModel.NoaaGfs &&
             report.Stage == RoutingProgressStage.Completed &&

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
@@ -61,15 +61,26 @@ public sealed class NativeRouterBridgeIntegrationTests
             snapshots.Add);
         Assert.NotEmpty(route.Points);
         Assert.True(route.Diagnostics.GeneratedCandidates > 0);
-        Assert.NotEmpty(snapshots);
-        Assert.Equal(
-            snapshots.Select(snapshot => snapshot.FrontierTime).Order(),
-            snapshots.Select(snapshot => snapshot.FrontierTime));
-        Assert.Equal(
-            Enumerable.Range(1, snapshots.Count),
-            snapshots.Select(snapshot => snapshot.Diagnostics.TimeSteps));
-        Assert.All(snapshots, snapshot =>
-            Assert.Equal(snapshot.FrontierTime, snapshot.ProvisionalRoute[^1].Timestamp));
+        Assert.NotNull(bridge.StreamingProgressAvailable);
+        if (bridge.StreamingProgressAvailable is true)
+        {
+            Assert.NotEmpty(snapshots);
+            Assert.Equal(
+                snapshots.Select(snapshot => snapshot.FrontierTime).Order(),
+                snapshots.Select(snapshot => snapshot.FrontierTime));
+            Assert.Equal(
+                Enumerable.Range(1, snapshots.Count),
+                snapshots.Select(snapshot => snapshot.Diagnostics.TimeSteps));
+            Assert.All(snapshots, snapshot =>
+                Assert.Equal(
+                    snapshot.FrontierTime,
+                    snapshot.ProvisionalRoute[^1].Timestamp));
+        }
+        else
+        {
+            Assert.Empty(snapshots);
+        }
+
         Assert.All(route.Points, point =>
         {
             Assert.True(point.HeadingDegrees is >= 0 and < 360);

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
@@ -8,14 +8,15 @@ public sealed class NativeRouterBridgeIntegrationTests
     [Fact]
     public void Native_contract_loads_metadata_samples_and_route_when_artifacts_are_available()
     {
+        var configuredSample = Environment.GetEnvironmentVariable(
+            "NAVTOOL_ROUTER_SAMPLE_GRIB");
         var repository = FindAncestor(AppContext.BaseDirectory, "Navtool.sln");
-        if (repository is null)
-        {
-            return;
-        }
-
-        var sample = Path.GetFullPath(
-            Path.Combine(repository, "..", "router-lib", "samples", "sample.grib"));
+        var sample = !string.IsNullOrWhiteSpace(configuredSample)
+            ? Path.GetFullPath(configuredSample)
+            : repository is null
+                ? string.Empty
+                : Path.GetFullPath(
+                    Path.Combine(repository, "..", "router-lib", "samples", "sample.grib"));
         if (!File.Exists(sample))
         {
             return;
@@ -52,12 +53,23 @@ public sealed class NativeRouterBridgeIntegrationTests
             new Coordinate(48.25, -123.35),
             forecast.Metadata.FirstValidAt,
             forecast.Metadata.FirstValidAt.AddHours(10));
+        var snapshots = new List<RouteCalculationSnapshot>();
         var route = bridge.CalculateRoute(
             forecast,
             request,
-            ForecastModel.NoaaGfs);
+            ForecastModel.NoaaGfs,
+            snapshots.Add);
         Assert.NotEmpty(route.Points);
         Assert.True(route.Diagnostics.GeneratedCandidates > 0);
+        Assert.NotEmpty(snapshots);
+        Assert.Equal(
+            snapshots.Select(snapshot => snapshot.FrontierTime).Order(),
+            snapshots.Select(snapshot => snapshot.FrontierTime));
+        Assert.Equal(
+            Enumerable.Range(1, snapshots.Count),
+            snapshots.Select(snapshot => snapshot.Diagnostics.TimeSteps));
+        Assert.All(snapshots, snapshot =>
+            Assert.Equal(snapshot.FrontierTime, snapshot.ProvisionalRoute[^1].Timestamp));
         Assert.All(route.Points, point =>
         {
             Assert.True(point.HeadingDegrees is >= 0 and < 360);


### PR DESCRIPTION
## Why

`router-lib` now reports each retained isochrone frontier, its closest provisional route, and cumulative diagnostics while optimization is running. Navtool previously discarded that data and left the map unchanged until the final route completed.

## What changed

- Adds an additive typed native callback ABI and copies callback-scoped data into immutable managed snapshots.
- Carries model-scoped snapshots through the concurrent routing workflow into Mapsui.
- Accumulates low-opacity NOAA/ECMWF isochrones while replacing each model's latest provisional route.
- Retains successful search overlays and clears failed, cancelled, or stale calculation overlays.
- Uses continuous wrapped Web Mercator projection for dateline-safe geometry, fit bounds, markers, focus, and hit testing.
- Falls back to final-only routing when an older ABI-v1 bridge lacks the streaming symbol.
- Documents the callback lifetime, visualization behavior, and notification-only cancellation constraint.

## Validation

- `dotnet test Navtool.sln --no-restore --nologo`
- Native bridge build and `ctest`
- Managed/native streaming integration against the upstream sample GRIB

## Notes

The final `RouteResult` remains authoritative and may differ from the last provisional route. Cancellation suppresses stale UI updates and results, but the upstream callback contract cannot interrupt an optimization already executing in native code.