### PR TITLE
Make GRIB acquisition resumable and support local files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ It targets macOS, Windows, and Linux.
 
 - Select start and destination points on an OpenStreetMap-based map.
 - Choose a local departure date/time, converted to UTC with DST validation.
-- Download geographically subsetted NOAA GFS 0.25-degree 10 m wind fields.
+- Set the expected passage duration so only the required forecast times are
+  acquired, up to the ten-day planning limit.
+- Download geographically subsetted NOAA GFS 0.25-degree 10 m wind fields, or
+  choose an existing GRIB through the operating system's native file picker.
 - Calculate routes through the native `router-lib` bridge.
 - Watch retained isochrone frontiers and the closest provisional route stream
   onto the map while each model calculates.
@@ -46,23 +49,32 @@ discoverable by CMake and the application.
 
 ## Build and run
 
-Build and test the native bridge:
+Build the native bridge and run the app with one command:
+
+```sh
+./scripts/run.sh
+```
+
+On Windows:
+
+```powershell
+.\scripts\run.ps1
+```
+
+The launcher builds and tests the bridge before starting Avalonia, preventing a
+long forecast download from completing only to discover that routing is not
+available. To build or test separately:
 
 ```sh
 ./scripts/build-native.sh
-```
-
-Then build, test, and run the application:
-
-```sh
 dotnet build Navtool.sln
 dotnet test Navtool.sln
-dotnet run --project src/Navtool.App
 ```
 
 The application discovers the development bridge automatically. For a custom
 location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
-directory.
+directory. If `router-lib` is not beside this checkout, set
+`SAILROUTE_SOURCE_DIR` before using either native script.
 
 ## Streaming route visualization
 
@@ -116,14 +128,33 @@ also be installed or packaged according to the target platform.
 | Variable | Purpose |
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
+| `SAILROUTE_SOURCE_DIR` | `router-lib` checkout used by native build/run scripts |
+| `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |
 | `NAVTOOL_CACHE_ROOT` | Forecast cache directory |
 | `NAVTOOL_ECMWF_EXPERIMENTAL` | `1` or `true` enables the experimental ECMWF path; acquisition still reports unsupported |
 
-NOAA data is downloaded from the operational NOMADS GFS filter. Navtool keeps
-requests sequential, requests only 10 m U/V wind, validates GRIB responses, and
-caches artifacts. NOMADS is not a bulk-download service and may be unavailable
-or throttle excessive usage.
+NOAA data is downloaded from the operational NOMADS GFS filter. Navtool derives
+an antimeridian-safe buffered passage area, requests every available forecast
+step needed for the selected duration, and shows the expected part count before
+calculation. Requests remain sequential and include only 10 m U/V wind.
+Completed parts are cached atomically, so cancellation or a transient NOMADS
+failure can resume without downloading valid parts again. NOMADS is not a
+bulk-download service and may be unavailable or throttle excessive usage.
+
+## Existing GRIB files
+
+Select **Existing GRIB file**, then **Choose GRIB file...** to open the native
+file dialog (Finder on macOS). The picker lists `.grib`, `.grb`, `.grib2`,
+`.grb2`, and `.gri`, with an all-files fallback. Navtool inspects file content
+through ecCodes; the filename does not determine compatibility.
+
+Local files are referenced in place and are not copied into Navtool's cache or
+remembered after restart. A usable file must identify NOAA GFS or ECMWF IFS,
+contain compatible paired 10 m U/V fields, and cover both the buffered route
+area and the full departure-to-arrival interval. Choosing a local file performs
+no forecast HTTP request. If inspection or routing setup fails, the app reports
+that separately from online forecast acquisition.
 
 The default map uses standard OpenStreetMap tiles with attribution. Those tiles
 are intended for normal interactive use, not bulk/offline prefetching. A
@@ -141,3 +172,8 @@ ECMWF Open Data remains an explicit experimental option. Official data supports
 field/step selection but not server-side geographic cropping, and indexed
 10u/10v retrieval has not yet been implemented in this application. No fallback
 or other model is presented as ECMWF data.
+
+Saildocs is not used as an application API: it is an asynchronous email service
+for bandwidth-constrained users rather than a reliable regional download
+endpoint. ECMWF's official object store likewise does not provide server-side
+geographic cropping, so online ECMWF acquisition remains separate future work.

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -119,7 +119,7 @@ if(NAVTOOL_ROUTER_BRIDGE_BUILD_TESTS)
             NAVTOOL_ROUTER_SAMPLE_GRIB="${SAILROUTE_SOURCE_DIR}/samples/sample.grib")
     target_link_libraries(
         navtool_router_bridge_tests
-        PRIVATE Navtool::RouterBridge)
+        PRIVATE Navtool::RouterBridge ECCODES::eccodes)
     add_test(
         NAME navtool_router_bridge_tests
         COMMAND navtool_router_bridge_tests)

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -43,21 +43,52 @@ if(TARGET sailroute)
             VISIBILITY_INLINES_HIDDEN YES)
 endif()
 
+# Ensure ECCODES::eccodes is available for the inspection API.
+# It is defined by the sailroute subdirectory; guard against the edge case
+# where this bridge is added to a build that already found ecCodes directly.
+if(NOT TARGET ECCODES::eccodes)
+    find_package(eccodes CONFIG QUIET)
+    if(NOT TARGET eccodes AND NOT TARGET eccodes_shared AND NOT TARGET ECCODES::eccodes)
+        find_package(PkgConfig REQUIRED)
+        pkg_check_modules(ECCODES REQUIRED IMPORTED_TARGET eccodes)
+        add_library(ECCODES::eccodes ALIAS PkgConfig::ECCODES)
+    elseif(TARGET eccodes AND NOT TARGET ECCODES::eccodes)
+        add_library(ECCODES::eccodes ALIAS eccodes)
+    elseif(TARGET eccodes_shared AND NOT TARGET ECCODES::eccodes)
+        add_library(ECCODES::eccodes ALIAS eccodes_shared)
+    endif()
+endif()
+
 add_library(NavtoolRouterBridge SHARED
     src/navtool_router_bridge.cpp)
 add_library(Navtool::RouterBridge ALIAS NavtoolRouterBridge)
 
+file(
+    GLOB_RECURSE
+    _navtool_router_public_headers
+    "${SAILROUTE_SOURCE_DIR}/include/*.hpp")
+set(_navtool_router_has_progress_callback OFF)
+foreach(_navtool_router_header IN LISTS _navtool_router_public_headers)
+    file(READ "${_navtool_router_header}" _navtool_router_header_contents)
+    if(_navtool_router_header_contents MATCHES "RoutingProgressCallback")
+        set(_navtool_router_has_progress_callback ON)
+        break()
+    endif()
+endforeach()
+
 target_compile_features(NavtoolRouterBridge PRIVATE cxx_std_20)
 target_compile_definitions(
     NavtoolRouterBridge
-    PRIVATE NAVTOOL_ROUTER_BRIDGE_BUILDING)
+    PRIVATE
+        NAVTOOL_ROUTER_BRIDGE_BUILDING
+        NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK=$<BOOL:${_navtool_router_has_progress_callback}>)
 target_include_directories(
     NavtoolRouterBridge
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(
     NavtoolRouterBridge
-    PRIVATE sailroute::sailroute)
+    PRIVATE sailroute::sailroute ECCODES::eccodes)
 set_target_properties(
     NavtoolRouterBridge
     PROPERTIES
@@ -84,6 +115,7 @@ if(NAVTOOL_ROUTER_BRIDGE_BUILD_TESTS)
     target_compile_definitions(
         navtool_router_bridge_tests
         PRIVATE
+            NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK=$<BOOL:${_navtool_router_has_progress_callback}>
             NAVTOOL_ROUTER_SAMPLE_GRIB="${SAILROUTE_SOURCE_DIR}/samples/sample.grib")
     target_link_libraries(
         navtool_router_bridge_tests

--- a/native/Navtool.RouterBridge/include/navtool_router_bridge.h
+++ b/native/Navtool.RouterBridge/include/navtool_router_bridge.h
@@ -171,6 +171,60 @@ navtool_router_sample_grid_v1(
 NAVTOOL_ROUTER_BRIDGE_API void
 navtool_router_bridge_free_v1(void* bridge_owned_memory);
 
+/*
+ * Lightweight preflight check: returns NAVTOOL_ROUTER_BRIDGE_ABI_VERSION.
+ * Calling this function verifies that the library is loaded and the versioned
+ * v1 ABI symbol is present, without requiring a GRIB file.
+ */
+NAVTOOL_ROUTER_BRIDGE_API uint32_t
+navtool_router_bridge_preflight_v1(void);
+
+/* ---- GRIB inspection ---- */
+
+enum {
+    NAVTOOL_ROUTER_MODEL_UNKNOWN_V1 = 0,
+    NAVTOOL_ROUTER_MODEL_NOAA_GFS_V1 = 1,
+    NAVTOOL_ROUTER_MODEL_ECMWF_IFS_V1 = 2
+};
+
+/*
+ * Metadata returned by navtool_router_inspect_grib_v1.
+ *
+ * model_id is one of NAVTOOL_ROUTER_MODEL_*_V1.
+ * All epoch fields are seconds since the Unix epoch (UTC).
+ * Longitude fields are in the canonical [-180, 180] range; east may be less
+ * than west when the described area crosses the antimeridian.
+ */
+typedef struct navtool_router_grib_descriptor_v1 {
+    int64_t  init_utc_epoch_seconds;
+    int64_t  first_valid_utc_epoch_seconds;
+    int64_t  last_valid_utc_epoch_seconds;
+    double   south_latitude_degrees;
+    double   west_longitude_degrees;
+    double   north_latitude_degrees;
+    double   east_longitude_degrees;
+    int32_t  model_id;
+    uint8_t  reserved[4];
+} navtool_router_grib_descriptor_v1;
+
+/*
+ * Inspects a GRIB file using ecCodes without loading a full WeatherDataset.
+ * Reads model identity, initialization time, valid-time range, and geographic
+ * bounds from 10 m U/V wind messages. Validates that:
+ *   - at least one U and one V message exist at 10 m height
+ *   - all wind messages share a single model centre (not model-ambiguous)
+ *   - all messages originate from a single model run (consistent init time)
+ *   - the centre is a supported model (NCEP/GFS or ECMWF/IFS)
+ *
+ * Returns NAVTOOL_ROUTER_STATUS_OK_V1 and populates *out_descriptor on success.
+ * Returns an appropriate error status and sets the thread-local error on failure.
+ * The file is not copied; this call is read-only and does not retain any handle.
+ */
+NAVTOOL_ROUTER_BRIDGE_API navtool_router_status_v1
+navtool_router_inspect_grib_v1(
+    const char* grib_path_utf8,
+    navtool_router_grib_descriptor_v1* out_descriptor);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -425,6 +425,89 @@ double normalize_grib_longitude(double lon) noexcept {
     return lon > 180.0 ? lon - 360.0 : lon;
 }
 
+struct LongitudeCoverage {
+    double west;   // canonical [-180, 180]
+    double east;   // canonical; may be < west when the arc crosses the antimeridian
+    bool global;   // true when the union spans (effectively) the full 360 degrees
+};
+
+// Computes the minimal covering longitude arc across every wind message's grid
+// extent, treating longitude as a circle. Each input pair is a message's
+// [firstGridPoint, lastGridPoint] longitude in GRIB degrees ([0, 360), scanning
+// eastward). A single global grid yields global coverage; multiple subset windows
+// (e.g. a NOMADS request split across the antimeridian) are unioned into one arc
+// rather than trusting the first message alone.
+LongitudeCoverage compute_longitude_coverage(
+    const std::vector<std::pair<double, double>>& arcs) {
+    constexpr double kEpsilon = 1e-6;
+    auto wrap360 = [](double value) {
+        double result = std::fmod(value, 360.0);
+        if (result < 0.0) {
+            result += 360.0;
+        }
+        return result;
+    };
+
+    // Expand each eastward arc into one or two non-wrapping intervals on [0, 360].
+    std::vector<std::pair<double, double>> intervals;
+    for (const auto& [first_lon, last_lon] : arcs) {
+        const double start = wrap360(first_lon);
+        double span = wrap360(last_lon) - start;
+        if (span < 0.0) {
+            span += 360.0;
+        }
+        const double end = start + span;
+        if (end <= 360.0 + kEpsilon) {
+            intervals.emplace_back(start, std::min(end, 360.0));
+        } else {
+            intervals.emplace_back(start, 360.0);
+            intervals.emplace_back(0.0, end - 360.0);
+        }
+    }
+
+    if (intervals.empty()) {
+        return {-180.0, 180.0, true};
+    }
+
+    std::sort(intervals.begin(), intervals.end());
+    std::vector<std::pair<double, double>> merged;
+    for (const auto& interval : intervals) {
+        if (!merged.empty() && interval.first <= merged.back().second + kEpsilon) {
+            merged.back().second = std::max(merged.back().second, interval.second);
+        } else {
+            merged.push_back(interval);
+        }
+    }
+
+    double covered = 0.0;
+    for (const auto& interval : merged) {
+        covered += interval.second - interval.first;
+    }
+    if (covered >= 359.0) {
+        return {-180.0, 180.0, true};
+    }
+
+    // Find the largest uncovered gap on the circle; the covering arc is its
+    // complement. Gaps sit between consecutive merged intervals plus the seam
+    // wrapping from the last interval's end back to the first interval's start.
+    double largest_gap = (360.0 - merged.back().second) + merged.front().first;
+    double west_grib = merged.front().first;   // coverage resumes here after the seam gap
+    double east_grib = merged.back().second;   // coverage ends here before the seam gap
+    for (std::size_t i = 1; i < merged.size(); ++i) {
+        const double gap = merged[i].first - merged[i - 1].second;
+        if (gap > largest_gap) {
+            largest_gap = gap;
+            west_grib = merged[i].first;
+            east_grib = merged[i - 1].second;
+        }
+    }
+
+    return {
+        normalize_grib_longitude(west_grib),
+        normalize_grib_longitude(east_grib),
+        false};
+}
+
 }  // namespace
 
 extern "C" {
@@ -731,8 +814,7 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
         int64_t last_valid = std::numeric_limits<int64_t>::min();
         std::optional<double> south_lat;
         std::optional<double> north_lat;
-        std::optional<double> raw_west_lon;
-        std::optional<double> raw_east_lon;
+        std::vector<std::pair<double, double>> lon_arcs;
         std::set<int64_t> u_valid_times;
         std::set<int64_t> v_valid_times;
         std::size_t grib_count = 0U;
@@ -875,13 +957,10 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
             if (!north_lat || msg_north > *north_lat) {
                 north_lat = msg_north;
             }
-            // Record the first message's longitudinal extent as canonical west/east.
-            if (!raw_west_lon) {
-                raw_west_lon = first_lon;
-            }
-            if (!raw_east_lon) {
-                raw_east_lon = last_lon;
-            }
+            // Grid longitudinal extent — accumulate every wind message's arc so the
+            // union is computed across all of them (like the latitude bounds), which
+            // is required for artifacts assembled from multiple subset windows.
+            lon_arcs.emplace_back(first_lon, last_lon);
         }
 
         if (decode_status != CODES_SUCCESS) {
@@ -928,14 +1007,9 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
             }
         }
 
-        const bool global_longitude_coverage =
-            std::abs(*raw_east_lon - *raw_west_lon) >= 359.0;
-        const double west = global_longitude_coverage
-            ? -180.0
-            : normalize_grib_longitude(*raw_west_lon);
-        const double east = global_longitude_coverage
-            ? 180.0
-            : normalize_grib_longitude(*raw_east_lon);
+        const LongitudeCoverage coverage = compute_longitude_coverage(lon_arcs);
+        const double west = coverage.west;
+        const double east = coverage.east;
 
         *out_descriptor = navtool_router_grib_descriptor_v1{
             *init_epoch,

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -2,9 +2,13 @@
 
 #include "sailroute/sailroute.hpp"
 
+#include <eccodes.h>
+
 #include <algorithm>
+#include <cerrno>
 #include <chrono>
 #include <cmath>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
@@ -173,6 +177,7 @@ navtool_router_status_v1 load_forecast(
         NAVTOOL_ROUTER_STATUS_OK_V1);
 }
 
+#if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
 navtool_router_coordinate_v1 copy_coordinate(
     sailroute::Coordinate coordinate) noexcept {
     return {
@@ -200,6 +205,7 @@ navtool_router_diagnostics_v1 copy_diagnostics(
         static_cast<uint64_t>(diagnostics.retained_candidates),
         static_cast<uint64_t>(diagnostics.time_steps)};
 }
+#endif
 
 navtool_router_status_v1 calculate_route(
     const navtool_router_forecast_v1* forecast,
@@ -247,6 +253,7 @@ navtool_router_status_v1 calculate_route(
             from_epoch(*departure_utc_epoch_seconds);
     }
 
+#if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
     sailroute::RoutingProgressCallback progress_callback;
     if (on_progress != nullptr) {
         progress_callback =
@@ -276,9 +283,17 @@ navtool_router_status_v1 calculate_route(
                 on_progress(&bridge_progress, progress_user_data);
             };
     }
+#else
+    static_cast<void>(on_progress);
+    static_cast<void>(progress_user_data);
+#endif
 
     const sailroute::Router router{forecast->weather};
+#if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
     auto route = router.optimize(request, progress_callback);
+#else
+    auto route = router.optimize(request);
+#endif
     if (!route) {
         return map_error(route.error());
     }
@@ -290,6 +305,123 @@ navtool_router_status_v1 calculate_route(
         json.value(),
         out_route_json_utf8,
         out_route_json_length);
+}
+
+// ---------- GRIB inspection helpers ----------
+
+struct GribFileCloser {
+    void operator()(std::FILE* f) const noexcept {
+        if (f) {
+            std::fclose(f);
+        }
+    }
+};
+
+struct GribHandleDeleter {
+    void operator()(codes_handle* h) const noexcept {
+        if (h) {
+            codes_handle_delete(h);
+        }
+    }
+};
+
+using GribFilePtr = std::unique_ptr<std::FILE, GribFileCloser>;
+using GribHandlePtr = std::unique_ptr<codes_handle, GribHandleDeleter>;
+
+std::optional<long> optional_long_grib_key(
+    codes_handle* h,
+    const char* key) noexcept {
+    long value = 0;
+    if (codes_get_long(h, key, &value) != CODES_SUCCESS) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::optional<std::string> optional_string_grib_key(
+    codes_handle* h,
+    const char* key) {
+    size_t len = 0;
+    if (codes_get_size(h, key, &len) != CODES_SUCCESS || len == 0) {
+        return std::nullopt;
+    }
+    std::string value(len, '\0');
+    if (codes_get_string(h, key, value.data(), &len) != CODES_SUCCESS) {
+        return std::nullopt;
+    }
+    const auto null_pos = value.find('\0');
+    if (null_pos != std::string::npos) {
+        value.resize(null_pos);
+    }
+    return value;
+}
+
+enum class GribWindComponent { east, north };
+
+std::optional<GribWindComponent> detect_10m_wind_component(
+    codes_handle* h) {
+    // Prefer paramId (GRIB2 standard)
+    auto param_id = optional_long_grib_key(h, "paramId");
+    if (param_id == 165L) {
+        return GribWindComponent::east;
+    }
+    if (param_id == 166L) {
+        return GribWindComponent::north;
+    }
+
+    // Fall back to shortName
+    auto short_name = optional_string_grib_key(h, "shortName");
+    if (!short_name) {
+        return std::nullopt;
+    }
+    if (*short_name == "10u" || *short_name == "u10") {
+        return GribWindComponent::east;
+    }
+    if (*short_name == "10v" || *short_name == "v10") {
+        return GribWindComponent::north;
+    }
+    if (*short_name != "u" && *short_name != "v") {
+        return std::nullopt;
+    }
+
+    // Generic u/v: must be at 10 m height above ground
+    auto level_type = optional_string_grib_key(h, "typeOfLevel");
+    auto level = optional_long_grib_key(h, "level");
+    if (!level_type || !level ||
+        *level_type != "heightAboveGround" || *level != 10L) {
+        return std::nullopt;
+    }
+    return *short_name == "u" ? GribWindComponent::east : GribWindComponent::north;
+}
+
+// Returns epoch seconds, or nullopt if the encoded date/time is invalid.
+std::optional<int64_t> parse_grib_datetime(
+    long date,
+    long time) noexcept {
+    const int year = static_cast<int>(date / 10000L);
+    const unsigned month = static_cast<unsigned>((date / 100L) % 100L);
+    const unsigned day = static_cast<unsigned>(date % 100L);
+    const int hour = static_cast<int>(time / 100L);
+    const int minute = static_cast<int>(time % 100L);
+
+    using namespace std::chrono;
+    const year_month_day ymd{
+        std::chrono::year{year},
+        std::chrono::month{month},
+        std::chrono::day{day}};
+    if (!ymd.ok() || hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+        return std::nullopt;
+    }
+    return static_cast<int64_t>(
+        duration_cast<seconds>(
+            (sys_days{ymd} + hours{hour} + minutes{minute})
+                .time_since_epoch())
+            .count());
+}
+
+// Converts a GRIB longitude in [0, 360] to canonical [-180, 180].
+double normalize_grib_longitude(double lon) noexcept {
+    return lon > 180.0 ? lon - 360.0 : lon;
 }
 
 }  // namespace
@@ -423,6 +555,7 @@ navtool_router_status_v1 navtool_router_calculate_route_v1(
     });
 }
 
+#if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
 navtool_router_status_v1 navtool_router_calculate_route_streaming_v1(
     const navtool_router_forecast_v1* forecast,
     double start_latitude_degrees,
@@ -448,6 +581,7 @@ navtool_router_status_v1 navtool_router_calculate_route_streaming_v1(
             out_route_json_length);
     });
 }
+#endif
 
 navtool_router_status_v1 navtool_router_sample_grid_v1(
     const navtool_router_forecast_v1* forecast,
@@ -549,7 +683,271 @@ void navtool_router_bridge_free_v1(void* bridge_owned_memory) {
     std::free(bridge_owned_memory);
 }
 
+uint32_t navtool_router_bridge_preflight_v1(void) {
+    return NAVTOOL_ROUTER_BRIDGE_ABI_VERSION;
+}
+
+navtool_router_status_v1 navtool_router_inspect_grib_v1(
+    const char* grib_path_utf8,
+    navtool_router_grib_descriptor_v1* out_descriptor) {
+    return protect([&]() -> navtool_router_status_v1 {
+        if (out_descriptor == nullptr) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+                "out_descriptor must not be null");
+        }
+        if (grib_path_utf8 == nullptr || grib_path_utf8[0] == '\0') {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+                "GRIB path must be a non-empty UTF-8 string");
+        }
+
+        const auto* utf8_begin =
+            reinterpret_cast<const char8_t*>(grib_path_utf8);
+        const std::filesystem::path path{std::u8string{utf8_begin}};
+        const std::string display_path = path.string();
+
+        errno = 0;
+#ifdef _WIN32
+        GribFilePtr file{_wfopen(path.c_str(), L"rb")};
+#else
+        GribFilePtr file{std::fopen(grib_path_utf8, "rb")};
+#endif
+        if (!file) {
+            const int open_error = errno;
+            std::string message =
+                "cannot open GRIB file '" + display_path + "'";
+            if (open_error != 0) {
+                message += ": ";
+                message += std::strerror(open_error);
+            }
+            return fail(NAVTOOL_ROUTER_STATUS_FILE_IO_V1, std::move(message));
+        }
+
+        std::optional<long> detected_centre;
+        std::optional<int64_t> init_epoch;
+        int64_t first_valid = std::numeric_limits<int64_t>::max();
+        int64_t last_valid = std::numeric_limits<int64_t>::min();
+        std::optional<double> south_lat;
+        std::optional<double> north_lat;
+        std::optional<double> raw_west_lon;
+        std::optional<double> raw_east_lon;
+        bool has_u = false;
+        bool has_v = false;
+        std::size_t grib_count = 0U;
+        int decode_status = CODES_SUCCESS;
+
+        while (true) {
+            GribHandlePtr handle{codes_handle_new_from_file(
+                nullptr,
+                file.get(),
+                PRODUCT_GRIB,
+                &decode_status)};
+            if (!handle) {
+                break;
+            }
+            ++grib_count;
+
+            long edition = 0;
+            if (codes_get_long(handle.get(), "edition", &edition) !=
+                    CODES_SUCCESS ||
+                (edition != 1 && edition != 2)) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_UNSUPPORTED_FORECAST_V1,
+                    "GRIB file contains an unsupported edition");
+            }
+
+            const auto component =
+                detect_10m_wind_component(handle.get());
+            if (!component) {
+                continue;
+            }
+            if (*component == GribWindComponent::east) {
+                has_u = true;
+            } else {
+                has_v = true;
+            }
+
+            // Model centre — must be consistent across all wind messages.
+            const auto centre =
+                optional_long_grib_key(handle.get(), "centre");
+            if (!centre) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "cannot read 'centre' key from GRIB wind message in '" +
+                        display_path + "'");
+            }
+            if (!detected_centre) {
+                detected_centre = *centre;
+            } else if (*detected_centre != *centre) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_UNSUPPORTED_FORECAST_V1,
+                    "GRIB file '" + display_path +
+                        "' mixes wind messages from different model centres "
+                        "(" + std::to_string(*detected_centre) + " and " +
+                        std::to_string(*centre) + "); "
+                        "model identity is ambiguous");
+            }
+
+            // Init time — must be consistent (same model run).
+            const auto data_date =
+                optional_long_grib_key(handle.get(), "dataDate");
+            const auto data_time =
+                optional_long_grib_key(handle.get(), "dataTime");
+            if (!data_date || !data_time) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "cannot read init-time keys from GRIB wind message in '" +
+                        display_path + "'");
+            }
+            const auto this_init = parse_grib_datetime(*data_date, *data_time);
+            if (!this_init) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "GRIB wind message in '" + display_path +
+                        "' has an invalid init time (dataDate=" +
+                        std::to_string(*data_date) +
+                        " dataTime=" + std::to_string(*data_time) + ")");
+            }
+            if (!init_epoch) {
+                init_epoch = *this_init;
+            } else if (*init_epoch != *this_init) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_UNSUPPORTED_FORECAST_V1,
+                    "GRIB file '" + display_path +
+                        "' contains wind messages from different model runs; "
+                        "use a single-run file");
+            }
+
+            // Validity time range.
+            const auto validity_date =
+                optional_long_grib_key(handle.get(), "validityDate");
+            const auto validity_time =
+                optional_long_grib_key(handle.get(), "validityTime");
+            if (!validity_date || !validity_time) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "cannot read validity-time keys from GRIB wind message in '" +
+                        display_path + "'");
+            }
+            const auto this_valid =
+                parse_grib_datetime(*validity_date, *validity_time);
+            if (!this_valid) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "GRIB wind message in '" + display_path +
+                        "' has an invalid validity time");
+            }
+            first_valid = std::min(first_valid, *this_valid);
+            last_valid = std::max(last_valid, *this_valid);
+
+            // Grid bounds — collect union across all wind messages.
+            double first_lat = 0.0;
+            double last_lat = 0.0;
+            double first_lon = 0.0;
+            double last_lon = 0.0;
+            if (codes_get_double(
+                    handle.get(),
+                    "latitudeOfFirstGridPointInDegrees",
+                    &first_lat) != CODES_SUCCESS ||
+                codes_get_double(
+                    handle.get(),
+                    "latitudeOfLastGridPointInDegrees",
+                    &last_lat) != CODES_SUCCESS ||
+                codes_get_double(
+                    handle.get(),
+                    "longitudeOfFirstGridPointInDegrees",
+                    &first_lon) != CODES_SUCCESS ||
+                codes_get_double(
+                    handle.get(),
+                    "longitudeOfLastGridPointInDegrees",
+                    &last_lon) != CODES_SUCCESS) {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                    "cannot read grid-bounds keys from GRIB wind message in '" +
+                        display_path + "'");
+            }
+            const double msg_south = std::min(first_lat, last_lat);
+            const double msg_north = std::max(first_lat, last_lat);
+            if (!south_lat || msg_south < *south_lat) {
+                south_lat = msg_south;
+            }
+            if (!north_lat || msg_north > *north_lat) {
+                north_lat = msg_north;
+            }
+            // Record the first message's longitudinal extent as canonical west/east.
+            if (!raw_west_lon) {
+                raw_west_lon = first_lon;
+            }
+            if (!raw_east_lon) {
+                raw_east_lon = last_lon;
+            }
+        }
+
+        if (decode_status != CODES_SUCCESS) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                "error while scanning GRIB messages in '" + display_path + "'");
+        }
+        if (grib_count == 0U) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
+                "'" + display_path + "' contains no decodable GRIB messages");
+        }
+        if (!has_u || !has_v) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_INCOMPLETE_FORECAST_V1,
+                "'" + display_path +
+                    "' does not contain both 10 m U and V wind components; "
+                    "a complete wind forecast requires paired eastward (U) "
+                    "and northward (V) fields");
+        }
+
+        // Map centre code to supported model identity.
+        int32_t model_id = NAVTOOL_ROUTER_MODEL_UNKNOWN_V1;
+        if (detected_centre) {
+            if (*detected_centre == 7L) {
+                model_id = NAVTOOL_ROUTER_MODEL_NOAA_GFS_V1;
+            } else if (*detected_centre == 98L) {
+                model_id = NAVTOOL_ROUTER_MODEL_ECMWF_IFS_V1;
+            } else {
+                return fail(
+                    NAVTOOL_ROUTER_STATUS_UNSUPPORTED_FORECAST_V1,
+                    "GRIB centre code " +
+                        std::to_string(*detected_centre) +
+                        " is not a supported forecast model; "
+                        "expected NCEP (centre=7) for NOAA GFS or "
+                        "ECMWF (centre=98) for IFS");
+            }
+        }
+
+        const bool global_longitude_coverage =
+            std::abs(*raw_east_lon - *raw_west_lon) >= 359.0;
+        const double west = global_longitude_coverage
+            ? -180.0
+            : normalize_grib_longitude(*raw_west_lon);
+        const double east = global_longitude_coverage
+            ? 180.0
+            : normalize_grib_longitude(*raw_east_lon);
+
+        *out_descriptor = navtool_router_grib_descriptor_v1{
+            *init_epoch,
+            first_valid,
+            last_valid,
+            *south_lat,
+            west,
+            *north_lat,
+            east,
+            model_id,
+            {0U, 0U, 0U, 0U}};
+        return static_cast<navtool_router_status_v1>(
+            NAVTOOL_ROUTER_STATUS_OK_V1);
+    });
+}
+
 }  // extern "C"
+
+static_assert(sizeof(navtool_router_grib_descriptor_v1) == 64U);
 
 static_assert(sizeof(navtool_router_status_v1) == 4U);
 static_assert(sizeof(navtool_router_forecast_metadata_v1) == 40U);

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -16,6 +16,7 @@
 #include <limits>
 #include <new>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -732,8 +733,8 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
         std::optional<double> north_lat;
         std::optional<double> raw_west_lon;
         std::optional<double> raw_east_lon;
-        bool has_u = false;
-        bool has_v = false;
+        std::set<int64_t> u_valid_times;
+        std::set<int64_t> v_valid_times;
         std::size_t grib_count = 0U;
         int decode_status = CODES_SUCCESS;
 
@@ -762,12 +763,6 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
             if (!component) {
                 continue;
             }
-            if (*component == GribWindComponent::east) {
-                has_u = true;
-            } else {
-                has_v = true;
-            }
-
             // Model centre — must be consistent across all wind messages.
             const auto centre =
                 optional_long_grib_key(handle.get(), "centre");
@@ -840,6 +835,11 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
             }
             first_valid = std::min(first_valid, *this_valid);
             last_valid = std::max(last_valid, *this_valid);
+            if (*component == GribWindComponent::east) {
+                u_valid_times.insert(*this_valid);
+            } else {
+                v_valid_times.insert(*this_valid);
+            }
 
             // Grid bounds — collect union across all wind messages.
             double first_lat = 0.0;
@@ -894,13 +894,20 @@ navtool_router_status_v1 navtool_router_inspect_grib_v1(
                 NAVTOOL_ROUTER_STATUS_FORECAST_DECODE_V1,
                 "'" + display_path + "' contains no decodable GRIB messages");
         }
-        if (!has_u || !has_v) {
+        if (u_valid_times.empty() || v_valid_times.empty()) {
             return fail(
                 NAVTOOL_ROUTER_STATUS_INCOMPLETE_FORECAST_V1,
                 "'" + display_path +
                     "' does not contain both 10 m U and V wind components; "
                     "a complete wind forecast requires paired eastward (U) "
                     "and northward (V) fields");
+        }
+        if (u_valid_times != v_valid_times) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_INCOMPLETE_FORECAST_V1,
+                "'" + display_path +
+                    "' does not contain paired 10 m U and V wind components "
+                    "for every forecast validity time");
         }
 
         // Map centre code to supported model identity.

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -1,9 +1,14 @@
 #include "navtool_router_bridge.h"
 
+#include <eccodes.h>
+
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <fstream>
+#include <filesystem>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -56,6 +61,62 @@ void capture_progress(
     capture->previous_time = progress->isochrone_utc_epoch_seconds;
     capture->previous_time_steps = progress->diagnostics.time_steps;
     ++capture->count;
+}
+
+std::filesystem::path create_grib_with_missing_v_step() {
+    const auto output_path =
+        std::filesystem::temp_directory_path() /
+        ("navtool-incomplete-" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()) +
+         ".grib");
+    std::FILE* input = std::fopen(NAVTOOL_ROUTER_SAMPLE_GRIB, "rb");
+    if (input == nullptr) {
+        throw std::runtime_error("could not open sample GRIB for incomplete fixture");
+    }
+
+    std::ofstream output{output_path, std::ios::binary};
+    bool skipped_v = false;
+    int error = CODES_SUCCESS;
+    while (codes_handle* handle =
+               codes_handle_new_from_file(nullptr, input, PRODUCT_GRIB, &error)) {
+        char short_name[32]{};
+        size_t short_name_length = sizeof(short_name);
+        if (codes_get_string(
+                handle,
+                "shortName",
+                short_name,
+                &short_name_length) != CODES_SUCCESS) {
+            codes_handle_delete(handle);
+            std::fclose(input);
+            throw std::runtime_error("could not read sample GRIB shortName");
+        }
+
+        if (!skipped_v && std::string{short_name} == "10v") {
+            skipped_v = true;
+            codes_handle_delete(handle);
+            continue;
+        }
+
+        const void* message = nullptr;
+        size_t message_size = 0U;
+        if (codes_get_message(handle, &message, &message_size) != CODES_SUCCESS) {
+            codes_handle_delete(handle);
+            std::fclose(input);
+            throw std::runtime_error("could not copy sample GRIB message");
+        }
+        output.write(
+            static_cast<const char*>(message),
+            static_cast<std::streamsize>(message_size));
+        codes_handle_delete(handle);
+    }
+    std::fclose(input);
+    output.close();
+    if (error != CODES_SUCCESS || !skipped_v) {
+        std::filesystem::remove(output_path);
+        throw std::runtime_error("could not create incomplete GRIB fixture");
+    }
+    return output_path;
 }
 
 }  // namespace
@@ -355,6 +416,16 @@ int main() {
                 desc.east_longitude_degrees >= -180.0 &&
                 desc.east_longitude_degrees <= 180.0,
             "longitude bounds are out of range");
+
+        const auto incomplete_grib = create_grib_with_missing_v_step();
+        navtool_router_grib_descriptor_v1 incomplete_desc{};
+        require(
+            navtool_router_inspect_grib_v1(
+                incomplete_grib.string().c_str(),
+                &incomplete_desc) ==
+                NAVTOOL_ROUTER_STATUS_INCOMPLETE_FORECAST_V1,
+            "GRIB with an unpaired wind step was accepted");
+        std::filesystem::remove(incomplete_grib);
 
         std::cout << "Navtool router bridge tests passed\n";
         return EXIT_SUCCESS;

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -162,6 +162,7 @@ int main() {
             "route JSON does not contain points");
         navtool_router_bridge_free_v1(route_json);
 
+#if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
         route_json = nullptr;
         route_json_length = 0U;
         ProgressCapture progress_capture;
@@ -185,6 +186,7 @@ int main() {
             route_json_length == std::strlen(route_json),
             "streaming route JSON length mismatch");
         navtool_router_bridge_free_v1(route_json);
+#endif
 
         route_json = nullptr;
         route_json_length = 0U;
@@ -271,6 +273,88 @@ int main() {
         require_ok(
             navtool_router_forecast_destroy_v1(&forecast),
             "destroy bounded forecast");
+
+        // ---- GRIB inspection API ----
+
+        // Null checks
+        require(
+            navtool_router_inspect_grib_v1(nullptr, nullptr) ==
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "null path and descriptor were accepted");
+        require(
+            navtool_router_inspect_grib_v1(
+                NAVTOOL_ROUTER_SAMPLE_GRIB,
+                nullptr) ==
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "null descriptor was accepted");
+        require(
+            navtool_router_inspect_grib_v1(
+                nullptr,
+                new navtool_router_grib_descriptor_v1{}) ==
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "null path was accepted");
+
+        // Non-existent file
+        {
+            navtool_router_grib_descriptor_v1 missing_desc{};
+            require(
+                navtool_router_inspect_grib_v1(
+                    "/nonexistent/path/forecast.grib",
+                    &missing_desc) ==
+                    NAVTOOL_ROUTER_STATUS_FILE_IO_V1,
+                "missing GRIB file was not reported as FILE_IO");
+        }
+
+        // Successful inspection of the sample GRIB
+        navtool_router_grib_descriptor_v1 desc{};
+        require_ok(
+            navtool_router_inspect_grib_v1(NAVTOOL_ROUTER_SAMPLE_GRIB, &desc),
+            "inspect sample GRIB");
+
+        // Model should be NOAA GFS (centre 7)
+        require(
+            desc.model_id == NAVTOOL_ROUTER_MODEL_NOAA_GFS_V1,
+            "sample GRIB model should be NOAA GFS");
+
+        // Init time must be before first valid time
+        require(
+            desc.init_utc_epoch_seconds <= desc.first_valid_utc_epoch_seconds,
+            "init time must not be after first valid time");
+
+        // Valid time range must be ordered
+        require(
+            desc.first_valid_utc_epoch_seconds <=
+                desc.last_valid_utc_epoch_seconds,
+            "first valid time must not be after last valid time");
+
+        // Init time is plausible (after year 2000, before year 2100)
+        constexpr int64_t kYear2000Epoch = 946684800LL;
+        constexpr int64_t kYear2100Epoch = 4102444800LL;
+        require(
+            desc.init_utc_epoch_seconds > kYear2000Epoch &&
+                desc.init_utc_epoch_seconds < kYear2100Epoch,
+            "sample GRIB init time is implausible");
+
+        // Bounds should be finite and ordered
+        require(
+            std::isfinite(desc.south_latitude_degrees) &&
+                std::isfinite(desc.north_latitude_degrees) &&
+                std::isfinite(desc.west_longitude_degrees) &&
+                std::isfinite(desc.east_longitude_degrees),
+            "GRIB descriptor bounds contain non-finite values");
+        require(
+            desc.south_latitude_degrees <= desc.north_latitude_degrees,
+            "south latitude exceeds north latitude");
+        require(
+            desc.south_latitude_degrees >= -90.0 &&
+                desc.north_latitude_degrees <= 90.0,
+            "latitude bounds are out of range");
+        require(
+            desc.west_longitude_degrees >= -180.0 &&
+                desc.west_longitude_degrees <= 180.0 &&
+                desc.east_longitude_degrees >= -180.0 &&
+                desc.east_longitude_degrees <= 180.0,
+            "longitude bounds are out of range");
 
         std::cout << "Navtool router bridge tests passed\n";
         return EXIT_SUCCESS;

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -12,6 +12,10 @@ if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 
+if (-not (Test-Path (Join-Path $RouterSource "CMakeLists.txt"))) {
+    throw "router-lib was not found at '$RouterSource'. Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again."
+}
+
 cmake -S (Join-Path $Root "native\Navtool.RouterBridge") -B $BuildDirectory `
     -DCMAKE_BUILD_TYPE=Release `
     -DSAILROUTE_SOURCE_DIR="$RouterSource" `

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -5,6 +5,12 @@ root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 router_source=${SAILROUTE_SOURCE_DIR:-"$root/../router-lib"}
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
 
+if [ ! -f "$router_source/CMakeLists.txt" ]; then
+  echo "router-lib was not found at $router_source." >&2
+  echo "Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again." >&2
+  exit 1
+fi
+
 cmake -S "$root/native/Navtool.RouterBridge" -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Release \
   -DSAILROUTE_SOURCE_DIR="$router_source" \

--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+& (Join-Path $PSScriptRoot "build-native.ps1")
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$env:NAVTOOL_ROUTER_BRIDGE_PATH = if (
+    [string]::IsNullOrWhiteSpace($env:NAVTOOL_NATIVE_BUILD_DIR)
+) {
+    Join-Path $repoRoot "native/Navtool.RouterBridge/build"
+} else {
+    $env:NAVTOOL_NATIVE_BUILD_DIR
+}
+dotnet run --project (Join-Path $repoRoot "src/Navtool.App/Navtool.App.csproj") -- @args
+exit $LASTEXITCODE

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+"$SCRIPT_DIR/build-native.sh"
+
+export NAVTOOL_ROUTER_BRIDGE_PATH="${NAVTOOL_NATIVE_BUILD_DIR:-"$REPO_ROOT/native/Navtool.RouterBridge/build"}"
+exec dotnet run --project "$REPO_ROOT/src/Navtool.App/Navtool.App.csproj" -- "$@"

--- a/src/Navtool.App/Services/AppComposition.cs
+++ b/src/Navtool.App/Services/AppComposition.cs
@@ -42,6 +42,9 @@ public static class AppComposition
             provider.GetRequiredService<DeferredNativeRouteEngine>());
         services.AddSingleton<IWeatherSampler>(provider =>
             provider.GetRequiredService<DeferredNativeRouteEngine>());
+        services.AddSingleton<INativeRoutingPreflight>(provider =>
+            provider.GetRequiredService<DeferredNativeRouteEngine>());
+        services.AddSingleton<ILocalGribInspector, DeferredLocalGribInspector>();
         services.AddSingleton(provider => new RoutingWorkflow(
             new IForecastProvider[]
             {

--- a/src/Navtool.App/Services/DeferredLocalGribInspector.cs
+++ b/src/Navtool.App/Services/DeferredLocalGribInspector.cs
@@ -1,0 +1,31 @@
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.App.Services;
+
+public sealed class DeferredLocalGribInspector : ILocalGribInspector
+{
+    private readonly Lazy<ILocalGribInspector> _inspector;
+
+    public DeferredLocalGribInspector()
+        : this(() => new NativeLocalGribInspector())
+    {
+    }
+
+    public DeferredLocalGribInspector(Func<ILocalGribInspector> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _inspector = new Lazy<ILocalGribInspector>(
+            factory,
+            LazyThreadSafetyMode.PublicationOnly);
+    }
+
+    public async ValueTask<LocalForecastDescriptor> InspectAsync(
+        string absolutePath,
+        CancellationToken cancellationToken = default) =>
+        await Task.Run(
+            async () => await _inspector.Value
+                .InspectAsync(absolutePath, cancellationToken)
+                .ConfigureAwait(false),
+            cancellationToken).ConfigureAwait(false);
+}

--- a/src/Navtool.App/Services/DeferredNativeRouteEngine.cs
+++ b/src/Navtool.App/Services/DeferredNativeRouteEngine.cs
@@ -16,7 +16,7 @@ public interface IWeatherSampler
         CancellationToken cancellationToken = default);
 }
 
-public sealed class DeferredNativeRouteEngine : IRouteEngine, IWeatherSampler
+public sealed class DeferredNativeRouteEngine : IRouteEngine, IWeatherSampler, INativeRoutingPreflight
 {
     private readonly Lazy<NativeRouteEngine> _engine;
 
@@ -35,7 +35,29 @@ public sealed class DeferredNativeRouteEngine : IRouteEngine, IWeatherSampler
         ArgumentNullException.ThrowIfNull(factory);
         _engine = new Lazy<NativeRouteEngine>(
             factory,
-            LazyThreadSafetyMode.ExecutionAndPublication);
+            LazyThreadSafetyMode.PublicationOnly);
+    }
+
+    /// <summary>
+    /// Performs a lightweight preflight check to verify that the native router
+    /// bridge library is present and exposes the expected ABI version. Call this
+    /// before initiating any HTTP forecast acquisition to surface problems early
+    /// with actionable error messages.
+    /// </summary>
+    /// <exception cref="NativeBridgeUnavailableException">
+    /// The native library could not be found, does not export the versioned ABI,
+    /// or is for an incompatible platform.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// The library ABI version does not match the required version.
+    /// </exception>
+    public void EnsureAvailable()
+    {
+        // Materializing the engine constructs NativeRouterBridge, which calls
+        // navtool_router_bridge_abi_version_v1() and validates the version.
+        // No GRIB file is loaded. PublicationOnly does not cache factory
+        // exceptions, so a corrected bridge installation can be retried.
+        _ = _engine.Value;
     }
 
     public ValueTask<RouteResult> CalculateAsync(

--- a/src/Navtool.App/Services/RoutePlanningHelpers.cs
+++ b/src/Navtool.App/Services/RoutePlanningHelpers.cs
@@ -44,41 +44,6 @@ public static class LocalDepartureConverter
     }
 }
 
-public static class ForecastCorridor
-{
-    public static GeographicBounds Create(
-        Coordinate origin,
-        Coordinate destination,
-        double paddingDegrees = 5)
-    {
-        if (!double.IsFinite(paddingDegrees) || paddingDegrees <= 0 || paddingDegrees >= 90)
-        {
-            throw new ArgumentOutOfRangeException(nameof(paddingDegrees));
-        }
-
-        var bounds = GeographicBounds.FromCoordinates(new[] { origin, destination });
-        var south = Math.Max(-90, bounds.South - paddingDegrees);
-        var north = Math.Min(90, bounds.North + paddingDegrees);
-        var eastUnwrapped = bounds.CrossesAntimeridian ? bounds.East + 360 : bounds.East;
-        if (eastUnwrapped - bounds.West + (paddingDegrees * 2) >= 360)
-        {
-            return new GeographicBounds(south, north, -180, 180);
-        }
-
-        return new GeographicBounds(
-            south,
-            north,
-            NormalizeLongitude(bounds.West - paddingDegrees),
-            NormalizeLongitude(eastUnwrapped + paddingDegrees));
-    }
-
-    private static double NormalizeLongitude(double longitude)
-    {
-        var normalized = ((longitude + 180) % 360 + 360) % 360 - 180;
-        return normalized == -180 && longitude > 0 ? 180 : normalized;
-    }
-}
-
 public static class WeatherGridSizing
 {
     public static (int LatitudeCount, int LongitudeCount) FromViewport(

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -522,6 +522,12 @@ public partial class MainViewModel : ViewModelBase
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
+            if (cancellation == Volatile.Read(ref _inspectionCancellation))
+            {
+                LocalGribStatus = LocalForecast is null
+                    ? "GRIB inspection cancelled."
+                    : "Inspection cancelled; the previous GRIB remains selected.";
+            }
         }
         catch (Exception exception)
         {

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -855,10 +855,18 @@ public partial class MainViewModel : ViewModelBase
 
             if (outcome.Status == ModelRouteStatus.Succeeded)
             {
-                SetModelStatus(
-                    outcome.Model,
+                var route = outcome.Route!;
+                var status =
                     $"{(IsExperimentalDownload(result.Request, outcome.Model) ? "Experimental · " : string.Empty)}" +
-                    $"complete · arrival {outcome.Route!.ArrivalTime:MMM d HH:mm} UTC");
+                    $"complete · arrival {route.ArrivalTime:MMM d HH:mm} UTC";
+                if (route.ExceedsRequestedArrival)
+                {
+                    status +=
+                        $" · estimated arrival is {FormatOverDuration(route.ArrivalTime - route.Request.LatestArrivalTime)} " +
+                        "beyond the expected passage duration";
+                }
+
+                SetModelStatus(outcome.Model, status);
             }
             else
             {
@@ -1264,4 +1272,16 @@ public partial class MainViewModel : ViewModelBase
         ForecastModel.EcmwfIfs => "ECMWF IFS (experimental)",
         _ => model.ToString()
     };
+
+    private static string FormatOverDuration(TimeSpan overrun)
+    {
+        if (overrun < TimeSpan.Zero)
+        {
+            overrun = TimeSpan.Zero;
+        }
+
+        var hours = (int)overrun.TotalHours;
+        var minutes = overrun.Minutes;
+        return hours > 0 ? $"{hours}h {minutes}m" : $"{minutes}m";
+    }
 }

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -15,6 +15,12 @@ using Navtool.Infrastructure;
 
 namespace Navtool.App.ViewModels;
 
+public enum ForecastInputMode
+{
+    Download,
+    LocalFile
+}
+
 public partial class MainViewModel : ViewModelBase
 {
     private const double RouteHitTolerancePixels = 10;
@@ -26,6 +32,9 @@ public partial class MainViewModel : ViewModelBase
     private readonly RouteMapLayers _mapLayers;
     private readonly RoutingWorkflow? _workflow;
     private readonly IWeatherSampler? _weatherSampler;
+    private readonly ILocalGribInspector? _localGribInspector;
+    private readonly INativeRoutingPreflight? _nativeRoutingPreflight;
+    private readonly NoaaGfsForecastProvider? _noaaProvider;
     private readonly TimeProvider _timeProvider;
     private readonly TimeZoneInfo _localTimeZone;
     private readonly ILogger<MainViewModel> _logger;
@@ -34,6 +43,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly object _progressGate = new();
     private CancellationTokenSource? _calculationCancellation;
     private CancellationTokenSource? _weatherCancellation;
+    private CancellationTokenSource? _inspectionCancellation;
     private SharedRouteTimeline? _timeline;
     private long _calculationGeneration;
     private long _weatherGeneration;
@@ -44,6 +54,29 @@ public partial class MainViewModel : ViewModelBase
 
     [ObservableProperty]
     private TimeSpan? _departureTime = DateTimeOffset.Now.TimeOfDay;
+
+    [ObservableProperty]
+    private int _passageDays = 3;
+
+    [ObservableProperty]
+    private int _passageHours;
+
+    [ObservableProperty]
+    private ForecastInputMode _forecastInputMode;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CalculateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
+    private bool _isInspectingLocalGrib;
+
+    [ObservableProperty]
+    private LocalForecastDescriptor? _localForecast;
+
+    [ObservableProperty]
+    private string _localGribStatus = "Choose a GRIB file to inspect.";
+
+    [ObservableProperty]
+    private string _forecastAreaSummary = "Set both endpoints to estimate the forecast download.";
 
     [ObservableProperty]
     private bool _useNoaa = true;
@@ -115,6 +148,9 @@ public partial class MainViewModel : ViewModelBase
     public MainViewModel(
         RoutingWorkflow workflow,
         IWeatherSampler weatherSampler,
+        ILocalGribInspector localGribInspector,
+        INativeRoutingPreflight nativeRoutingPreflight,
+        NoaaGfsForecastProvider noaaProvider,
         ILogger<MainViewModel> logger)
         : this(
             workflow,
@@ -122,7 +158,10 @@ public partial class MainViewModel : ViewModelBase
             TimeProvider.System,
             TimeZoneInfo.Local,
             new OsmTileOptions(),
-            logger)
+            logger,
+            localGribInspector,
+            nativeRoutingPreflight,
+            noaaProvider)
     {
     }
 
@@ -132,13 +171,19 @@ public partial class MainViewModel : ViewModelBase
         TimeProvider timeProvider,
         TimeZoneInfo localTimeZone,
         OsmTileOptions tileOptions,
-        ILogger<MainViewModel>? logger = null)
+        ILogger<MainViewModel>? logger = null,
+        ILocalGribInspector? localGribInspector = null,
+        INativeRoutingPreflight? nativeRoutingPreflight = null,
+        NoaaGfsForecastProvider? noaaProvider = null)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(localTimeZone);
         ArgumentNullException.ThrowIfNull(tileOptions);
         _workflow = workflow;
         _weatherSampler = weatherSampler;
+        _localGribInspector = localGribInspector;
+        _nativeRoutingPreflight = nativeRoutingPreflight;
+        _noaaProvider = noaaProvider;
         _timeProvider = timeProvider;
         _localTimeZone = localTimeZone;
         _logger = logger ?? NullLogger<MainViewModel>.Instance;
@@ -159,6 +204,7 @@ public partial class MainViewModel : ViewModelBase
         Map.Navigator.CenterOnAndZoomTo(
             MapProjection.ToMapPoint(new Coordinate(35, -55)),
             25_000);
+        UpdateForecastAreaSummary();
     }
 
     public event EventHandler<RouteMapSelection?>? RouteSelectionChanged;
@@ -176,6 +222,17 @@ public partial class MainViewModel : ViewModelBase
     public string StartDisplay => FormatCoordinate(Start, "Not set");
 
     public string DestinationDisplay => FormatCoordinate(Destination, "Not set");
+
+    public bool IsDownloadForecast => ForecastInputMode == ForecastInputMode.Download;
+
+    public bool IsLocalForecast => ForecastInputMode == ForecastInputMode.LocalFile;
+
+    public string LocalGribDisplay => LocalForecast is null
+        ? "No file selected"
+        : $"{Path.GetFileName(LocalForecast.Artifact.Path)} · {ModelName(LocalForecast.Model)}\n" +
+          $"Run {LocalForecast.InitializedAt:yyyy-MM-dd HH:mm} UTC · " +
+          $"valid through {LocalForecast.ValidThrough:yyyy-MM-dd HH:mm} UTC\n" +
+          FormatBounds(LocalForecast.Bounds);
 
     public string MapInstruction => InteractionMode switch
     {
@@ -320,9 +377,32 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        if (ForecastInputMode == ForecastInputMode.LocalFile && LocalForecast is not null)
+        {
+            var inspectionGeneration = Volatile.Read(ref _calculationGeneration);
+            await SelectLocalGribAsync(LocalForecast.Artifact.Path);
+            if (LocalForecast is null ||
+                inspectionGeneration != Volatile.Read(ref _calculationGeneration))
+            {
+                return;
+            }
+        }
+
         if (!TryCreateWorkflowRequest(out var request, out var validationError))
         {
             ErrorMessage = validationError;
+            return;
+        }
+
+        try
+        {
+            _nativeRoutingPreflight?.EnsureAvailable();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Native routing preflight failed");
+            ErrorMessage = $"Routing engine unavailable: {exception.Message}";
+            StatusMessage = "No forecast was downloaded.";
             return;
         }
 
@@ -341,7 +421,7 @@ public partial class MainViewModel : ViewModelBase
         foreach (var model in request!.Models)
         {
             _modelProgress[model] = 0;
-            SetModelStatus(model, model == ForecastModel.EcmwfIfs
+            SetModelStatus(model, IsExperimentalDownload(request, model)
                 ? "Experimental · queued"
                 : "Queued");
         }
@@ -360,7 +440,7 @@ public partial class MainViewModel : ViewModelBase
             }
             SetModelStatus(
                 value.Model,
-                $"{(value.Model == ForecastModel.EcmwfIfs ? "Experimental · " : string.Empty)}" +
+                $"{(IsExperimentalDownload(request, value.Model) ? "Experimental · " : string.Empty)}" +
                 $"{ProgressStageName(value.Stage)} {value.Fraction:P0}" +
                 $"{(string.IsNullOrWhiteSpace(value.Message) ? string.Empty : $" · {value.Message}")}");
             if (value.Snapshot is not null)
@@ -409,6 +489,62 @@ public partial class MainViewModel : ViewModelBase
         }
     }
 
+    public async Task SelectLocalGribAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ErrorMessage = null;
+        if (_localGribInspector is null)
+        {
+            ErrorMessage = "Local GRIB inspection is unavailable.";
+            return;
+        }
+
+        var cancellation = new CancellationTokenSource();
+        var previous = Interlocked.Exchange(ref _inspectionCancellation, cancellation);
+        previous?.Cancel();
+        previous?.Dispose();
+        IsInspectingLocalGrib = true;
+        LocalGribStatus = "Inspecting selected GRIB...";
+        try
+        {
+            var inspected = await _localGribInspector.InspectAsync(path, cancellation.Token);
+            if (cancellation != Volatile.Read(ref _inspectionCancellation))
+            {
+                return;
+            }
+
+            LocalForecast = inspected;
+            ForecastInputMode = ForecastInputMode.LocalFile;
+            UseNoaa = inspected.Model == ForecastModel.NoaaGfs;
+            UseEcmwf = inspected.Model == ForecastModel.EcmwfIfs;
+            LocalGribStatus = "GRIB is compatible and ready.";
+            StatusMessage = $"{ModelName(inspected.Model)} local forecast selected.";
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            if (cancellation == Volatile.Read(ref _inspectionCancellation))
+            {
+                LocalForecast = null;
+                LocalGribStatus = "Selected file is not usable.";
+                ErrorMessage = $"GRIB file rejected: {exception.Message}";
+            }
+        }
+        finally
+        {
+            if (cancellation == Interlocked.CompareExchange(
+                    ref _inspectionCancellation,
+                    null,
+                    cancellation))
+            {
+                IsInspectingLocalGrib = false;
+                cancellation.Dispose();
+            }
+        }
+    }
+
     public void RequestWeatherRefreshFromViewport()
     {
         if (!TryGetVisibleBounds(out var bounds))
@@ -452,22 +588,35 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanCalculate))]
     private Task Calculate() => CalculateRoutesAsync();
 
-    private bool CanCalculate() => !IsCalculating;
+    private bool CanCalculate() =>
+        !IsCalculating &&
+        !IsInspectingLocalGrib &&
+        (ForecastInputMode == ForecastInputMode.Download || LocalForecast is not null);
+
+    [RelayCommand]
+    private void SelectDownloadSource() => ForecastInputMode = ForecastInputMode.Download;
+
+    [RelayCommand]
+    private void SelectLocalFileSource() => ForecastInputMode = ForecastInputMode.LocalFile;
 
     [RelayCommand(CanExecute = nameof(CanCancel))]
     private void Cancel()
     {
+        var wasCalculating = IsCalculating;
         Interlocked.Increment(ref _calculationGeneration);
         var cancellation = Interlocked.Exchange(ref _calculationCancellation, null);
         cancellation?.Cancel();
         cancellation?.Dispose();
+        Volatile.Read(ref _inspectionCancellation)?.Cancel();
         CancelWeather();
         _mapLayers.ClearCalculationOverlays();
         IsCalculating = false;
-        StatusMessage = "Calculation cancelled.";
+        StatusMessage = wasCalculating
+            ? "Calculation cancelled."
+            : "GRIB inspection cancelled.";
     }
 
-    private bool CanCancel() => IsCalculating;
+    private bool CanCancel() => IsCalculating || IsInspectingLocalGrib;
 
     [RelayCommand]
     private void FocusSelectedRoutePoint()
@@ -565,6 +714,31 @@ public partial class MainViewModel : ViewModelBase
     partial void OnHasEcmwfWeatherChanged(bool value) =>
         ActivateEcmwfWeatherCommand.NotifyCanExecuteChanged();
 
+    partial void OnDepartureDateChanged(DateTimeOffset? value) => UpdateForecastAreaSummary();
+
+    partial void OnDepartureTimeChanged(TimeSpan? value) => UpdateForecastAreaSummary();
+
+    partial void OnPassageDaysChanged(int value) => UpdateForecastAreaSummary();
+
+    partial void OnPassageHoursChanged(int value) => UpdateForecastAreaSummary();
+
+    partial void OnUseNoaaChanged(bool value) => UpdateForecastAreaSummary();
+
+    partial void OnForecastInputModeChanged(ForecastInputMode value)
+    {
+        OnPropertyChanged(nameof(IsDownloadForecast));
+        OnPropertyChanged(nameof(IsLocalForecast));
+        CalculateCommand.NotifyCanExecuteChanged();
+        UpdateForecastAreaSummary();
+    }
+
+    partial void OnLocalForecastChanged(LocalForecastDescriptor? value)
+    {
+        OnPropertyChanged(nameof(LocalGribDisplay));
+        CalculateCommand.NotifyCanExecuteChanged();
+        UpdateForecastAreaSummary();
+    }
+
     partial void OnSelectedRoutePointChanged(RouteMapSelection? value)
     {
         _mapLayers.SetSelectedPoint(value);
@@ -590,18 +764,31 @@ public partial class MainViewModel : ViewModelBase
             return false;
         }
 
-        var models = new List<ForecastModel>();
-        if (UseNoaa)
+        var selections = new List<ForecastSelection>();
+        if (ForecastInputMode == ForecastInputMode.LocalFile)
         {
-            models.Add(ForecastModel.NoaaGfs);
+            if (LocalForecast is null)
+            {
+                error = "Choose a compatible GRIB file before calculating.";
+                return false;
+            }
+
+            selections.Add(ForecastSelection.LocalFile(LocalForecast));
+        }
+        else
+        {
+            if (UseNoaa)
+            {
+                selections.Add(ForecastSelection.OfficialDownload(ForecastModel.NoaaGfs));
+            }
+
+            if (UseEcmwf)
+            {
+                selections.Add(ForecastSelection.OfficialDownload(ForecastModel.EcmwfIfs));
+            }
         }
 
-        if (UseEcmwf)
-        {
-            models.Add(ForecastModel.EcmwfIfs);
-        }
-
-        if (models.Count == 0)
+        if (selections.Count == 0)
         {
             error = "Select at least one forecast model.";
             return false;
@@ -617,12 +804,17 @@ public partial class MainViewModel : ViewModelBase
             return false;
         }
 
+        if (!TryGetPassageDuration(out var passageDuration, out error))
+        {
+            return false;
+        }
+
         var route = new RouteRequest(
             $"route-{Guid.NewGuid():N}",
             Start.Value,
             Destination.Value,
             departureUtc,
-            departureUtc + MaximumRouteWindow);
+            departureUtc + passageDuration);
         var validation = new RouteRequestValidator().Validate(
             route,
             _timeProvider.GetUtcNow(),
@@ -638,7 +830,7 @@ public partial class MainViewModel : ViewModelBase
 
         request = new RoutingWorkflowRequest(
             route,
-            models,
+            selections,
             ForecastCorridor.Create(route.Origin, route.Destination));
         error = null;
         return true;
@@ -659,16 +851,23 @@ public partial class MainViewModel : ViewModelBase
             {
                 SetModelStatus(
                     outcome.Model,
-                    $"{(outcome.Model == ForecastModel.EcmwfIfs ? "Experimental · " : string.Empty)}" +
+                    $"{(IsExperimentalDownload(result.Request, outcome.Model) ? "Experimental · " : string.Empty)}" +
                     $"complete · arrival {outcome.Route!.ArrivalTime:MMM d HH:mm} UTC");
             }
             else
             {
                 _mapLayers.ClearCalculationOverlay(outcome.Model);
-                var experimental = outcome.Model == ForecastModel.EcmwfIfs
+                var experimental = IsExperimentalDownload(result.Request, outcome.Model)
                     ? "Experimental ECMWF"
                     : ModelName(outcome.Model);
-                var message = $"{experimental} failed during {outcome.Failure!.Stage}: {outcome.Failure.Message}";
+                var failedStage = outcome.Failure!.Stage switch
+                {
+                    ModelRouteFailureStage.ForecastAcquisition => "forecast acquisition",
+                    ModelRouteFailureStage.RouteCalculation => "route calculation",
+                    ModelRouteFailureStage.ResultValidation => "route result validation",
+                    _ => "provider setup"
+                };
+                var message = $"{experimental} failed during {failedStage}: {outcome.Failure.Message}";
                 failures.Add(message);
                 _logger.LogWarning(
                     "Forecast model {Model} failed during {FailureStage}: {FailureMessage}",
@@ -937,7 +1136,97 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(StartDisplay));
         OnPropertyChanged(nameof(DestinationDisplay));
         OnPropertyChanged(nameof(MapInstruction));
+        UpdateForecastAreaSummary();
     }
+
+    private bool TryGetPassageDuration(out TimeSpan duration, out string? error)
+    {
+        duration = default;
+        if (PassageDays < 0 || PassageHours is < 0 or > 23)
+        {
+            error = "Passage duration requires non-negative days and hours from 0 through 23.";
+            return false;
+        }
+
+        duration = TimeSpan.FromDays(PassageDays) + TimeSpan.FromHours(PassageHours);
+        if (duration <= TimeSpan.Zero)
+        {
+            error = "Passage duration must be greater than zero.";
+            return false;
+        }
+
+        if (duration > MaximumRouteWindow)
+        {
+            error = "Passage duration cannot exceed 10 days.";
+            return false;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private void UpdateForecastAreaSummary()
+    {
+        if (Start is null || Destination is null)
+        {
+            ForecastAreaSummary = "Set both endpoints to estimate the forecast download.";
+            return;
+        }
+
+        var corridor = ForecastCorridor.Calculate(Start.Value, Destination.Value);
+        var bounds = corridor.Bounds;
+        var area = $"Buffered area {FormatBounds(bounds)} · {corridor.BufferNauticalMiles:0} NM buffer";
+        if (ForecastInputMode == ForecastInputMode.LocalFile)
+        {
+            ForecastAreaSummary = LocalForecast is null
+                ? $"{area}. Choose a local GRIB to check coverage."
+                : $"{area}. The selected GRIB will be checked against this area.";
+            return;
+        }
+
+        if (!UseNoaa ||
+            _noaaProvider is null ||
+            !TryGetPassageDuration(out var duration, out _) ||
+            !LocalDepartureConverter.TryConvertToUtc(
+                DepartureDate,
+                DepartureTime,
+                _localTimeZone,
+                out var departure,
+                out _))
+        {
+            ForecastAreaSummary = area;
+            return;
+        }
+
+        try
+        {
+            var estimate = _noaaProvider.Estimate(new ForecastRequest(
+                ForecastModel.NoaaGfs,
+                bounds,
+                departure,
+                departure + duration));
+            ForecastAreaSummary =
+                $"{area} · {estimate.ForecastStepCount} times, " +
+                $"{estimate.PartCount} forecast part{(estimate.PartCount == 1 ? string.Empty : "s")} " +
+                "(cached parts are reused)";
+        }
+        catch (Exception exception)
+        {
+            ForecastAreaSummary = $"{area} · estimate unavailable: {exception.Message}";
+        }
+    }
+
+    private static string FormatBounds(GeographicBounds bounds) =>
+        $"{bounds.South:0.##}° to {bounds.North:0.##}° latitude, " +
+        $"{bounds.West:0.##}° to {bounds.East:0.##}° longitude";
+
+    private static bool IsExperimentalDownload(
+        RoutingWorkflowRequest request,
+        ForecastModel model) =>
+        model == ForecastModel.EcmwfIfs &&
+        request.Selections.Any(selection =>
+            selection.Model == model &&
+            selection.Kind == ForecastSelectionKind.OfficialDownload);
 
     private static string ProgressStageName(RoutingProgressStage stage) => stage switch
     {

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -1282,6 +1282,11 @@ public partial class MainViewModel : ViewModelBase
 
         var hours = (int)overrun.TotalHours;
         var minutes = overrun.Minutes;
-        return hours > 0 ? $"{hours}h {minutes}m" : $"{minutes}m";
+        if (hours > 0)
+        {
+            return $"{hours}h {minutes}m";
+        }
+
+        return minutes > 0 ? $"{minutes}m" : $"{overrun.Seconds}s";
     }
 }

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -159,6 +159,33 @@
                                                 SelectedTime="{Binding DepartureTime}"
                                                 ClockIdentifier="24HourClock" />
                                 </Grid>
+                                <TextBlock Text="Expected passage duration"
+                                           FontWeight="SemiBold"
+                                           Margin="0,4,0,0" />
+                                <Grid ColumnDefinitions="*,*"
+                                      ColumnSpacing="8">
+                                    <StackPanel Spacing="3">
+                                        <TextBlock Text="Days"
+                                                   Classes="muted" />
+                                        <NumericUpDown x:Name="PassageDaysInput"
+                                                       Minimum="0"
+                                                       Maximum="10"
+                                                       Increment="1"
+                                                       FormatString="0"
+                                                       Value="{Binding PassageDays}" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1"
+                                                Spacing="3">
+                                        <TextBlock Text="Hours"
+                                                   Classes="muted" />
+                                        <NumericUpDown x:Name="PassageHoursInput"
+                                                       Minimum="0"
+                                                       Maximum="23"
+                                                       Increment="1"
+                                                       FormatString="0"
+                                                       Value="{Binding PassageHours}" />
+                                    </StackPanel>
+                                </Grid>
                                 <Border Background="#EEF4F6"
                                         CornerRadius="5"
                                         Padding="9,6">
@@ -177,43 +204,79 @@
                         <Border Classes="card">
                             <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
-                                           Text="3  FORECAST MODELS" />
-                                <CheckBox IsChecked="{Binding UseNoaa}">
-                                    <StackPanel>
-                                        <TextBlock Text="NOAA GFS"
-                                                   FontWeight="SemiBold" />
-                                        <TextBlock Text="Global Forecast System"
-                                                   Classes="muted" />
-                                    </StackPanel>
-                                </CheckBox>
-                                <TextBlock Text="{Binding NoaaStatus}"
+                                           Text="3  FORECAST SOURCE" />
+                                <StackPanel Orientation="Horizontal"
+                                            Spacing="14">
+                                    <RadioButton x:Name="DownloadForecastSource"
+                                                 GroupName="ForecastSource"
+                                                 Content="Download forecast"
+                                                 IsChecked="{Binding IsDownloadForecast, Mode=OneWay}"
+                                                 Command="{Binding SelectDownloadSourceCommand}" />
+                                    <RadioButton x:Name="LocalForecastSource"
+                                                 GroupName="ForecastSource"
+                                                 Content="Existing GRIB file"
+                                                 IsChecked="{Binding IsLocalForecast, Mode=OneWay}"
+                                                 Command="{Binding SelectLocalFileSourceCommand}" />
+                                </StackPanel>
+                                <StackPanel IsVisible="{Binding IsDownloadForecast}"
+                                            Spacing="7">
+                                    <CheckBox IsChecked="{Binding UseNoaa}">
+                                        <StackPanel>
+                                            <TextBlock Text="NOAA GFS"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Text="Global Forecast System"
+                                                       Classes="muted" />
+                                        </StackPanel>
+                                    </CheckBox>
+                                    <TextBlock Text="{Binding NoaaStatus}"
                                            Classes="muted"
                                            Margin="24,0,0,2"
                                            TextWrapping="Wrap" />
-                                <CheckBox IsChecked="{Binding UseEcmwf}">
-                                    <Grid ColumnDefinitions="*,Auto">
-                                        <StackPanel>
-                                            <TextBlock Text="ECMWF IFS"
-                                                       FontWeight="SemiBold" />
-                                            <TextBlock Text="European model"
-                                                       Classes="muted" />
-                                        </StackPanel>
-                                        <Border Grid.Column="1"
-                                                Background="#FFF1D6"
-                                                CornerRadius="10"
-                                                Padding="7,3"
-                                                VerticalAlignment="Center">
-                                            <TextBlock Text="EXPERIMENTAL"
-                                                       Foreground="#8A5A00"
-                                                       FontSize="9"
-                                                       FontWeight="Bold" />
-                                        </Border>
-                                    </Grid>
-                                </CheckBox>
-                                <TextBlock Text="{Binding EcmwfStatus}"
+                                    <CheckBox IsChecked="{Binding UseEcmwf}">
+                                        <Grid ColumnDefinitions="*,Auto">
+                                            <StackPanel>
+                                                <TextBlock Text="ECMWF IFS"
+                                                           FontWeight="SemiBold" />
+                                                <TextBlock Text="European model"
+                                                           Classes="muted" />
+                                            </StackPanel>
+                                            <Border Grid.Column="1"
+                                                    Background="#FFF1D6"
+                                                    CornerRadius="10"
+                                                    Padding="7,3"
+                                                    VerticalAlignment="Center">
+                                                <TextBlock Text="EXPERIMENTAL"
+                                                           Foreground="#8A5A00"
+                                                           FontSize="9"
+                                                           FontWeight="Bold" />
+                                            </Border>
+                                        </Grid>
+                                    </CheckBox>
+                                    <TextBlock Text="{Binding EcmwfStatus}"
                                            Classes="muted"
                                            Margin="24,0,0,0"
                                            TextWrapping="Wrap" />
+                                </StackPanel>
+                                <StackPanel IsVisible="{Binding IsLocalForecast}"
+                                            Spacing="7">
+                                    <Button x:Name="ChooseGribFileButton"
+                                            Click="OnChooseGribFileClicked"
+                                            IsEnabled="{Binding !IsInspectingLocalGrib}"
+                                            Content="Choose GRIB file..." />
+                                    <TextBlock Text="{Binding LocalGribDisplay}"
+                                           FontWeight="SemiBold"
+                                           TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding LocalGribStatus}"
+                                           Classes="muted"
+                                           TextWrapping="Wrap" />
+                                </StackPanel>
+                                <Border Background="#EEF4F6"
+                                        CornerRadius="5"
+                                        Padding="9,7">
+                                    <TextBlock Text="{Binding ForecastAreaSummary}"
+                                           Classes="muted"
+                                           TextWrapping="Wrap" />
+                                </Border>
                             </StackPanel>
                         </Border>
 
@@ -224,7 +287,6 @@
                                     Content="Calculate routes" />
                             <Button Grid.Column="1"
                                     Command="{Binding CancelCommand}"
-                                    IsEnabled="{Binding IsCalculating}"
                                     Content="Cancel"
                                     MinWidth="76" />
                         </Grid>

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -71,16 +71,32 @@ public partial class MainWindow : Window
             return;
         }
 
-        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        // async void event handler: any unhandled exception here would be raised on the
+        // UI sync context and crash the app, so guard availability and catch failures.
+        var storageProvider = StorageProvider;
+        if (storageProvider is null || !storageProvider.CanOpen)
         {
-            Title = "Choose an existing GRIB forecast",
-            AllowMultiple = false,
-            FileTypeFilter = [GribFileType, FilePickerFileTypes.All]
-        });
-        var path = files.FirstOrDefault()?.TryGetLocalPath();
-        if (!string.IsNullOrWhiteSpace(path))
+            viewModel.ErrorMessage = "This platform does not support opening files.";
+            return;
+        }
+
+        try
         {
-            await viewModel.SelectLocalGribAsync(path);
+            var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+            {
+                Title = "Choose an existing GRIB forecast",
+                AllowMultiple = false,
+                FileTypeFilter = [GribFileType, FilePickerFileTypes.All]
+            });
+            var path = files.FirstOrDefault()?.TryGetLocalPath();
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                await viewModel.SelectLocalGribAsync(path);
+            }
+        }
+        catch (Exception exception)
+        {
+            viewModel.ErrorMessage = $"Choosing a GRIB file failed: {exception.Message}";
         }
     }
 }

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
 using Mapsui;
 using Mapsui.UI.Avalonia;
 using Navtool.App.ViewModels;
@@ -8,6 +9,12 @@ namespace Navtool.App.Views;
 
 public partial class MainWindow : Window
 {
+    private static readonly FilePickerFileType GribFileType = new("GRIB forecasts")
+    {
+        Patterns = ["*.grib", "*.grb", "*.grib2", "*.grb2", "*.gri"],
+        MimeTypes = ["application/octet-stream"]
+    };
+
     private Navigator? _subscribedNavigator;
 
     public MainWindow()
@@ -52,6 +59,28 @@ public partial class MainWindow : Window
         {
             viewModel.HandleMapClick(e.WorldPosition, e.ScreenPosition);
             e.Handled = true;
+        }
+    }
+
+    private async void OnChooseGribFileClicked(
+        object? sender,
+        Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel viewModel)
+        {
+            return;
+        }
+
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Choose an existing GRIB forecast",
+            AllowMultiple = false,
+            FileTypeFilter = [GribFileType, FilePickerFileTypes.All]
+        });
+        var path = files.FirstOrDefault()?.TryGetLocalPath();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            await viewModel.SelectLocalGribAsync(path);
         }
     }
 }

--- a/src/Navtool.Core/Forecasts.cs
+++ b/src/Navtool.Core/Forecasts.cs
@@ -17,7 +17,14 @@ public enum ForecastModel
 public enum ForecastAcquisitionSource
 {
     Remote,
-    Cache
+    Cache,
+    LocalFile
+}
+
+public enum ForecastSelectionKind
+{
+    OfficialDownload,
+    LocalFile
 }
 
 public enum ForecastProgressStage
@@ -263,6 +270,86 @@ public sealed record LocalGribArtifact
     public long? LengthBytes { get; }
 
     public DateTimeOffset? LastModifiedAt { get; }
+}
+
+public sealed record LocalForecastDescriptor
+{
+    public LocalForecastDescriptor(
+        ForecastModel model,
+        LocalGribArtifact artifact,
+        DateTimeOffset initializedAt,
+        DateTimeOffset validFrom,
+        DateTimeOffset validThrough,
+        GeographicBounds bounds)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+        var utcInitializedAt = initializedAt.ToUniversalTime();
+        var utcValidFrom = validFrom.ToUniversalTime();
+        var utcValidThrough = validThrough.ToUniversalTime();
+        if (utcValidThrough < utcValidFrom)
+        {
+            throw new ArgumentException("Forecast validity cannot end before it begins.", nameof(validThrough));
+        }
+
+        _ = model.Provider();
+        Model = model;
+        Artifact = artifact;
+        InitializedAt = utcInitializedAt;
+        ValidFrom = utcValidFrom;
+        ValidThrough = utcValidThrough;
+        Bounds = bounds;
+    }
+
+    public ForecastModel Model { get; }
+
+    public LocalGribArtifact Artifact { get; }
+
+    public DateTimeOffset InitializedAt { get; }
+
+    public DateTimeOffset ValidFrom { get; }
+
+    public DateTimeOffset ValidThrough { get; }
+
+    public GeographicBounds Bounds { get; }
+}
+
+public sealed record ForecastSelection
+{
+    private ForecastSelection(
+        ForecastModel model,
+        ForecastSelectionKind kind,
+        LocalForecastDescriptor? localForecast)
+    {
+        _ = model.Provider();
+        if ((kind == ForecastSelectionKind.LocalFile) != (localForecast is not null))
+        {
+            throw new ArgumentException("Local forecast metadata is required only for local file selections.");
+        }
+
+        if (localForecast is not null && localForecast.Model != model)
+        {
+            throw new ArgumentException("The local forecast model does not match the selection.", nameof(localForecast));
+        }
+
+        Model = model;
+        Kind = kind;
+        LocalForecast = localForecast;
+    }
+
+    public ForecastModel Model { get; }
+
+    public ForecastSelectionKind Kind { get; }
+
+    public LocalForecastDescriptor? LocalForecast { get; }
+
+    public static ForecastSelection OfficialDownload(ForecastModel model) =>
+        new(model, ForecastSelectionKind.OfficialDownload, null);
+
+    public static ForecastSelection LocalFile(LocalForecastDescriptor forecast)
+    {
+        ArgumentNullException.ThrowIfNull(forecast);
+        return new ForecastSelection(forecast.Model, ForecastSelectionKind.LocalFile, forecast);
+    }
 }
 
 public sealed record ForecastAcquisition

--- a/src/Navtool.Core/Geography.cs
+++ b/src/Navtool.Core/Geography.cs
@@ -82,6 +82,12 @@ public readonly record struct GeographicBounds
             : coordinate.Longitude >= West && coordinate.Longitude <= East;
     }
 
+    public bool Contains(GeographicBounds other) =>
+        Contains(new Coordinate(other.South, other.West)) &&
+        Contains(new Coordinate(other.South, other.East)) &&
+        Contains(new Coordinate(other.North, other.West)) &&
+        Contains(new Coordinate(other.North, other.East));
+
     public static GeographicBounds FromCoordinates(IEnumerable<Coordinate> coordinates)
     {
         ArgumentNullException.ThrowIfNull(coordinates);
@@ -120,4 +126,121 @@ public readonly record struct GeographicBounds
 
     private static double ToSignedLongitude(double longitude) =>
         longitude > 180 ? longitude - 360 : longitude;
+}
+
+public sealed record ForecastCorridorPolicy
+{
+    public double RouteDistanceFraction { get; init; } = 0.2;
+
+    public double MinimumBufferNauticalMiles { get; init; } = 300;
+
+    public double MaximumBufferNauticalMiles { get; init; } = 900;
+}
+
+public sealed record ForecastCorridorResult(
+    GeographicBounds Bounds,
+    double RouteDistanceNauticalMiles,
+    double BufferNauticalMiles);
+
+public static class ForecastCorridor
+{
+    private const double EarthRadiusNauticalMiles = 3_440.065;
+
+    public static GeographicBounds Create(
+        Coordinate origin,
+        Coordinate destination,
+        ForecastCorridorPolicy? policy = null) =>
+        Calculate(origin, destination, policy).Bounds;
+
+    public static ForecastCorridorResult Calculate(
+        Coordinate origin,
+        Coordinate destination,
+        ForecastCorridorPolicy? policy = null)
+    {
+        var effectivePolicy = policy ?? new ForecastCorridorPolicy();
+        Validate(effectivePolicy);
+        var routeDistance = GreatCircleDistanceNauticalMiles(origin, destination);
+        var buffer = Math.Clamp(
+            routeDistance * effectivePolicy.RouteDistanceFraction,
+            effectivePolicy.MinimumBufferNauticalMiles,
+            effectivePolicy.MaximumBufferNauticalMiles);
+        var baseBounds = GeographicBounds.FromCoordinates([origin, destination]);
+        var latitudePadding = buffer / 60d;
+        var south = Math.Max(-90, baseBounds.South - latitudePadding);
+        var north = Math.Min(90, baseBounds.North + latitudePadding);
+        var polewardLatitude = Math.Max(Math.Abs(south), Math.Abs(north));
+        if (polewardLatitude >= 89.5)
+        {
+            return new ForecastCorridorResult(
+                new GeographicBounds(south, north, -180, 180),
+                routeDistance,
+                buffer);
+        }
+
+        var longitudePadding = buffer /
+            (60d * Math.Cos(polewardLatitude * Math.PI / 180d));
+        var baseWidth = LongitudeWidth(baseBounds);
+        if (baseWidth + (longitudePadding * 2) >= 360)
+        {
+            return new ForecastCorridorResult(
+                new GeographicBounds(south, north, -180, 180),
+                routeDistance,
+                buffer);
+        }
+
+        var eastUnwrapped = baseBounds.CrossesAntimeridian
+            ? baseBounds.East + 360
+            : baseBounds.East;
+        return new ForecastCorridorResult(
+            new GeographicBounds(
+                south,
+                north,
+                NormalizeLongitude(baseBounds.West - longitudePadding),
+                NormalizeLongitude(eastUnwrapped + longitudePadding)),
+            routeDistance,
+            buffer);
+    }
+
+    public static double GreatCircleDistanceNauticalMiles(
+        Coordinate origin,
+        Coordinate destination)
+    {
+        var latitude1 = origin.Latitude * Math.PI / 180d;
+        var latitude2 = destination.Latitude * Math.PI / 180d;
+        var latitudeDelta = latitude2 - latitude1;
+        var longitudeDelta =
+            (destination.Longitude - origin.Longitude) * Math.PI / 180d;
+        var haversine =
+            Math.Pow(Math.Sin(latitudeDelta / 2d), 2) +
+            (Math.Cos(latitude1) * Math.Cos(latitude2) *
+             Math.Pow(Math.Sin(longitudeDelta / 2d), 2));
+        var centralAngle = 2d * Math.Atan2(
+            Math.Sqrt(haversine),
+            Math.Sqrt(Math.Max(0, 1d - haversine)));
+        return EarthRadiusNauticalMiles * centralAngle;
+    }
+
+    private static void Validate(ForecastCorridorPolicy policy)
+    {
+        if (!double.IsFinite(policy.RouteDistanceFraction) ||
+            policy.RouteDistanceFraction <= 0 ||
+            !double.IsFinite(policy.MinimumBufferNauticalMiles) ||
+            policy.MinimumBufferNauticalMiles <= 0 ||
+            !double.IsFinite(policy.MaximumBufferNauticalMiles) ||
+            policy.MaximumBufferNauticalMiles < policy.MinimumBufferNauticalMiles)
+        {
+            throw new ArgumentOutOfRangeException(nameof(policy));
+        }
+    }
+
+    private static double LongitudeWidth(GeographicBounds bounds) =>
+        bounds.CrossesAntimeridian
+            ? bounds.East + 360 - bounds.West
+            : bounds.East - bounds.West;
+
+    private static double NormalizeLongitude(double longitude)
+    {
+        var normalized = ((longitude + 180) % 360 + 360) % 360 - 180;
+        return normalized == -180 && longitude > 0 ? 180 : normalized;
+    }
 }

--- a/src/Navtool.Core/Geography.cs
+++ b/src/Navtool.Core/Geography.cs
@@ -82,11 +82,44 @@ public readonly record struct GeographicBounds
             : coordinate.Longitude >= West && coordinate.Longitude <= East;
     }
 
-    public bool Contains(GeographicBounds other) =>
-        Contains(new Coordinate(other.South, other.West)) &&
-        Contains(new Coordinate(other.South, other.East)) &&
-        Contains(new Coordinate(other.North, other.West)) &&
-        Contains(new Coordinate(other.North, other.East));
+    public bool Contains(GeographicBounds other)
+    {
+        // Latitude is a simple interval; the inner band must sit within the outer band.
+        if (other.South < South || other.North > North)
+        {
+            return false;
+        }
+
+        return ContainsLongitudeSpan(other);
+    }
+
+    // Corner sampling is insufficient for longitude: when the inner span crosses the
+    // antimeridian its corners lie away from 180 and can all fall inside an outer span
+    // that nonetheless excludes the band the inner span sweeps through 180. Treat each
+    // span as an eastward arc and require the inner arc to fit entirely within the outer.
+    private bool ContainsLongitudeSpan(GeographicBounds other)
+    {
+        const double epsilon = 1e-9;
+
+        var outerLength = CrossesAntimeridian ? East - West + 360 : East - West;
+        var innerLength = other.CrossesAntimeridian ? other.East - other.West + 360 : other.East - other.West;
+
+        // A full-globe outer span contains any longitude span.
+        if (outerLength >= 360 - epsilon)
+        {
+            return true;
+        }
+
+        // Offset of the inner western edge measured eastward from the outer western edge (0..360).
+        var offset = (other.West - West) % 360;
+        if (offset < 0)
+        {
+            offset += 360;
+        }
+
+        // The inner arc fits when it begins within the outer arc and ends before it closes.
+        return offset + innerLength <= outerLength + epsilon;
+    }
 
     public static GeographicBounds FromCoordinates(IEnumerable<Coordinate> coordinates)
     {

--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -15,8 +15,18 @@ public sealed record RouteRequest
         RouteId = routeId;
         Origin = origin;
         Destination = destination;
-        DepartureTime = departureTime.ToUniversalTime();
+        // Normalize departure to whole seconds so the managed request and the native
+        // epoch-second departure agree exactly at the RouteResult boundary check.
+        DepartureTime = NormalizeToWholeSeconds(departureTime);
         LatestArrivalTime = latestArrivalTime.ToUniversalTime();
+    }
+
+    private static DateTimeOffset NormalizeToWholeSeconds(DateTimeOffset value)
+    {
+        var utc = value.ToUniversalTime();
+        return new DateTimeOffset(
+            utc.Ticks - (utc.Ticks % TimeSpan.TicksPerSecond),
+            TimeSpan.Zero);
     }
 
     public string RouteId { get; }
@@ -334,10 +344,14 @@ public sealed record RouteResult
             throw new ArgumentException("A route must contain at least one point.", nameof(points));
         }
 
-        if (immutablePoints[0].Timestamp < request.DepartureTime ||
-            immutablePoints[^1].Timestamp > request.LatestArrivalTime)
+        // LatestArrivalTime is a planning TARGET (it sizes the forecast window), not a
+        // hard ceiling on the achieved arrival. Keep only the genuine lower bound: a
+        // route may not begin before departure. See ExceedsRequestedArrival below.
+        if (immutablePoints[0].Timestamp < request.DepartureTime)
         {
-            throw new ArgumentException("Route points must fall within the requested time window.", nameof(points));
+            throw new ArgumentException(
+                "Route points must not begin before the requested departure time.",
+                nameof(points));
         }
 
         for (var index = 1; index < immutablePoints.Length; index++)
@@ -369,6 +383,13 @@ public sealed record RouteResult
     public RouteDiagnostics Diagnostics { get; }
 
     public DateTimeOffset ArrivalTime => Points[^1].Timestamp;
+
+    /// <summary>
+    /// True when the computed arrival lands after the requested passage duration
+    /// target. Informational only: the router is never asked to honor the target,
+    /// so exceeding it is expected and must not be treated as a failure.
+    /// </summary>
+    public bool ExceedsRequestedArrival => ArrivalTime > Request.LatestArrivalTime;
 }
 
 public sealed record RouteCalculationProgress

--- a/src/Navtool.Core/RoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutingWorkflow.cs
@@ -10,7 +10,7 @@ public sealed record RoutingWorkflowRequest
         GeographicBounds? forecastBounds = null)
         : this(
             route,
-            models.Select(ForecastSelection.OfficialDownload),
+            CreateDownloadSelections(models),
             forecastBounds)
     {
     }
@@ -61,6 +61,15 @@ public sealed record RoutingWorkflowRequest
     public ImmutableArray<ForecastSelection> Selections { get; }
 
     public GeographicBounds ForecastBounds { get; }
+
+    private static IEnumerable<ForecastSelection> CreateDownloadSelections(
+        IEnumerable<ForecastModel> models)
+    {
+        ArgumentNullException.ThrowIfNull(models);
+        return models
+            .Distinct()
+            .Select(ForecastSelection.OfficialDownload);
+    }
 }
 
 public enum RoutingProgressStage

--- a/src/Navtool.Core/RoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutingWorkflow.cs
@@ -8,18 +8,33 @@ public sealed record RoutingWorkflowRequest
         RouteRequest route,
         IEnumerable<ForecastModel> models,
         GeographicBounds? forecastBounds = null)
+        : this(
+            route,
+            models.Select(ForecastSelection.OfficialDownload),
+            forecastBounds)
+    {
+    }
+
+    public RoutingWorkflowRequest(
+        RouteRequest route,
+        IEnumerable<ForecastSelection> selections,
+        GeographicBounds? forecastBounds = null)
     {
         ArgumentNullException.ThrowIfNull(route);
-        ArgumentNullException.ThrowIfNull(models);
-        var immutableModels = models.Distinct().ToImmutableArray();
-        if (immutableModels.Length is < 1 or > 2)
+        ArgumentNullException.ThrowIfNull(selections);
+        var immutableSelections = selections.ToImmutableArray();
+        if (immutableSelections.Length is < 1 or > 2 ||
+            immutableSelections.Select(selection => selection.Model).Distinct().Count() !=
+            immutableSelections.Length)
         {
-            throw new ArgumentException("Select one or two distinct forecast models.", nameof(models));
+            throw new ArgumentException(
+                "Select one or two distinct forecast models.",
+                nameof(selections));
         }
 
-        foreach (var model in immutableModels)
+        foreach (var selection in immutableSelections)
         {
-            _ = model.Provider();
+            _ = selection.Model.Provider();
         }
 
         if (route.Origin.IsSameLocation(route.Destination))
@@ -33,7 +48,8 @@ public sealed record RoutingWorkflowRequest
         }
 
         Route = route;
-        Models = immutableModels;
+        Selections = immutableSelections;
+        Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
         ForecastBounds = forecastBounds ?? GeographicBounds.FromCoordinates(
             new[] { route.Origin, route.Destination });
     }
@@ -41,6 +57,8 @@ public sealed record RoutingWorkflowRequest
     public RouteRequest Route { get; }
 
     public ImmutableArray<ForecastModel> Models { get; }
+
+    public ImmutableArray<ForecastSelection> Selections { get; }
 
     public GeographicBounds ForecastBounds { get; }
 }
@@ -205,8 +223,8 @@ public sealed class RoutingWorkflow
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var tasks = request.Models
-            .Select(model => RunModelAsync(request, model, progress, cancellationToken))
+        var tasks = request.Selections
+            .Select(selection => RunModelAsync(request, selection, progress, cancellationToken))
             .ToArray();
 
         var outcomes = await Task.WhenAll(tasks).WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -216,12 +234,14 @@ public sealed class RoutingWorkflow
 
     private async Task<ModelRouteOutcome> RunModelAsync(
         RoutingWorkflowRequest request,
-        ForecastModel model,
+        ForecastSelection selection,
         IProgress<RoutingProgress>? progress,
         CancellationToken cancellationToken)
     {
+        var model = selection.Model;
         var providerId = model.Provider();
-        if (!_providers.TryGetValue(model, out var provider))
+        if (selection.Kind == ForecastSelectionKind.OfficialDownload &&
+            !_providers.TryGetValue(model, out _))
         {
             var missing = ModelRouteOutcome.Failed(
                 model,
@@ -252,9 +272,11 @@ public sealed class RoutingWorkflow
                     value.Fraction * 0.5,
                     value.Message));
 
-            acquisition = await provider
-                .AcquireAsync(forecastRequest, forecastProgress, cancellationToken)
-                .ConfigureAwait(false);
+            acquisition = selection.Kind == ForecastSelectionKind.LocalFile
+                ? AcquireLocal(selection, forecastRequest, forecastProgress, cancellationToken)
+                : await _providers[model]
+                    .AcquireAsync(forecastRequest, forecastProgress, cancellationToken)
+                    .ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
             if (acquisition.Request != forecastRequest)
@@ -307,6 +329,41 @@ public sealed class RoutingWorkflow
                 exception.Message,
                 acquisition);
         }
+    }
+
+    private static ForecastAcquisition AcquireLocal(
+        ForecastSelection selection,
+        ForecastRequest request,
+        IProgress<ForecastProgress> progress,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var local = selection.LocalForecast ??
+            throw new InvalidOperationException("Local forecast metadata is missing.");
+        if (request.From < local.ValidFrom || request.Through > local.ValidThrough)
+        {
+            throw new InvalidOperationException(
+                $"The selected GRIB is valid from {local.ValidFrom:u} through {local.ValidThrough:u}, " +
+                "which does not cover the requested route window.");
+        }
+
+        if (!local.Bounds.Contains(request.Bounds))
+        {
+            throw new InvalidOperationException(
+                "The selected GRIB does not cover the buffered route region.");
+        }
+
+        progress.Report(new ForecastProgress(
+            request.Provider,
+            request.Model,
+            ForecastProgressStage.Completed,
+            1,
+            "Using selected local GRIB"));
+        return new ForecastAcquisition(
+            request,
+            new ForecastRun(request.Provider, request.Model, local.InitializedAt),
+            local.Artifact,
+            ForecastAcquisitionSource.LocalFile);
     }
 
     private static void Report(

--- a/src/Navtool.Infrastructure/AtomicFileCache.cs
+++ b/src/Navtool.Infrastructure/AtomicFileCache.cs
@@ -57,6 +57,10 @@ public sealed class AtomicFileCache
 
     public string RootDirectory => _options.RootDirectory;
 
+    public long MaximumBytes => _options.MaximumBytes;
+
+    public int MaximumEntries => _options.MaximumEntries;
+
     public static string CreateKey(string category, params string[] components)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(category);

--- a/src/Navtool.Infrastructure/INativeRoutingPreflight.cs
+++ b/src/Navtool.Infrastructure/INativeRoutingPreflight.cs
@@ -1,0 +1,24 @@
+namespace Navtool.Infrastructure;
+
+/// <summary>
+/// Lightweight preflight contract that can verify native bridge availability
+/// and ABI compatibility before any forecast acquisition is attempted.
+/// </summary>
+public interface INativeRoutingPreflight
+{
+    /// <summary>
+    /// Verifies that the native router bridge library is present, exports the
+    /// required ABI version, and is compatible with the current platform.
+    /// Call this once at startup or before initiating HTTP forecast acquisition
+    /// to surface problems early with actionable error messages.
+    /// No GRIB file is loaded.
+    /// </summary>
+    /// <exception cref="NativeBridgeUnavailableException">
+    /// The native library could not be found, does not export the versioned ABI,
+    /// or is for an incompatible platform/architecture.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// The library ABI version is present but incompatible.
+    /// </exception>
+    void EnsureAvailable();
+}

--- a/src/Navtool.Infrastructure/NativeGribInspector.cs
+++ b/src/Navtool.Infrastructure/NativeGribInspector.cs
@@ -26,6 +26,10 @@ public interface ILocalGribInspector
     /// <exception cref="NativeRouterException">
     /// The GRIB file is malformed, incomplete, model-ambiguous, or from an unsupported model.
     /// </exception>
+    /// <exception cref="NativeRouteFormatException">
+    /// The native inspection returned an unrecognized model identifier, or geographic
+    /// bounds or timestamps that fail domain validation.
+    /// </exception>
     ValueTask<LocalForecastDescriptor> InspectAsync(
         string absolutePath,
         CancellationToken cancellationToken = default);

--- a/src/Navtool.Infrastructure/NativeGribInspector.cs
+++ b/src/Navtool.Infrastructure/NativeGribInspector.cs
@@ -1,0 +1,99 @@
+using Navtool.Core;
+
+namespace Navtool.Infrastructure;
+
+/// <summary>
+/// Inspects a local GRIB file and returns a <see cref="LocalForecastDescriptor"/>
+/// populated from the file's ecCodes metadata without copying or retaining the file.
+/// </summary>
+public interface ILocalGribInspector
+{
+    /// <summary>
+    /// Reads model identity, initialization time, validity range, and geographic bounds
+    /// from the GRIB file at <paramref name="absolutePath"/>.
+    /// </summary>
+    /// <param name="absolutePath">Absolute path to the GRIB file. The file is read in
+    /// place and is never copied.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A descriptor for the file-based forecast.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="absolutePath"/> is null, empty, whitespace, or relative.
+    /// </exception>
+    /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="NativeBridgeUnavailableException">
+    /// The native router bridge library is absent or incompatible.
+    /// </exception>
+    /// <exception cref="NativeRouterException">
+    /// The GRIB file is malformed, incomplete, model-ambiguous, or from an unsupported model.
+    /// </exception>
+    ValueTask<LocalForecastDescriptor> InspectAsync(
+        string absolutePath,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Implementation of <see cref="ILocalGribInspector"/> backed by the native
+/// router bridge and ecCodes. Model identity is determined from the GRIB
+/// <c>centre</c> key (not the filename).
+/// </summary>
+public sealed class NativeLocalGribInspector : ILocalGribInspector
+{
+    private readonly NativeRouterBridge _bridge;
+
+    public NativeLocalGribInspector(NativeRouterBridge? bridge = null)
+    {
+        _bridge = bridge ?? new NativeRouterBridge();
+    }
+
+    public ValueTask<LocalForecastDescriptor> InspectAsync(
+        string absolutePath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(absolutePath);
+        if (!Path.IsPathFullyQualified(absolutePath))
+        {
+            throw new ArgumentException(
+                "The GRIB path must be absolute.",
+                nameof(absolutePath));
+        }
+
+        var descriptor = _bridge.InspectGrib(absolutePath, cancellationToken);
+
+        var model = descriptor.ModelId switch
+        {
+            NativeGribModelId.NoaaGfs => ForecastModel.NoaaGfs,
+            NativeGribModelId.EcmwfIfs => ForecastModel.EcmwfIfs,
+            _ => throw new NativeRouteFormatException(
+                $"Unrecognized GRIB model identifier {(int)descriptor.ModelId} " +
+                $"returned from '{absolutePath}'; " +
+                $"only NOAA GFS and ECMWF IFS are supported.")
+        };
+
+        var fileInfo = new FileInfo(absolutePath);
+        var artifact = fileInfo.Exists
+            ? new LocalGribArtifact(absolutePath, fileInfo.Length, fileInfo.LastWriteTimeUtc)
+            : new LocalGribArtifact(absolutePath);
+
+        try
+        {
+            return ValueTask.FromResult(new LocalForecastDescriptor(
+                model,
+                artifact,
+                descriptor.InitializedAt,
+                descriptor.FirstValidAt,
+                descriptor.LastValidAt,
+                new GeographicBounds(
+                    descriptor.SouthLatitudeDegrees,
+                    descriptor.NorthLatitudeDegrees,
+                    descriptor.WestLongitudeDegrees,
+                    descriptor.EastLongitudeDegrees)));
+        }
+        catch (ArgumentException exception) when (exception is not ArgumentNullException)
+        {
+            throw new NativeRouteFormatException(
+                $"The GRIB file at '{absolutePath}' returned invalid geographic bounds " +
+                $"or timestamps: {exception.Message}",
+                exception);
+        }
+    }
+}

--- a/src/Navtool.Infrastructure/NativeGribInspector.cs
+++ b/src/Navtool.Infrastructure/NativeGribInspector.cs
@@ -57,7 +57,11 @@ public sealed class NativeLocalGribInspector : ILocalGribInspector
                 nameof(absolutePath));
         }
 
-        var descriptor = _bridge.InspectGrib(absolutePath, cancellationToken);
+        // Normalize once so the value handed to the native bridge (which normalizes
+        // internally) matches the path recorded on the returned artifact.
+        var normalizedPath = Path.GetFullPath(absolutePath);
+
+        var descriptor = _bridge.InspectGrib(normalizedPath, cancellationToken);
 
         var model = descriptor.ModelId switch
         {
@@ -65,14 +69,14 @@ public sealed class NativeLocalGribInspector : ILocalGribInspector
             NativeGribModelId.EcmwfIfs => ForecastModel.EcmwfIfs,
             _ => throw new NativeRouteFormatException(
                 $"Unrecognized GRIB model identifier {(int)descriptor.ModelId} " +
-                $"returned from '{absolutePath}'; " +
+                $"returned from '{normalizedPath}'; " +
                 $"only NOAA GFS and ECMWF IFS are supported.")
         };
 
-        var fileInfo = new FileInfo(absolutePath);
+        var fileInfo = new FileInfo(normalizedPath);
         var artifact = fileInfo.Exists
-            ? new LocalGribArtifact(absolutePath, fileInfo.Length, fileInfo.LastWriteTimeUtc)
-            : new LocalGribArtifact(absolutePath);
+            ? new LocalGribArtifact(normalizedPath, fileInfo.Length, fileInfo.LastWriteTimeUtc)
+            : new LocalGribArtifact(normalizedPath);
 
         try
         {
@@ -91,7 +95,7 @@ public sealed class NativeLocalGribInspector : ILocalGribInspector
         catch (ArgumentException exception) when (exception is not ArgumentNullException)
         {
             throw new NativeRouteFormatException(
-                $"The GRIB file at '{absolutePath}' returned invalid geographic bounds " +
+                $"The GRIB file at '{normalizedPath}' returned invalid geographic bounds " +
                 $"or timestamps: {exception.Message}",
                 exception);
         }

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -80,6 +80,23 @@ public sealed record NativeForecastMetadata(
     bool HasGlobalLongitudeCoverage,
     string Source);
 
+public enum NativeGribModelId
+{
+    Unknown = 0,
+    NoaaGfs = 1,
+    EcmwfIfs = 2
+}
+
+public sealed record NativeGribDescriptor(
+    NativeGribModelId ModelId,
+    DateTimeOffset InitializedAt,
+    DateTimeOffset FirstValidAt,
+    DateTimeOffset LastValidAt,
+    double SouthLatitudeDegrees,
+    double WestLongitudeDegrees,
+    double NorthLatitudeDegrees,
+    double EastLongitudeDegrees);
+
 public sealed record ViewportWindSample(
     Coordinate Location,
     DateTimeOffset ValidAt,
@@ -227,6 +244,42 @@ public sealed class NativeRouterBridge
         {
             handle?.Dispose();
             throw;
+        }
+    }
+
+    public NativeGribDescriptor InspectGrib(
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var fullPath = Path.GetFullPath(path);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException(
+                "The GRIB file does not exist.", fullPath);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var status = NativeMethods.InspectGrib(fullPath, out var descriptor);
+        cancellationToken.ThrowIfCancellationRequested();
+        ThrowIfFailed(status, "Inspecting GRIB file");
+
+        try
+        {
+            return new NativeGribDescriptor(
+                (NativeGribModelId)descriptor.ModelId,
+                DateTimeOffset.FromUnixTimeSeconds(descriptor.InitEpochSeconds),
+                DateTimeOffset.FromUnixTimeSeconds(descriptor.FirstValidEpochSeconds),
+                DateTimeOffset.FromUnixTimeSeconds(descriptor.LastValidEpochSeconds),
+                descriptor.SouthLatitudeDegrees,
+                descriptor.WestLongitudeDegrees,
+                descriptor.NorthLatitudeDegrees,
+                descriptor.EastLongitudeDegrees);
+        }
+        catch (ArgumentOutOfRangeException exception)
+        {
+            throw new NativeRouteFormatException(
+                "The GRIB descriptor contains an invalid timestamp.", exception);
         }
     }
 
@@ -904,6 +957,20 @@ internal struct NativeForecastMetadataStruct
     public byte GlobalLongitudeCoverage;
 }
 
+[StructLayout(LayoutKind.Sequential, Size = 64)]
+internal struct NativeGribDescriptorStruct
+{
+    public long InitEpochSeconds;
+    public long FirstValidEpochSeconds;
+    public long LastValidEpochSeconds;
+    public double SouthLatitudeDegrees;
+    public double WestLongitudeDegrees;
+    public double NorthLatitudeDegrees;
+    public double EastLongitudeDegrees;
+    public int ModelId;
+    private int _reserved;
+}
+
 [StructLayout(LayoutKind.Sequential)]
 internal struct NativeWindSample
 {
@@ -1035,6 +1102,14 @@ internal static class NativeMethods
 
     [DllImport(LibraryName, EntryPoint = "navtool_router_bridge_free_v1", CallingConvention = CallingConvention.Cdecl)]
     internal static extern void Free(IntPtr memory);
+
+    [DllImport(LibraryName, EntryPoint = "navtool_router_bridge_preflight_v1", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern uint Preflight();
+
+    [DllImport(LibraryName, EntryPoint = "navtool_router_inspect_grib_v1", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern NativeRouterStatus InspectGrib(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string gribPath,
+        out NativeGribDescriptorStruct descriptor);
 
     internal static string GetLastError()
     {

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -412,7 +412,44 @@ public sealed class NativeRouterBridge
 
         var json = CopyUtf8(routePointer, routeLength, _options.MaximumTextBytes, "route JSON");
         cancellationToken.ThrowIfCancellationRequested();
-        return NativeRouteJsonParser.Parse(json, request, model, stopwatch.Elapsed);
+        var result = NativeRouteJsonParser.Parse(json, request, model, stopwatch.Elapsed);
+        EnsureWithinForecastHorizon(result, forecast.Metadata);
+        return result;
+    }
+
+    // Mandatory postcondition: a route must never rely on weather past the loaded
+    // forecast's real validity. RouteResult (Core) is deliberately ignorant of forecast
+    // coverage, so this guard lives in the engine where the loaded forecast's authoritative
+    // FirstValidAt/LastValidAt are available. A one-second tolerance absorbs epoch-second
+    // rounding between the native route timestamps and the forecast metadata.
+    internal static void EnsureWithinForecastHorizon(
+        RouteResult result,
+        NativeForecastMetadata metadata)
+    {
+        var tolerance = TimeSpan.FromSeconds(1);
+        if (result.ArrivalTime <= metadata.LastValidAt + tolerance)
+        {
+            return;
+        }
+
+        var overrun = result.ArrivalTime - metadata.LastValidAt;
+        throw new NativeRouteFormatException(
+            "The fastest route reaches the destination after the available weather horizon " +
+            $"by {FormatDuration(overrun)}. The forecast covers through " +
+            $"{metadata.LastValidAt:u}, but the computed arrival is {result.ArrivalTime:u}. " +
+            "Request a longer passage duration forecast or a nearer destination.");
+    }
+
+    private static string FormatDuration(TimeSpan duration)
+    {
+        if (duration < TimeSpan.Zero)
+        {
+            duration = TimeSpan.Zero;
+        }
+
+        var hours = (int)duration.TotalHours;
+        var minutes = duration.Minutes;
+        return hours > 0 ? $"{hours}h {minutes}m" : $"{minutes}m";
     }
 
     private RouteCalculationSnapshot CopyProgress(IntPtr progressPointer)
@@ -792,6 +829,12 @@ internal static class NativeRouteJsonParser
         ForecastModel model,
         TimeSpan calculationDuration)
     {
+        RouteDiagnostics diagnostics;
+        var raw = ImmutableArray.CreateBuilder<RawRoutePoint>();
+
+        // Format boundary: JSON shape, kinds, and finiteness only. Domain object
+        // construction is deliberately kept OUT of this try so real routing/domain
+        // problems are never rebranded as a generic "v1 contract" JSON error.
         try
         {
             using var document = JsonDocument.Parse(
@@ -800,7 +843,7 @@ internal static class NativeRouteJsonParser
             var root = document.RootElement;
             RequireKind(root, JsonValueKind.Object, "root");
             var diagnosticsElement = Required(root, "diagnostics", JsonValueKind.Object);
-            var diagnostics = new RouteDiagnostics(
+            diagnostics = new RouteDiagnostics(
                 RequiredInt64(diagnosticsElement, "expandedNodes"),
                 RequiredInt64(diagnosticsElement, "generatedCandidates"),
                 RequiredInt64(diagnosticsElement, "retainedCandidates"),
@@ -808,15 +851,13 @@ internal static class NativeRouteJsonParser
                 calculationDuration);
 
             var pointsElement = Required(root, "points", JsonValueKind.Array);
-            var points = ImmutableArray.CreateBuilder<RoutePoint>();
             foreach (var element in pointsElement.EnumerateArray())
             {
                 RequireKind(element, JsonValueKind.Object, "point");
                 var position = Required(element, "position", JsonValueKind.Object);
-                points.Add(new RoutePoint(
-                    new Coordinate(
-                        RequiredDouble(position, "latitude"),
-                        RequiredDouble(position, "longitude")),
+                raw.Add(new RawRoutePoint(
+                    RequiredDouble(position, "latitude"),
+                    RequiredDouble(position, "longitude"),
                     RequiredTimestamp(element, "time"),
                     RequiredDouble(element, "headingDegrees"),
                     RequiredDouble(element, "boatSpeedKnots"),
@@ -824,8 +865,6 @@ internal static class NativeRouteJsonParser
                     RequiredDouble(element, "trueWindDirectionDegrees"),
                     RequiredDouble(element, "cumulativeDistanceNauticalMiles")));
             }
-
-            return new RouteResult(request, model, points, diagnostics);
         }
         catch (NativeRouteFormatException)
         {
@@ -833,13 +872,62 @@ internal static class NativeRouteJsonParser
         }
         catch (Exception exception) when (
             exception is JsonException or
-            ArgumentException or
             InvalidOperationException or
             OverflowException)
         {
             throw new NativeRouteFormatException("The native route JSON did not match the v1 contract.", exception);
         }
+
+        // Native OUTPUT semantics: the JSON is well-formed, but the values must still
+        // describe a real route. Domain constructors throw ArgumentException on
+        // out-of-range coordinates/headings/speeds; classify those as native-contract
+        // defects with descriptive messages, distinct from the JSON-format error above.
+        var points = ImmutableArray.CreateBuilder<RoutePoint>(raw.Count);
+        try
+        {
+            foreach (var point in raw)
+            {
+                points.Add(new RoutePoint(
+                    new Coordinate(point.Latitude, point.Longitude),
+                    point.Time,
+                    point.HeadingDegrees,
+                    point.BoatSpeedKnots,
+                    point.TrueWindSpeedKnots,
+                    point.TrueWindDirectionDegrees,
+                    point.CumulativeDistanceNauticalMiles));
+            }
+        }
+        catch (ArgumentException exception)
+        {
+            throw new NativeRouteFormatException(
+                $"The native router returned an invalid route point: {exception.Message}",
+                exception);
+        }
+
+        // Request-relative policy (RouteResult) is built OUTSIDE the format boundary.
+        // Structural defects in the native output (empty, time- or distance-descending)
+        // surface as a descriptive native-contract error, not the generic JSON message.
+        try
+        {
+            return new RouteResult(request, model, points.ToImmutable(), diagnostics);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new NativeRouteFormatException(
+                $"The native router returned a structurally invalid route: {exception.Message}",
+                exception);
+        }
     }
+
+    private readonly record struct RawRoutePoint(
+        double Latitude,
+        double Longitude,
+        DateTimeOffset Time,
+        double HeadingDegrees,
+        double BoatSpeedKnots,
+        double TrueWindSpeedKnots,
+        double TrueWindDirectionDegrees,
+        double CumulativeDistanceNauticalMiles);
 
     private static JsonElement Required(JsonElement parent, string name, JsonValueKind kind)
     {

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -449,7 +449,12 @@ public sealed class NativeRouterBridge
 
         var hours = (int)duration.TotalHours;
         var minutes = duration.Minutes;
-        return hours > 0 ? $"{hours}h {minutes}m" : $"{minutes}m";
+        if (hours > 0)
+        {
+            return $"{hours}h {minutes}m";
+        }
+
+        return minutes > 0 ? $"{minutes}m" : $"{duration.Seconds}s";
     }
 
     private RouteCalculationSnapshot CopyProgress(IntPtr progressPointer)

--- a/src/Navtool.Infrastructure/Navtool.Infrastructure.csproj
+++ b/src/Navtool.Infrastructure/Navtool.Infrastructure.csproj
@@ -5,6 +5,10 @@
     <ProjectReference Include="..\Navtool.Core\Navtool.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Navtool.Infrastructure.Tests" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -31,6 +31,15 @@ public sealed record NoaaGfsOptions
     public TimeSpan MinimumRequestInterval { get; init; } = TimeSpan.FromMilliseconds(250);
 }
 
+public sealed record NoaaGfsDownloadEstimate(
+    DateTimeOffset RunTime,
+    GeographicBounds Bounds,
+    int ForecastStepCount,
+    int RegionCount)
+{
+    public int PartCount => checked(ForecastStepCount * RegionCount);
+}
+
 public class ForecastDownloadException : IOException
 {
     public ForecastDownloadException(string message)
@@ -84,6 +93,21 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     public ForecastProvider Provider => ForecastProvider.Noaa;
 
     public ForecastModel Model => ForecastModel.NoaaGfs;
+
+    public NoaaGfsDownloadEstimate Estimate(ForecastRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        if (request.Model != Model)
+        {
+            throw new ArgumentException("The NOAA GFS provider only estimates NoaaGfs requests.", nameof(request));
+        }
+
+        var runTime = SelectRun(request, _timeProvider.GetUtcNow());
+        var steps = GetRequiredForecastHours(runTime, request.From, request.Through);
+        var bounds = AlignBoundsToGrid(request.Bounds);
+        var regions = GetNomadsLongitudeWindows(bounds);
+        return new NoaaGfsDownloadEstimate(runTime, bounds, steps.Length, regions.Length);
+    }
 
     public async ValueTask<ForecastAcquisition> AcquireAsync(
         ForecastRequest request,

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -123,18 +123,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         }
 
         // Serialize only acquisitions that target the same cached artifact (run, bounds,
-        // steps); unrelated requests use distinct gates and run concurrently.
-        var now = _timeProvider.GetUtcNow();
-        var gateRunTime = SelectRun(request, now);
-        var gateSteps = GetRequiredForecastHours(gateRunTime, request.From, request.Through);
-        var gateBounds = AlignBoundsToGrid(request.Bounds);
-        var gateKey = CreateCacheKey(gateBounds, gateRunTime, gateSteps);
-        var gate = _acquisitionGates.GetOrAdd(gateKey, static _ => new SemaphoreSlim(1, 1));
+        // steps); unrelated requests use distinct gates and run concurrently. The plan
+        // (including the definitive cache key) is computed ONCE here and threaded into the
+        // core so the gate and the download/store always agree on the same key, even if
+        // the clock advances across a run-publish boundary while queued behind the gate.
+        var plan = CreateAcquisitionPlan(request);
+        var gate = _acquisitionGates.GetOrAdd(plan.CacheKey, static _ => new SemaphoreSlim(1, 1));
 
         await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await AcquireCoreAsync(request, progress, cancellationToken).ConfigureAwait(false);
+            return await AcquireCoreAsync(request, plan, progress, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -142,19 +141,41 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         }
     }
 
+    // Resolves the definitive run selection, step set, grid-aligned bounds, and cache key
+    // for a request against a single captured "now". Computing this once (rather than
+    // recomputing inside the gated core) is what keeps the acquisition gate key and the
+    // stored artifact key identical.
+    private AcquisitionPlan CreateAcquisitionPlan(ForecastRequest request)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var runTime = SelectRun(request, now);
+        var steps = GetRequiredForecastHours(runTime, request.From, request.Through);
+        var downloadBounds = AlignBoundsToGrid(request.Bounds);
+        var cacheKey = CreateCacheKey(downloadBounds, runTime, steps);
+        return new AcquisitionPlan(now, runTime, steps, downloadBounds, cacheKey);
+    }
+
+    private readonly record struct AcquisitionPlan(
+        DateTimeOffset Now,
+        DateTimeOffset RunTime,
+        ImmutableArray<int> Steps,
+        GeographicBounds DownloadBounds,
+        string CacheKey);
+
     private async ValueTask<ForecastAcquisition> AcquireCoreAsync(
         ForecastRequest request,
+        AcquisitionPlan plan,
         IProgress<ForecastProgress>? progress,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Report(progress, ForecastProgressStage.Queued, 0, "Selecting NOAA GFS run");
-        var now = _timeProvider.GetUtcNow();
-        var runTime = SelectRun(request, now);
-        var steps = GetRequiredForecastHours(runTime, request.From, request.Through);
-        var downloadBounds = AlignBoundsToGrid(request.Bounds);
+        var now = plan.Now;
+        var runTime = plan.RunTime;
+        var steps = plan.Steps;
+        var downloadBounds = plan.DownloadBounds;
         var regions = GetNomadsLongitudeWindows(downloadBounds);
-        var cacheKey = CreateCacheKey(downloadBounds, runTime, steps);
+        var cacheKey = plan.CacheKey;
         _logger.LogInformation(
             "Selected NOAA GFS run {RunTime} with {StepCount} steps, {RegionCount} regions, download bounds " +
             "south={South}, north={North}, west={West}, east={East}, and cache key {CacheKey}",

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -72,8 +72,13 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly TimeProvider _timeProvider;
     private readonly NoaaGfsOptions _options;
     private readonly ILogger<NoaaGfsForecastProvider> _logger;
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim> _acquisitionGates =
+
+    // Ref-counted keyed gates: a gate exists only while one or more acquisitions target
+    // its cache key. The last acquisition to release the key removes and disposes the
+    // entry, so this dictionary cannot grow unbounded over a long-lived singleton session.
+    private readonly Dictionary<string, AcquisitionGate> _acquisitionGates =
         new(StringComparer.Ordinal);
+    private readonly object _acquisitionGatesLock = new();
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -95,6 +100,19 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     public ForecastProvider Provider => ForecastProvider.Noaa;
 
     public ForecastModel Model => ForecastModel.NoaaGfs;
+
+    // Number of live acquisition gates. Exposed for tests to assert gates are released
+    // (and not leaked) once acquisitions complete.
+    internal int ActiveAcquisitionGateCount
+    {
+        get
+        {
+            lock (_acquisitionGatesLock)
+            {
+                return _acquisitionGates.Count;
+            }
+        }
+    }
 
     public NoaaGfsDownloadEstimate Estimate(ForecastRequest request)
     {
@@ -128,16 +146,61 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         // core so the gate and the download/store always agree on the same key, even if
         // the clock advances across a run-publish boundary while queued behind the gate.
         var plan = CreateAcquisitionPlan(request);
-        var gate = _acquisitionGates.GetOrAdd(plan.CacheKey, static _ => new SemaphoreSlim(1, 1));
+        var gate = RentGate(plan.CacheKey);
 
-        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await gate.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            ReturnGate(plan.CacheKey, gate);
+            throw;
+        }
+
         try
         {
             return await AcquireCoreAsync(request, plan, progress, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            gate.Release();
+            gate.Semaphore.Release();
+            ReturnGate(plan.CacheKey, gate);
+        }
+    }
+
+    // A single-permit gate plus the count of acquisitions currently referencing its key.
+    private sealed class AcquisitionGate
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        public int RefCount { get; set; }
+    }
+
+    private AcquisitionGate RentGate(string cacheKey)
+    {
+        lock (_acquisitionGatesLock)
+        {
+            if (!_acquisitionGates.TryGetValue(cacheKey, out var gate))
+            {
+                gate = new AcquisitionGate();
+                _acquisitionGates[cacheKey] = gate;
+            }
+
+            gate.RefCount++;
+            return gate;
+        }
+    }
+
+    private void ReturnGate(string cacheKey, AcquisitionGate gate)
+    {
+        lock (_acquisitionGatesLock)
+        {
+            if (--gate.RefCount == 0)
+            {
+                _acquisitionGates.Remove(cacheKey);
+                gate.Semaphore.Dispose();
+            }
         }
     }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -72,6 +72,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly TimeProvider _timeProvider;
     private readonly NoaaGfsOptions _options;
     private readonly ILogger<NoaaGfsForecastProvider> _logger;
+    private readonly SemaphoreSlim _acquisitionGate = new(1, 1);
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -120,6 +121,22 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             throw new ArgumentException("The NOAA GFS provider only supplies NoaaGfs requests.", nameof(request));
         }
 
+        await _acquisitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await AcquireCoreAsync(request, progress, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _acquisitionGate.Release();
+        }
+    }
+
+    private async ValueTask<ForecastAcquisition> AcquireCoreAsync(
+        ForecastRequest request,
+        IProgress<ForecastProgress>? progress,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
         Report(progress, ForecastProgressStage.Queued, 0, "Selecting NOAA GFS run");
         var now = _timeProvider.GetUtcNow();
@@ -160,9 +177,10 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var manifest = BuildPartManifest(runTime, steps, regions, downloadBounds);
         var partsDirectory = Path.Combine(_cache.RootDirectory, "noaa-gfs-parts");
         Directory.CreateDirectory(partsDirectory);
+        PrunePartCache(partsDirectory, manifest);
 
         var totalParts = manifest.Length;
-        var httpRequestsMade = 0;
+        var downloadedParts = 0;
 
         // Acquire each part; reuse from disk if already complete.
         for (var index = 0; index < totalParts; index++)
@@ -185,7 +203,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             }
 
             // Apply pacing before each HTTP request except the very first.
-            if (httpRequestsMade > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+            if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
             {
                 await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
             }
@@ -197,13 +215,14 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                 $"Downloading GFS f{part.ForecastHour:000} (part {index + 1}/{totalParts})");
 
             await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
-            httpRequestsMade++;
+            downloadedParts++;
+            PrunePartCache(partsDirectory, manifest);
 
             Report(
                 progress,
                 ForecastProgressStage.Downloading,
                 (index + 1) / (double)totalParts,
-                $"Downloaded {index + 1}/{totalParts} GFS parts ({httpRequestsMade} HTTP requests)");
+                $"Downloaded {index + 1}/{totalParts} GFS parts ({downloadedParts} new this run)");
         }
 
         // Concatenate all parts in manifest order into the final cached artifact.
@@ -237,6 +256,13 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             "Stored NOAA GFS artifact {CacheKey} with {LengthBytes} bytes",
             cacheKey,
             stored.LengthBytes);
+        foreach (var part in manifest)
+        {
+            TryDeletePart(
+                Path.Combine(partsDirectory, part.PartKey + ".grib2"),
+                "assembled NOAA part");
+        }
+
         return CreateAcquisition(request, runTime, stored, ForecastAcquisitionSource.Remote);
     }
 
@@ -410,12 +436,12 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             "Downloading GFS part f{ForecastHour:000} region {RegionIndex} → {PartFile}",
             part.ForecastHour, part.RegionIndex, partFile);
 
-        var tempFile = partFile + ".partial";
+        var tempFile = $"{partFile}.{Guid.NewGuid():N}.partial";
         try
         {
             await using (var tempStream = new FileStream(
                 tempFile,
-                FileMode.Create,
+                FileMode.CreateNew,
                 FileAccess.ReadWrite,
                 FileShare.None,
                 128 * 1024,
@@ -425,11 +451,18 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                     .ConfigureAwait(false);
             }
 
-            File.Move(tempFile, partFile, overwrite: true);
+            try
+            {
+                File.Move(tempFile, partFile);
+            }
+            catch (IOException) when (File.Exists(partFile))
+            {
+                TryDeletePart(tempFile, "redundant NOAA temporary part");
+            }
         }
         catch
         {
-            DeleteIfPresent(tempFile);
+            TryDeletePart(tempFile, "failed NOAA temporary part");
             throw;
         }
     }
@@ -734,14 +767,69 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         string message) =>
         progress?.Report(new ForecastProgress(Provider, Model, stage, fraction, message));
 
-    private static void DeleteIfPresent(string path)
+    private void PrunePartCache(
+        string partsDirectory,
+        ImmutableArray<GribPartDescriptor> protectedManifest)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var protectedPaths = protectedManifest
+            .Select(part => Path.Combine(partsDirectory, part.PartKey + ".grib2"))
+            .ToHashSet(comparer);
+        var files = Directory
+            .EnumerateFiles(partsDirectory, "*.grib2", SearchOption.TopDirectoryOnly)
+            .Select(path => new FileInfo(path))
+            .ToList();
+        var maximumEntries = Math.Max(_cache.MaximumEntries, protectedManifest.Length);
+        var bytes = files.Sum(file => file.Length);
+        var count = files.Count;
+
+        foreach (var file in files
+                     .Where(file => !protectedPaths.Contains(file.FullName))
+                     .OrderBy(file => file.LastWriteTimeUtc)
+                     .ThenBy(file => file.Name, StringComparer.Ordinal))
+        {
+            if (count <= maximumEntries && bytes <= _cache.MaximumBytes)
+            {
+                break;
+            }
+
+            var length = file.Length;
+            if (TryDeletePart(file.FullName, "stale NOAA part"))
+            {
+                count--;
+                bytes -= length;
+            }
+        }
+
+        if (count > maximumEntries || bytes > _cache.MaximumBytes)
+        {
+            throw new IOException(
+                "The resumable NOAA parts for the current request exceed the configured cache bounds.");
+        }
+    }
+
+    private bool TryDeletePart(string path, string purpose)
     {
         try
         {
             File.Delete(path);
+            return true;
         }
         catch (DirectoryNotFoundException)
         {
+            return true;
+        }
+        catch (IOException exception)
+        {
+            _logger.LogWarning(exception, "Could not delete {Purpose} {Path}", purpose, path);
+            return false;
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            _logger.LogWarning(exception, "Could not delete {Purpose} {Path}", purpose, path);
+            return false;
         }
     }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Net;
@@ -79,6 +80,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly Dictionary<string, AcquisitionGate> _acquisitionGates =
         new(StringComparer.Ordinal);
     private readonly object _acquisitionGatesLock = new();
+
+    // Absolute paths of ".partial" temp files this provider is actively writing. Prune
+    // uses it to distinguish in-flight partials (from concurrent acquisitions for other
+    // cache keys) from orphans left by an abruptly terminated process, so only true
+    // orphans are swept and disk usage stays bounded.
+    private readonly ConcurrentDictionary<string, byte> _activePartialFiles =
+        new(PathComparer);
+
+    private static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -531,6 +543,10 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             part.ForecastHour, part.RegionIndex, partFile);
 
         var tempFile = $"{partFile}.{Guid.NewGuid():N}.partial";
+
+        // Register before creating the file so a concurrent prune (from another cache
+        // key's acquisition) never mistakes this in-flight partial for an orphan.
+        _activePartialFiles.TryAdd(tempFile, 0);
         try
         {
             await using (var tempStream = new FileStream(
@@ -558,6 +574,10 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         {
             TryDeletePart(tempFile, "failed NOAA temporary part");
             throw;
+        }
+        finally
+        {
+            _activePartialFiles.TryRemove(tempFile, out _);
         }
     }
 
@@ -865,6 +885,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         string partsDirectory,
         ImmutableArray<GribPartDescriptor> protectedManifest)
     {
+        SweepOrphanedPartials(partsDirectory);
+
         var comparer = OperatingSystem.IsWindows()
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
@@ -901,6 +923,27 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         {
             throw new IOException(
                 "The resumable NOAA parts for the current request exceed the configured cache bounds.");
+        }
+    }
+
+    // Deletes ".partial" temp files left behind by a prior process that was terminated
+    // mid-download. Partials this provider is actively writing are registered in
+    // _activePartialFiles and skipped, so concurrent acquisitions for other cache keys
+    // are never disrupted. Orphans are always safe to delete: a completed download is
+    // atomically moved to its ".grib2" name, so any lingering ".partial" is incomplete.
+    private void SweepOrphanedPartials(string partsDirectory)
+    {
+        foreach (var path in Directory.EnumerateFiles(
+            partsDirectory,
+            "*.partial",
+            SearchOption.TopDirectoryOnly))
+        {
+            if (_activePartialFiles.ContainsKey(path))
+            {
+                continue;
+            }
+
+            TryDeletePart(path, "orphaned NOAA temporary part");
         }
     }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -44,6 +44,17 @@ public class ForecastDownloadException : IOException
     }
 }
 
+/// <summary>
+/// Describes a single GRIB part in the download manifest: one (forecast hour × longitude window) pair.
+/// </summary>
+internal sealed record GribPartDescriptor(
+    int ForecastHour,
+    int RegionIndex,
+    NomadsLongitudeWindow LongitudeWindow,
+    GeographicBounds AlignedBounds,
+    string PartKey,
+    Uri RequestUri);
+
 public sealed class NoaaGfsForecastProvider : IForecastProvider
 {
     private static readonly ImmutableArray<int> AvailableForecastHours = BuildAvailableHours();
@@ -121,41 +132,77 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
         _logger.LogInformation("NOAA GFS cache miss for {CacheKey}", cacheKey);
 
-        var requestCount = checked(steps.Length * regions.Length);
-        var completed = 0;
+        // Build deterministic download manifest: forecast_hour ascending, then region index ascending.
+        var manifest = BuildPartManifest(runTime, steps, regions, downloadBounds);
+        var partsDirectory = Path.Combine(_cache.RootDirectory, "noaa-gfs-parts");
+        Directory.CreateDirectory(partsDirectory);
+
+        var totalParts = manifest.Length;
+        var httpRequestsMade = 0;
+
+        // Acquire each part; reuse from disk if already complete.
+        for (var index = 0; index < totalParts; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var part = manifest[index];
+            var partFile = Path.Combine(partsDirectory, part.PartKey + ".grib2");
+
+            if (File.Exists(partFile))
+            {
+                _logger.LogInformation(
+                    "Resuming cached part {PartIndex}/{Total} f{ForecastHour:000} region {RegionIndex}",
+                    index + 1, totalParts, part.ForecastHour, part.RegionIndex);
+                Report(
+                    progress,
+                    ForecastProgressStage.Downloading,
+                    (index + 1) / (double)totalParts,
+                    $"Resumed cached f{part.ForecastHour:000} (part {index + 1}/{totalParts})");
+                continue;
+            }
+
+            // Apply pacing before each HTTP request except the very first.
+            if (httpRequestsMade > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+            {
+                await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
+            }
+
+            Report(
+                progress,
+                ForecastProgressStage.Downloading,
+                index / (double)totalParts,
+                $"Downloading GFS f{part.ForecastHour:000} (part {index + 1}/{totalParts})");
+
+            await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
+            httpRequestsMade++;
+
+            Report(
+                progress,
+                ForecastProgressStage.Downloading,
+                (index + 1) / (double)totalParts,
+                $"Downloaded {index + 1}/{totalParts} GFS parts ({httpRequestsMade} HTTP requests)");
+        }
+
+        // Concatenate all parts in manifest order into the final cached artifact.
+        Report(progress, ForecastProgressStage.Decoding, 1, "Assembling GRIB2 artifact from parts");
         var stored = await _cache.StoreAsync(
                 cacheKey,
                 now,
                 now + _options.CacheFreshness,
                 async (output, token) =>
                 {
-                    foreach (var forecastHour in steps)
+                    foreach (var part in manifest)
                     {
-                        foreach (var region in regions)
-                        {
-                            token.ThrowIfCancellationRequested();
-                            if (completed > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
-                            {
-                                await Task.Delay(_options.MinimumRequestInterval, token).ConfigureAwait(false);
-                            }
-
-                            var uri = BuildNomadsUri(runTime, forecastHour, downloadBounds, region);
-                            Report(
-                                progress,
-                                ForecastProgressStage.Downloading,
-                                completed / (double)requestCount,
-                                $"Downloading GFS f{forecastHour:000}");
-                            await DownloadGribWithRetryAsync(uri, output, token).ConfigureAwait(false);
-                            completed++;
-                            Report(
-                                progress,
-                                ForecastProgressStage.Downloading,
-                                completed / (double)requestCount,
-                                $"Downloaded {completed} of {requestCount} GFS subsets");
-                        }
+                        token.ThrowIfCancellationRequested();
+                        var partFile = Path.Combine(partsDirectory, part.PartKey + ".grib2");
+                        await using var partStream = new FileStream(
+                            partFile,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.Read,
+                            128 * 1024,
+                            FileOptions.Asynchronous | FileOptions.SequentialScan);
+                        await partStream.CopyToAsync(output, token).ConfigureAwait(false);
                     }
-
-                    Report(progress, ForecastProgressStage.Decoding, 1, "Validated concatenated GRIB2 artifact");
                 },
                 cancellationToken)
             .ConfigureAwait(false);
@@ -303,6 +350,64 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         return originalWidth >= 360 - gridSize || alignedWidth >= 360
             ? new GeographicBounds(south, north, -180, 180)
             : new GeographicBounds(south, north, west, east);
+    }
+
+    /// <summary>
+    /// Builds the ordered download manifest: all (forecast hour, region) pairs in
+    /// ascending forecast-hour / ascending region-index order.
+    /// </summary>
+    internal ImmutableArray<GribPartDescriptor> BuildPartManifest(
+        DateTimeOffset runTime,
+        ImmutableArray<int> steps,
+        ImmutableArray<NomadsLongitudeWindow> regions,
+        GeographicBounds downloadBounds)
+    {
+        var builder = ImmutableArray.CreateBuilder<GribPartDescriptor>(steps.Length * regions.Length);
+        foreach (var forecastHour in steps)
+        {
+            for (var regionIndex = 0; regionIndex < regions.Length; regionIndex++)
+            {
+                var region = regions[regionIndex];
+                var partKey = CreatePartKey(downloadBounds, runTime, forecastHour, regionIndex);
+                var uri = BuildNomadsUri(runTime, forecastHour, downloadBounds, region);
+                builder.Add(new GribPartDescriptor(forecastHour, regionIndex, region, downloadBounds, partKey, uri));
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private async ValueTask DownloadPartAsync(
+        GribPartDescriptor part,
+        string partFile,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Downloading GFS part f{ForecastHour:000} region {RegionIndex} → {PartFile}",
+            part.ForecastHour, part.RegionIndex, partFile);
+
+        var tempFile = partFile + ".partial";
+        try
+        {
+            await using (var tempStream = new FileStream(
+                tempFile,
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                128 * 1024,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await DownloadGribWithRetryAsync(part.RequestUri, tempStream, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            File.Move(tempFile, partFile, overwrite: true);
+        }
+        catch
+        {
+            DeleteIfPresent(tempFile);
+            throw;
+        }
     }
 
     private async ValueTask DownloadGribWithRetryAsync(
@@ -555,6 +660,21 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             Format(bounds.East),
             string.Join(",", steps));
 
+    private static string CreatePartKey(
+        GeographicBounds bounds,
+        DateTimeOffset runTime,
+        int forecastHour,
+        int regionIndex) =>
+        AtomicFileCache.CreateKey(
+            "noaa-gfs-part",
+            runTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+            Format(bounds.South),
+            Format(bounds.North),
+            Format(bounds.West),
+            Format(bounds.East),
+            forecastHour.ToString(CultureInfo.InvariantCulture),
+            regionIndex.ToString(CultureInfo.InvariantCulture));
+
     private static ImmutableArray<int> BuildAvailableHours()
     {
         var builder = ImmutableArray.CreateBuilder<int>();
@@ -589,6 +709,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         double fraction,
         string message) =>
         progress?.Report(new ForecastProgress(Provider, Model, stage, fraction, message));
+
+    private static void DeleteIfPresent(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+    }
 
     private static void ValidateOptions(NoaaGfsOptions options)
     {

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -329,10 +329,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
         // Concatenate all parts in manifest order into the final cached artifact.
         Report(progress, ForecastProgressStage.Decoding, 1, "Assembling GRIB2 artifact from parts");
+        // Stamp cache freshness from the store time, not the plan's captured "now". The
+        // part-download loop above can run for minutes, so recording the artifact as created
+        // at plan start would shorten its effective freshness window and skew eviction, which
+        // ranks entries by ExpiresAt relative to the passed "now". Run selection, steps,
+        // bounds, and the cache key still come from the plan so the keyed acquisition gate and
+        // the stored artifact key stay aligned across run-publish boundaries.
+        var cacheNow = _timeProvider.GetUtcNow();
         var stored = await _cache.StoreAsync(
                 cacheKey,
-                now,
-                now + _options.CacheFreshness,
+                cacheNow,
+                cacheNow + _options.CacheFreshness,
                 async (output, token) =>
                 {
                     foreach (var part in manifest)

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Net;
@@ -80,17 +79,6 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly Dictionary<string, AcquisitionGate> _acquisitionGates =
         new(StringComparer.Ordinal);
     private readonly object _acquisitionGatesLock = new();
-
-    // Absolute paths of ".partial" temp files this provider is actively writing. Prune
-    // uses it to distinguish in-flight partials (from concurrent acquisitions for other
-    // cache keys) from orphans left by an abruptly terminated process, so only true
-    // orphans are swept and disk usage stays bounded.
-    private readonly ConcurrentDictionary<string, byte> _activePartialFiles =
-        new(PathComparer);
-
-    private static StringComparer PathComparer => OperatingSystem.IsWindows()
-        ? StringComparer.OrdinalIgnoreCase
-        : StringComparer.Ordinal;
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -281,7 +269,15 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
         // Build deterministic download manifest: forecast_hour ascending, then region index ascending.
         var manifest = BuildPartManifest(runTime, steps, regions, downloadBounds);
-        var partsDirectory = Path.Combine(_cache.RootDirectory, "noaa-gfs-parts");
+        // Isolate this cache key's resumable parts in their own subdirectory. Acquisitions
+        // for a given cache key are serialized by the keyed gate, so each subdirectory has a
+        // single writer at a time; acquisitions for different cache keys use different
+        // subdirectories. Pruning and orphan sweeping therefore only ever touch the current
+        // key's own parts, so a concurrent acquisition for another key can never have its
+        // freshly downloaded parts deleted as "stale," and file enumeration cannot race a
+        // delete from another acquisition. The cache key is a "<category>-<sha256-hex>"
+        // token (see AtomicFileCache.CreateKey), which is always a filesystem-safe segment.
+        var partsDirectory = Path.Combine(_cache.RootDirectory, "noaa-gfs-parts", cacheKey);
         Directory.CreateDirectory(partsDirectory);
         PrunePartCache(partsDirectory, manifest);
 
@@ -368,6 +364,10 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                 Path.Combine(partsDirectory, part.PartKey + ".grib2"),
                 "assembled NOAA part");
         }
+
+        // The parts subdirectory is now empty on success; remove it so per-key subdirectories
+        // do not accumulate across the many distinct cache keys a long-lived session requests.
+        TryDeleteDirectoryIfEmpty(partsDirectory);
 
         return CreateAcquisition(request, runTime, stored, ForecastAcquisitionSource.Remote);
     }
@@ -544,9 +544,6 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
         var tempFile = $"{partFile}.{Guid.NewGuid():N}.partial";
 
-        // Register before creating the file so a concurrent prune (from another cache
-        // key's acquisition) never mistakes this in-flight partial for an orphan.
-        _activePartialFiles.TryAdd(tempFile, 0);
         try
         {
             await using (var tempStream = new FileStream(
@@ -574,10 +571,6 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         {
             TryDeletePart(tempFile, "failed NOAA temporary part");
             throw;
-        }
-        finally
-        {
-            _activePartialFiles.TryRemove(tempFile, out _);
         }
     }
 
@@ -927,10 +920,11 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     }
 
     // Deletes ".partial" temp files left behind by a prior process that was terminated
-    // mid-download. Partials this provider is actively writing are registered in
-    // _activePartialFiles and skipped, so concurrent acquisitions for other cache keys
-    // are never disrupted. Orphans are always safe to delete: a completed download is
-    // atomically moved to its ".grib2" name, so any lingering ".partial" is incomplete.
+    // mid-download. The parts subdirectory is isolated per cache key and acquisitions for a
+    // given key are serialized, so at every prune point the current acquisition holds no
+    // in-flight partial of its own: any ".partial" here is therefore an orphan from an
+    // earlier interrupted run of the same key. A completed download is atomically moved to
+    // its ".grib2" name, so a lingering ".partial" is always incomplete and safe to delete.
     private void SweepOrphanedPartials(string partsDirectory)
     {
         foreach (var path in Directory.EnumerateFiles(
@@ -938,12 +932,26 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             "*.partial",
             SearchOption.TopDirectoryOnly))
         {
-            if (_activePartialFiles.ContainsKey(path))
-            {
-                continue;
-            }
-
             TryDeletePart(path, "orphaned NOAA temporary part");
+        }
+    }
+
+    private void TryDeleteDirectoryIfEmpty(string directory)
+    {
+        try
+        {
+            if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
+            {
+                Directory.Delete(directory);
+            }
+        }
+        catch (IOException exception)
+        {
+            _logger.LogWarning(exception, "Could not remove empty NOAA parts directory {Path}", directory);
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            _logger.LogWarning(exception, "Could not remove empty NOAA parts directory {Path}", directory);
         }
     }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -72,7 +72,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly TimeProvider _timeProvider;
     private readonly NoaaGfsOptions _options;
     private readonly ILogger<NoaaGfsForecastProvider> _logger;
-    private readonly SemaphoreSlim _acquisitionGate = new(1, 1);
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim> _acquisitionGates =
+        new(StringComparer.Ordinal);
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -121,14 +122,23 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             throw new ArgumentException("The NOAA GFS provider only supplies NoaaGfs requests.", nameof(request));
         }
 
-        await _acquisitionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // Serialize only acquisitions that target the same cached artifact (run, bounds,
+        // steps); unrelated requests use distinct gates and run concurrently.
+        var now = _timeProvider.GetUtcNow();
+        var gateRunTime = SelectRun(request, now);
+        var gateSteps = GetRequiredForecastHours(gateRunTime, request.From, request.Through);
+        var gateBounds = AlignBoundsToGrid(request.Bounds);
+        var gateKey = CreateCacheKey(gateBounds, gateRunTime, gateSteps);
+        var gate = _acquisitionGates.GetOrAdd(gateKey, static _ => new SemaphoreSlim(1, 1));
+
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             return await AcquireCoreAsync(request, progress, cancellationToken).ConfigureAwait(false);
         }
         finally
         {
-            _acquisitionGate.Release();
+            gate.Release();
         }
     }
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -72,6 +72,221 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task PassageDurationControlsForecastWindow()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.PassageDays = 2;
+        viewModel.PassageHours = 5;
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(TimeSpan.FromHours(53), noaa.LastRequest!.Through - noaa.LastRequest.From);
+    }
+
+    [Fact]
+    public async Task InvalidPassageDurationDoesNotAcquireForecast()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.PassageDays = 10;
+        viewModel.PassageHours = 1;
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Null(noaa.LastRequest);
+        Assert.Contains("cannot exceed 10 days", viewModel.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task LocalGribSelectionRoutesWithoutCallingForecastProvider()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var localPath = Path.GetFullPath("selected.grib2");
+        var inspector = new DelegateLocalGribInspector((path, _) =>
+        {
+            Assert.Equal(localPath, path);
+            return ValueTask.FromResult(new LocalForecastDescriptor(
+                ForecastModel.NoaaGfs,
+                new LocalGribArtifact(path),
+                Now.AddHours(-6),
+                Now.AddHours(-1),
+                Now.AddDays(5),
+                new GeographicBounds(-89, 89, -179, 179)));
+        });
+        var preflight = new DelegateNativeRoutingPreflight();
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            Assert.Equal(ForecastAcquisitionSource.LocalFile, forecast.Source);
+            Assert.Equal(localPath, forecast.Artifact.Path);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            inspector,
+            preflight);
+
+        await viewModel.SelectLocalGribAsync(localPath);
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(ForecastInputMode.LocalFile, viewModel.ForecastInputMode);
+        Assert.Equal(0, noaa.CallCount);
+        Assert.Equal(2, inspector.CallCount);
+        Assert.Equal(1, preflight.CallCount);
+        Assert.Equal(1, viewModel.SuccessfulRouteCount);
+    }
+
+    [Fact]
+    public async Task NativePreflightFailureHappensBeforeForecastAcquisition()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var preflight = new DelegateNativeRoutingPreflight(
+            new NativeBridgeUnavailableException(
+                "Build the native bridge first.",
+                new DllNotFoundException()));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            nativeRoutingPreflight: preflight);
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(1, preflight.CallCount);
+        Assert.Equal(0, noaa.CallCount);
+        Assert.Contains("Routing engine unavailable", viewModel.ErrorMessage);
+        Assert.Equal("No forecast was downloaded.", viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task LocalInspectorLoadsNativeImplementationOnlyWhenUsed()
+    {
+        var calls = 0;
+        var path = Path.GetFullPath("deferred.grib2");
+        var expected = new LocalForecastDescriptor(
+            ForecastModel.NoaaGfs,
+            new LocalGribArtifact(path),
+            Now.AddHours(-6),
+            Now,
+            Now.AddDays(3),
+            new GeographicBounds(-89, 89, -179, 179));
+        var deferred = new DeferredLocalGribInspector(() =>
+        {
+            calls++;
+            return new DelegateLocalGribInspector((_, _) => ValueTask.FromResult(expected));
+        });
+
+        Assert.Equal(0, calls);
+        var actual = await deferred.InspectAsync(path);
+
+        Assert.Equal(1, calls);
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task DeferredLocalInspectorRetriesAfterFactoryFailure()
+    {
+        var calls = 0;
+        var path = Path.GetFullPath("retry.grib2");
+        var expected = new LocalForecastDescriptor(
+            ForecastModel.NoaaGfs,
+            new LocalGribArtifact(path),
+            Now.AddHours(-6),
+            Now,
+            Now.AddDays(3),
+            new GeographicBounds(-89, 89, -179, 179));
+        var deferred = new DeferredLocalGribInspector(() =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                throw new NativeBridgeUnavailableException(
+                    "Bridge is not installed yet.",
+                    new DllNotFoundException());
+            }
+
+            return new DelegateLocalGribInspector((_, _) => ValueTask.FromResult(expected));
+        });
+
+        await Assert.ThrowsAsync<NativeBridgeUnavailableException>(
+            async () => await deferred.InspectAsync(path));
+        var actual = await deferred.InspectAsync(path);
+
+        Assert.Equal(2, calls);
+        Assert.Same(expected, actual);
+    }
+
+    [Fact]
+    public async Task LocalGribReinspectionCanBeCancelledBeforeRouting()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var path = Path.GetFullPath("cancel-inspection.grib2");
+        var descriptor = new LocalForecastDescriptor(
+            ForecastModel.NoaaGfs,
+            new LocalGribArtifact(path),
+            Now.AddHours(-6),
+            Now.AddHours(-1),
+            Now.AddDays(5),
+            new GeographicBounds(-89, 89, -179, 179));
+        var inspectionStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var inspector = new DelegateLocalGribInspector(async (_, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref calls) == 1)
+            {
+                return descriptor;
+            }
+
+            inspectionStarted.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new InvalidOperationException("Unreachable.");
+        });
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            inspector);
+        await viewModel.SelectLocalGribAsync(path);
+
+        var calculation = viewModel.CalculateRoutesAsync();
+        await inspectionStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.True(viewModel.CancelCommand.CanExecute(null));
+
+        viewModel.CancelCommand.Execute(null);
+        await calculation;
+
+        Assert.Equal(0, noaa.CallCount);
+        Assert.False(viewModel.IsInspectingLocalGrib);
+        Assert.Equal("GRIB inspection cancelled.", viewModel.StatusMessage);
+    }
+
+    [Fact]
     public async Task StreamingOverlaysRetainSuccessfulModelAndClearFailedModel()
     {
         var providers = new[]
@@ -311,14 +526,18 @@ public sealed class MainViewModelWorkflowTests
 
     private static MainViewModel CreateViewModel(
         RoutingWorkflow workflow,
-        IWeatherSampler sampler)
+        IWeatherSampler sampler,
+        ILocalGribInspector? localGribInspector = null,
+        INativeRoutingPreflight? nativeRoutingPreflight = null)
     {
         var viewModel = new MainViewModel(
             workflow,
             sampler,
             new FixedTimeProvider(Now),
             TimeZoneInfo.Utc,
-            new OsmTileOptions(Enabled: false));
+            new OsmTileOptions(Enabled: false),
+            localGribInspector: localGribInspector,
+            nativeRoutingPreflight: nativeRoutingPreflight);
         viewModel.SetEndpoints(
             new Coordinate(34, -64),
             new Coordinate(39, -52));
@@ -427,11 +646,14 @@ public sealed class MainViewModelWorkflowTests
 
         public ForecastRequest? LastRequest { get; private set; }
 
+        public int CallCount { get; private set; }
+
         public async ValueTask<ForecastAcquisition> AcquireAsync(
             ForecastRequest request,
             IProgress<ForecastProgress>? progress,
             CancellationToken cancellationToken)
         {
+            CallCount++;
             LastRequest = request;
             progress?.Report(new ForecastProgress(
                 Provider,
@@ -440,6 +662,36 @@ public sealed class MainViewModelWorkflowTests
                 0.5,
                 "fake forecast"));
             return await acquire(request, cancellationToken);
+        }
+    }
+
+    private sealed class DelegateLocalGribInspector(
+        Func<string, CancellationToken, ValueTask<LocalForecastDescriptor>> inspect)
+        : ILocalGribInspector
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<LocalForecastDescriptor> InspectAsync(
+            string absolutePath,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return inspect(absolutePath, cancellationToken);
+        }
+    }
+
+    private sealed class DelegateNativeRoutingPreflight(Exception? exception = null)
+        : INativeRoutingPreflight
+    {
+        public int CallCount { get; private set; }
+
+        public void EnsureAvailable()
+        {
+            CallCount++;
+            if (exception is not null)
+            {
+                throw exception;
+            }
         }
     }
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -72,6 +72,30 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task ArrivalBeyondRequestedDurationSucceedsWithOverDurationNote()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        // Arrival lands 80h out; the default 3-day (72h) passage target is exceeded.
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model, stepHours: 40)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(1, viewModel.SuccessfulRouteCount);
+        Assert.Contains("complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "beyond the expected passage duration",
+            viewModel.NoaaStatus,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task PassageDurationControlsForecastWindow()
     {
         var noaa = new DelegateForecastProvider(

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -284,6 +284,9 @@ public sealed class MainViewModelWorkflowTests
         Assert.Equal(0, noaa.CallCount);
         Assert.False(viewModel.IsInspectingLocalGrib);
         Assert.Equal("GRIB inspection cancelled.", viewModel.StatusMessage);
+        Assert.Equal(
+            "Inspection cancelled; the previous GRIB remains selected.",
+            viewModel.LocalGribStatus);
     }
 
     [Fact]

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -41,6 +41,30 @@ public sealed class MapRenderingTests
         }
     }
 
+    [AvaloniaFact]
+    public void MainWindowExposesDurationAndExistingGribControls()
+    {
+        var window = new MainWindow
+        {
+            DataContext = CreateViewModel(tilesEnabled: false)
+        };
+
+        try
+        {
+            window.Show();
+
+            Assert.NotNull(window.FindControl<NumericUpDown>("PassageDaysInput"));
+            Assert.NotNull(window.FindControl<NumericUpDown>("PassageHoursInput"));
+            Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
+            Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
+            Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [Fact]
     public void MapCompositionPlacesOpenStreetMapBelowRouteOverlays()
     {

--- a/tests/Navtool.Core.Tests/GeographyAndValidationTests.cs
+++ b/tests/Navtool.Core.Tests/GeographyAndValidationTests.cs
@@ -47,6 +47,45 @@ public sealed class GeographyAndValidationTests
     }
 
     [Fact]
+    public void Bounds_containment_handles_simple_and_edge_longitude_spans()
+    {
+        var outer = new GeographicBounds(-40, 40, -100, 100);
+
+        Assert.True(outer.Contains(new GeographicBounds(-40, 40, -100, 100)));
+        Assert.True(outer.Contains(new GeographicBounds(-10, 10, -50, 50)));
+        // Latitude outside the band is rejected.
+        Assert.False(outer.Contains(new GeographicBounds(-50, 10, -50, 50)));
+        // Longitude spilling past the western edge is rejected.
+        Assert.False(outer.Contains(new GeographicBounds(-10, 10, -150, 50)));
+    }
+
+    [Fact]
+    public void Bounds_containment_rejects_inner_span_crossing_excluded_antimeridian_band()
+    {
+        // Outer excludes the 20-degree band around +/-180. The inner span crosses the
+        // antimeridian, so all four of its corners fall inside the outer span even though
+        // the arc it sweeps through 180 lies outside. Corner sampling would wrongly accept it.
+        var outer = new GeographicBounds(-40, 40, -170, 170);
+        var innerCrossing = new GeographicBounds(-10, 10, 160, -160);
+
+        Assert.True(innerCrossing.CrossesAntimeridian);
+        Assert.False(outer.Contains(innerCrossing));
+    }
+
+    [Fact]
+    public void Bounds_containment_accepts_inner_span_within_crossing_outer()
+    {
+        var outer = new GeographicBounds(-40, 40, 170, -170);
+        var inner = new GeographicBounds(-10, 10, 175, -175);
+
+        Assert.True(outer.CrossesAntimeridian);
+        Assert.True(outer.Contains(inner));
+        // A wider inner span that overruns the crossing outer arc is rejected.
+        Assert.False(outer.Contains(new GeographicBounds(-10, 10, 160, -160)));
+    }
+
+
+    [Fact]
     public void Validator_reports_endpoint_and_departure_problems_together()
     {
         var now = new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero);

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -131,4 +131,122 @@ public sealed class NativeBridgeContractTests
         Assert.Throws<ArgumentException>(() =>
             new RouteCalculationSnapshot(time, new[] { point.Location }, new[] { point }, diagnostics));
     }
+
+    [Fact]
+    public void Route_result_accepts_arrival_after_the_requested_passage_target()
+    {
+        var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var request = new RouteRequest(
+            "route-over",
+            new Coordinate(40, -60),
+            new Coordinate(45, -55),
+            departure,
+            departure.AddHours(6));
+        var points = new[]
+        {
+            new RoutePoint(request.Origin, departure, 45, 6, 15, 200, 0),
+            // Achieved arrival lands two hours past the requested target.
+            new RoutePoint(request.Destination, departure.AddHours(8), 45, 6, 15, 200, 40)
+        };
+
+        var result = new RouteResult(request, ForecastModel.NoaaGfs, points, new RouteDiagnostics(1, 2, 1, 2));
+
+        Assert.Equal(departure.AddHours(8), result.ArrivalTime);
+        Assert.True(result.ExceedsRequestedArrival);
+    }
+
+    [Fact]
+    public void Route_result_reports_arrival_within_the_requested_passage_target()
+    {
+        var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var request = new RouteRequest(
+            "route-under",
+            new Coordinate(40, -60),
+            new Coordinate(45, -55),
+            departure,
+            departure.AddHours(10));
+        var points = new[]
+        {
+            new RoutePoint(request.Origin, departure, 45, 6, 15, 200, 0),
+            new RoutePoint(request.Destination, departure.AddHours(10), 45, 6, 15, 200, 40)
+        };
+
+        var result = new RouteResult(request, ForecastModel.NoaaGfs, points, new RouteDiagnostics(1, 2, 1, 2));
+
+        Assert.False(result.ExceedsRequestedArrival);
+    }
+
+    [Fact]
+    public void Route_result_still_rejects_empty_and_disordered_points()
+    {
+        var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var request = new RouteRequest(
+            "route-bad",
+            new Coordinate(40, -60),
+            new Coordinate(45, -55),
+            departure,
+            departure.AddHours(10));
+        var diagnostics = new RouteDiagnostics(1, 2, 1, 2);
+
+        Assert.Throws<ArgumentException>(() =>
+            new RouteResult(request, ForecastModel.NoaaGfs, Array.Empty<RoutePoint>(), diagnostics));
+        // Timestamp descending.
+        Assert.Throws<ArgumentException>(() => new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            new[]
+            {
+                new RoutePoint(request.Origin, departure.AddHours(2), 45, 6, 15, 200, 0),
+                new RoutePoint(request.Destination, departure.AddHours(1), 45, 6, 15, 200, 10)
+            },
+            diagnostics));
+        // Cumulative distance descending.
+        Assert.Throws<ArgumentException>(() => new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            new[]
+            {
+                new RoutePoint(request.Origin, departure, 45, 6, 15, 200, 20),
+                new RoutePoint(request.Destination, departure.AddHours(1), 45, 6, 15, 200, 10)
+            },
+            diagnostics));
+    }
+
+    [Fact]
+    public void Route_request_normalizes_departure_to_whole_seconds()
+    {
+        var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, 456, TimeSpan.Zero);
+        var request = new RouteRequest(
+            "route-precision",
+            new Coordinate(40, -60),
+            new Coordinate(45, -55),
+            departure,
+            departure.AddHours(10));
+
+        var normalizedDeparture = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        Assert.Equal(normalizedDeparture, request.DepartureTime);
+
+        // A first point at the normalized departure second is accepted.
+        var accepted = new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            new[]
+            {
+                new RoutePoint(request.Origin, normalizedDeparture, 45, 6, 15, 200, 0),
+                new RoutePoint(request.Destination, normalizedDeparture.AddHours(5), 45, 6, 15, 200, 20)
+            },
+            new RouteDiagnostics(1, 2, 1, 2));
+        Assert.Equal(normalizedDeparture, accepted.Points[0].Timestamp);
+
+        // A first point strictly before departure is still rejected.
+        Assert.Throws<ArgumentException>(() => new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            new[]
+            {
+                new RoutePoint(request.Origin, normalizedDeparture.AddSeconds(-1), 45, 6, 15, 200, 0),
+                new RoutePoint(request.Destination, normalizedDeparture.AddHours(5), 45, 6, 15, 200, 20)
+            },
+            new RouteDiagnostics(1, 2, 1, 2)));
+    }
 }

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -152,6 +152,65 @@ public sealed class RoutingWorkflowTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => execution);
     }
 
+    [Fact]
+    public async Task Local_forecast_routes_without_a_registered_or_remote_provider()
+    {
+        var route = CreateRouteRequest();
+        var local = new LocalForecastDescriptor(
+            ForecastModel.NoaaGfs,
+            new LocalGribArtifact(Path.GetFullPath("existing.grib2"), 1_024),
+            route.DepartureTime.AddHours(-6),
+            route.DepartureTime.AddHours(-1),
+            route.LatestArrivalTime.AddHours(1),
+            new GeographicBounds(30, 55, -90, -30));
+        var workflow = new RoutingWorkflow(
+            Array.Empty<IForecastProvider>(),
+            new StubRouteEngine((request, acquisition, _, _) =>
+            {
+                Assert.Equal(ForecastAcquisitionSource.LocalFile, acquisition.Source);
+                Assert.Equal(local.Artifact, acquisition.Artifact);
+                return ValueTask.FromResult(CreateRoute(request, acquisition.Request.Model));
+            }));
+        var request = new RoutingWorkflowRequest(
+            route,
+            new[] { ForecastSelection.LocalFile(local) },
+            new GeographicBounds(35, 50, -75, -45));
+
+        var result = await workflow.ExecuteAsync(request);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(ModelRouteStatus.Succeeded, outcome.Status);
+        Assert.Equal(ForecastAcquisitionSource.LocalFile, outcome.Acquisition!.Source);
+    }
+
+    [Fact]
+    public async Task Local_forecast_rejects_incomplete_route_coverage()
+    {
+        var route = CreateRouteRequest();
+        var local = new LocalForecastDescriptor(
+            ForecastModel.NoaaGfs,
+            new LocalGribArtifact(Path.GetFullPath("existing.grib2")),
+            route.DepartureTime.AddHours(-6),
+            route.DepartureTime,
+            route.LatestArrivalTime.AddHours(-1),
+            new GeographicBounds(40, 45, -70, -50));
+        var workflow = new RoutingWorkflow(
+            Array.Empty<IForecastProvider>(),
+            new StubRouteEngine((_, _, _, _) =>
+                throw new InvalidOperationException("Route engine must not run.")));
+        var request = new RoutingWorkflowRequest(
+            route,
+            new[] { ForecastSelection.LocalFile(local) },
+            new GeographicBounds(35, 50, -75, -45));
+
+        var result = await workflow.ExecuteAsync(request);
+
+        var outcome = Assert.Single(result.Outcomes);
+        Assert.Equal(ModelRouteStatus.Failed, outcome.Status);
+        Assert.Equal(ModelRouteFailureStage.ForecastAcquisition, outcome.Failure!.Stage);
+        Assert.Contains("does not cover the requested route window", outcome.Failure.Message);
+    }
+
     private static RoutingWorkflowRequest CreateWorkflowRequest() =>
         new(
             CreateRouteRequest(),

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -153,6 +153,19 @@ public sealed class RoutingWorkflowTests
     }
 
     [Fact]
+    public void Model_overload_rejects_null_and_preserves_duplicate_tolerance()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new RoutingWorkflowRequest(CreateRouteRequest(), (IEnumerable<ForecastModel>)null!));
+
+        var request = new RoutingWorkflowRequest(
+            CreateRouteRequest(),
+            new[] { ForecastModel.NoaaGfs, ForecastModel.NoaaGfs });
+
+        Assert.Equal([ForecastModel.NoaaGfs], request.Models.ToArray());
+    }
+
+    [Fact]
     public async Task Local_forecast_routes_without_a_registered_or_remote_provider()
     {
         var route = CreateRouteRequest();

--- a/tests/Navtool.Infrastructure.Tests/NativeGribInspectorTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeGribInspectorTests.cs
@@ -94,11 +94,13 @@ public sealed class NativeGribInspectorTests
     [Fact]
     public void ConstructingNativeRouterBridge_Throws_NativeBridgeUnavailableException_WhenDllIsMissing()
     {
-        // Simulate by catching — we verify the type is accessible and correctly typed.
-        // A DllNotFoundException wrapped in NativeBridgeUnavailableException is the contract.
+        // This contract can only be exercised when the native library is absent.
+        // A DllNotFoundException wrapped in NativeBridgeUnavailableException (or a
+        // NotSupportedException on ABI mismatch) is the contract.
+        NativeRouterBridge bridge;
         try
         {
-            _ = new NativeRouterBridge();
+            bridge = new NativeRouterBridge();
         }
         catch (NativeBridgeUnavailableException ex)
         {
@@ -106,11 +108,17 @@ public sealed class NativeGribInspectorTests
             Assert.True(
                 ex.InnerException is DllNotFoundException or InvalidOperationException,
                 $"Expected DllNotFound or InvalidOperation inner exception, got: {ex.InnerException?.GetType()}");
+            return;
         }
         catch (NotSupportedException)
         {
-            // ABI version mismatch — also acceptable for this test
+            // ABI version mismatch — also acceptable for this test.
+            return;
         }
+
+        // The native library is present, so the DLL-missing contract cannot be
+        // exercised here. Skip explicitly instead of passing on an empty try block.
+        Assert.NotNull(bridge);
     }
 
     // ---- NativeRouterBridge.InspectGrib — argument validation ----

--- a/tests/Navtool.Infrastructure.Tests/NativeGribInspectorTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeGribInspectorTests.cs
@@ -1,0 +1,362 @@
+using System.Reflection;
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+/// <summary>
+/// Tests for the native bridge preflight check (NativeRouterBridge construction as preflight)
+/// and the GRIB inspection service (NativeGribInspector / NativeRouterBridge.InspectGrib).
+/// Tests skip gracefully when the native library or the sample GRIB is unavailable,
+/// following the same pattern as NativeRouterBridgeIntegrationTests.
+/// </summary>
+public sealed class NativeGribInspectorTests
+{
+    // The same sample search logic used by NativeRouterBridgeIntegrationTests.
+    private static string? FindSampleGrib()
+    {
+        var configured = Environment.GetEnvironmentVariable("NAVTOOL_ROUTER_SAMPLE_GRIB");
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            var full = Path.GetFullPath(configured);
+            return File.Exists(full) ? full : null;
+        }
+
+        var repository = FindAncestor(AppContext.BaseDirectory, "Navtool.sln");
+        if (repository is null)
+        {
+            return null;
+        }
+
+        var candidate = Path.GetFullPath(
+            Path.Combine(repository, "..", "router-lib", "samples", "sample.grib"));
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    private static NativeRouterBridge? TryCreateBridge()
+    {
+        try
+        {
+            return new NativeRouterBridge();
+        }
+        catch (NativeBridgeUnavailableException)
+        {
+            return null;
+        }
+    }
+
+    private static string? FindAncestor(string start, string marker)
+    {
+        var directory = new DirectoryInfo(start);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, marker)))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    // ---- INativeRoutingPreflight contract (NativeRouterBridge construction performs preflight) ----
+
+    [Fact]
+    public void ConstructingNativeRouterBridge_DoesNotThrow_WhenBridgeIsAvailable()
+    {
+        if (TryCreateBridge() is null)
+        {
+            return; // skip — native library not present
+        }
+
+        // Successfully constructing a second instance validates the preflight path
+        var bridge2 = new NativeRouterBridge();
+        Assert.NotNull(bridge2);
+    }
+
+    [Fact]
+    public void ConstructingNativeRouterBridge_IsIdempotent_WhenBridgeIsAvailable()
+    {
+        if (TryCreateBridge() is null)
+        {
+            return;
+        }
+
+        // Calling twice must be consistent — no state corruption from first call
+        var bridge1 = new NativeRouterBridge();
+        var bridge2 = new NativeRouterBridge();
+        Assert.NotNull(bridge1);
+        Assert.NotNull(bridge2);
+    }
+
+    [Fact]
+    public void ConstructingNativeRouterBridge_Throws_NativeBridgeUnavailableException_WhenDllIsMissing()
+    {
+        // Simulate by catching — we verify the type is accessible and correctly typed.
+        // A DllNotFoundException wrapped in NativeBridgeUnavailableException is the contract.
+        try
+        {
+            _ = new NativeRouterBridge();
+        }
+        catch (NativeBridgeUnavailableException ex)
+        {
+            Assert.NotNull(ex.Message);
+            Assert.True(
+                ex.InnerException is DllNotFoundException or InvalidOperationException,
+                $"Expected DllNotFound or InvalidOperation inner exception, got: {ex.InnerException?.GetType()}");
+        }
+        catch (NotSupportedException)
+        {
+            // ABI version mismatch — also acceptable for this test
+        }
+    }
+
+    // ---- NativeRouterBridge.InspectGrib — argument validation ----
+
+    [Fact]
+    public void InspectGrib_Throws_ArgumentException_WhenPathIsEmpty()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        Assert.Throws<ArgumentException>(() => bridge.InspectGrib(string.Empty));
+        Assert.Throws<ArgumentException>(() => bridge.InspectGrib("   "));
+    }
+
+    [Fact]
+    public void InspectGrib_Throws_FileNotFound_WhenFileIsMissing()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var missing = Path.Combine(
+            AppContext.BaseDirectory,
+            "nonexistent_forecast_that_does_not_exist.grib");
+        Assert.Throws<FileNotFoundException>(() => bridge.InspectGrib(missing));
+    }
+
+    // ---- NativeGribInspector — argument validation ----
+
+    [Fact]
+    public void Inspect_Throws_ArgumentException_WhenPathIsRelative()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var ex = Assert.Throws<ArgumentException>(
+            () => inspector.InspectAsync("relative/path/forecast.grib"));
+        Assert.Equal("absolutePath", ex.ParamName);
+    }
+
+    [Fact]
+    public void Inspect_Throws_ArgumentException_WhenPathIsEmpty()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        Assert.Throws<ArgumentException>(() => inspector.InspectAsync(string.Empty));
+    }
+
+    [Fact]
+    public void Inspect_Throws_FileNotFound_WhenFileIsMissing()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var missing = Path.GetFullPath(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "nonexistent_forecast_that_does_not_exist.grib"));
+        Assert.Throws<FileNotFoundException>(() => inspector.InspectAsync(missing));
+    }
+
+    // ---- NativeGribInspector — sample GRIB integration (skip if unavailable) ----
+
+    [Fact]
+    public async Task Inspect_Returns_NoaaGfsDescriptor_ForSampleGrib()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var samplePath = FindSampleGrib();
+        if (samplePath is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var descriptor = await inspector.InspectAsync(samplePath);
+
+        Assert.Equal(ForecastModel.NoaaGfs, descriptor.Model);
+        Assert.NotNull(descriptor.Artifact);
+        Assert.Equal(samplePath, descriptor.Artifact.Path);
+    }
+
+    [Fact]
+    public async Task Inspect_Returns_Artifact_ReferencingOriginalPath_NotACopy()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var samplePath = FindSampleGrib();
+        if (samplePath is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var descriptor = await inspector.InspectAsync(samplePath);
+
+        // File is referenced in place — the artifact path must be the normalized
+        // form of the input path, not a copy in a temp directory.
+        Assert.Equal(
+            Path.GetFullPath(samplePath),
+            descriptor.Artifact.Path,
+            StringComparer.OrdinalIgnoreCase);
+        Assert.True(descriptor.Artifact.LengthBytes is > 0);
+    }
+
+    [Fact]
+    public async Task Inspect_Returns_ValidTimeRange_ForSampleGrib()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var samplePath = FindSampleGrib();
+        if (samplePath is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var descriptor = await inspector.InspectAsync(samplePath);
+
+        Assert.True(
+            descriptor.InitializedAt <= descriptor.ValidFrom,
+            "InitializedAt must not be after ValidFrom");
+        Assert.True(
+            descriptor.ValidFrom <= descriptor.ValidThrough,
+            "ValidFrom must not be after ValidThrough");
+
+        // Must be plausible: after year 2000, before year 2100
+        var year2000 = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var year2100 = new DateTimeOffset(2100, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        Assert.True(descriptor.InitializedAt > year2000);
+        Assert.True(descriptor.ValidThrough < year2100);
+    }
+
+    [Fact]
+    public async Task Inspect_Returns_FiniteBounds_ForSampleGrib()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var samplePath = FindSampleGrib();
+        if (samplePath is null)
+        {
+            return;
+        }
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var descriptor = await inspector.InspectAsync(samplePath);
+        var bounds = descriptor.Bounds;
+
+        Assert.True(bounds.South <= bounds.North);
+        Assert.InRange(bounds.South, -90.0, 90.0);
+        Assert.InRange(bounds.North, -90.0, 90.0);
+        Assert.InRange(bounds.West, -180.0, 180.0);
+        Assert.InRange(bounds.East, -180.0, 180.0);
+    }
+
+    [Fact]
+    public async Task Inspect_ModelDetection_DoesNotUseFilename()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        var samplePath = FindSampleGrib();
+        if (samplePath is null)
+        {
+            return;
+        }
+
+        // Copy the file to a name that looks like ECMWF to prove model detection
+        // comes from GRIB centre metadata, not the filename.
+        using var tempDir = new TestDirectory();
+        var misleadingName = Path.Combine(tempDir.Path, "ecmwf_ifs_forecast.grib");
+        File.Copy(samplePath, misleadingName);
+
+        var inspector = new NativeLocalGribInspector(bridge);
+        var descriptor = await inspector.InspectAsync(misleadingName);
+
+        // The file is NCEP/GFS data: model must be NoaaGfs regardless of filename.
+        Assert.Equal(ForecastModel.NoaaGfs, descriptor.Model);
+    }
+
+    [Fact]
+    public void InspectGrib_Throws_NativeRouterException_ForEmptyFile()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        using var tempDir = new TestDirectory();
+        var emptyPath = Path.Combine(tempDir.Path, "empty.grib");
+        File.WriteAllBytes(emptyPath, []);
+
+        Assert.Throws<NativeRouterException>(() => bridge.InspectGrib(emptyPath));
+    }
+
+    [Fact]
+    public void InspectGrib_Throws_NativeRouterException_ForTruncatedFile()
+    {
+        var bridge = TryCreateBridge();
+        if (bridge is null)
+        {
+            return;
+        }
+
+        using var tempDir = new TestDirectory();
+        var badPath = Path.Combine(tempDir.Path, "truncated.grib");
+        File.WriteAllBytes(badPath, "GRIB\x00\x00not-a-real-grib-file"u8.ToArray());
+
+        Assert.Throws<NativeRouterException>(() => bridge.InspectGrib(badPath));
+    }
+}

--- a/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
@@ -186,6 +186,25 @@ public sealed class NativeRouteJsonParserTests
         Assert.Contains("weather horizon", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Horizon_guard_reports_sub_minute_overruns_in_seconds()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var arrival = Departure.AddHours(8);
+        var result = NativeRouteJsonParser.Parse(
+            BuildJson((Departure, 40, -60, 0), (arrival, 45, -55, 40)),
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1));
+
+        // A 30-second overrun must not collapse to a misleading "0m".
+        var exception = Assert.Throws<NativeRouteFormatException>(() =>
+            NativeRouterBridge.EnsureWithinForecastHorizon(result, Metadata(arrival.AddSeconds(-30))));
+
+        Assert.Contains("30s", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("0m", exception.Message, StringComparison.Ordinal);
+    }
+
     private static NativeForecastMetadata Metadata(DateTimeOffset lastValidAt) => new(
         Departure,
         lastValidAt,

--- a/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
@@ -1,0 +1,196 @@
+using System.Globalization;
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="NativeRouteJsonParser.Parse"/> with no file or network I/O.
+/// These lock in the fix that stops mislabeling domain/native-output defects as the
+/// generic "v1 contract" JSON error, and that lets an arrival exceed the requested
+/// passage target without failing.
+/// </summary>
+public sealed class NativeRouteJsonParserTests
+{
+    private static readonly DateTimeOffset Departure =
+        new(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+
+    private static RouteRequest CreateRequest(TimeSpan window) => new(
+        "route-parse",
+        new Coordinate(40, -60),
+        new Coordinate(45, -55),
+        Departure,
+        Departure + window);
+
+    private static string Iso(DateTimeOffset value) =>
+        value.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+
+    private static string BuildJson(params (DateTimeOffset Time, double Lat, double Lon, double Distance)[] points)
+    {
+        var pointJson = points.Select(point =>
+            $$"""
+            {
+              "position": { "latitude": {{point.Lat.ToString(CultureInfo.InvariantCulture)}}, "longitude": {{point.Lon.ToString(CultureInfo.InvariantCulture)}} },
+              "time": "{{Iso(point.Time)}}",
+              "headingDegrees": 45,
+              "boatSpeedKnots": 6,
+              "trueWindSpeedKnots": 15,
+              "trueWindDirectionDegrees": 200,
+              "cumulativeDistanceNauticalMiles": {{point.Distance.ToString(CultureInfo.InvariantCulture)}}
+            }
+            """);
+
+        return $$"""
+        {
+          "diagnostics": {
+            "expandedNodes": 10,
+            "generatedCandidates": 20,
+            "retainedCandidates": 5,
+            "timeSteps": 2
+          },
+          "points": [ {{string.Join(",", pointJson)}} ]
+        }
+        """;
+    }
+
+    [Fact]
+    public void Parse_accepts_arrival_beyond_requested_target()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(6));
+        var json = BuildJson(
+            (Departure, 40, -60, 0),
+            (Departure.AddHours(8), 45, -55, 40));
+
+        var result = NativeRouteJsonParser.Parse(json, request, ForecastModel.NoaaGfs, TimeSpan.FromSeconds(1));
+
+        Assert.Equal(2, result.Points.Length);
+        Assert.True(result.ExceedsRequestedArrival);
+    }
+
+    [Fact]
+    public void Parse_throws_format_error_for_malformed_json()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+
+        // Missing required field ("points").
+        Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            """{ "diagnostics": { "expandedNodes": 1, "generatedCandidates": 2, "retainedCandidates": 1, "timeSteps": 1 } }""",
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+
+        // Syntactically broken JSON.
+        Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            "{ not json",
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+
+        // Non-finite numeric field.
+        var nonFinite = BuildJson(
+            (Departure, 40, -60, 0),
+            (Departure.AddHours(5), 45, -55, 20)).Replace("\"boatSpeedKnots\": 6", "\"boatSpeedKnots\": 1e400");
+        Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            nonFinite,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public void Parse_reports_native_output_defect_for_out_of_range_point()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        // Latitude 91 is valid JSON but an impossible coordinate.
+        var json = BuildJson(
+            (Departure, 91, -60, 0),
+            (Departure.AddHours(5), 45, -55, 20));
+
+        var exception = Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            json,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+
+        Assert.Contains("invalid route point", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_reports_native_output_defect_for_time_descending_points()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var json = BuildJson(
+            (Departure.AddHours(3), 40, -60, 0),
+            (Departure.AddHours(1), 45, -55, 20));
+
+        var exception = Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            json,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+
+        Assert.Contains("structurally invalid route", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_reports_native_output_defect_for_empty_points()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var json = """
+        {
+          "diagnostics": { "expandedNodes": 1, "generatedCandidates": 2, "retainedCandidates": 1, "timeSteps": 1 },
+          "points": []
+        }
+        """;
+
+        var exception = Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            json,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1)));
+
+        Assert.Contains("structurally invalid route", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Horizon_guard_accepts_arrival_at_or_within_tolerance_of_last_valid()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var arrival = Departure.AddHours(8);
+        var result = NativeRouteJsonParser.Parse(
+            BuildJson((Departure, 40, -60, 0), (arrival, 45, -55, 40)),
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1));
+
+        // Arrival exactly at the forecast horizon.
+        NativeRouterBridge.EnsureWithinForecastHorizon(result, Metadata(arrival));
+        // Arrival one second past the horizon (absorbed by the epoch-second tolerance).
+        NativeRouterBridge.EnsureWithinForecastHorizon(result, Metadata(arrival.AddSeconds(-1)));
+    }
+
+    [Fact]
+    public void Horizon_guard_rejects_arrival_beyond_last_valid()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var arrival = Departure.AddHours(8);
+        var result = NativeRouteJsonParser.Parse(
+            BuildJson((Departure, 40, -60, 0), (arrival, 45, -55, 40)),
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1));
+
+        var exception = Assert.Throws<NativeRouteFormatException>(() =>
+            NativeRouterBridge.EnsureWithinForecastHorizon(result, Metadata(arrival.AddHours(-2))));
+
+        Assert.Contains("weather horizon", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static NativeForecastMetadata Metadata(DateTimeOffset lastValidAt) => new(
+        Departure,
+        lastValidAt,
+        180,
+        360,
+        false,
+        "test-forecast");
+}

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -306,6 +306,37 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
+    public async Task Acquire_captures_the_clock_once_so_gate_and_stored_keys_stay_aligned()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler(async (_, _, cancellationToken) =>
+        {
+            await Task.Delay(1, cancellationToken);
+            return RecordingHttpHandler.GribResponse();
+        });
+        using var client = new HttpClient(handler);
+
+        // Advance the clock by a full 6h GFS run cadence on every read: if AcquireAsync
+        // read "now" more than once, the gate key (computed up front) and the run selected
+        // inside the gated core would land in different run windows and diverge.
+        var timeProvider = new CountingTimeProvider(Now, TimeSpan.FromHours(6));
+        var provider = new NoaaGfsForecastProvider(
+            client,
+            new AtomicFileCache(new AtomicFileCacheOptions(directory.Path)),
+            timeProvider,
+            TestOptions());
+
+        var acquisition = await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None);
+
+        Assert.Equal(1, timeProvider.Reads);
+        Assert.Equal(ForecastAcquisitionSource.Remote, acquisition.Source);
+        Assert.Empty(
+            Directory.EnumerateFiles(
+                Path.Combine(directory.Path, "noaa-gfs-parts"),
+                "*.partial"));
+    }
+
+    [Fact]
     public async Task Acquire_serializes_concurrent_requests_for_the_same_cache_key()
     {
         using var directory = new TestDirectory();

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -306,6 +306,24 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
+    public async Task Acquire_releases_gate_after_completion_so_gates_do_not_leak()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+
+        await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None);
+        await provider.AcquireAsync(
+            CreateRequest(new GeographicBounds(10, 15, 20, 30)),
+            null,
+            CancellationToken.None);
+
+        Assert.Equal(0, provider.ActiveAcquisitionGateCount);
+    }
+
+    [Fact]
     public async Task Acquire_captures_the_clock_once_so_gate_and_stored_keys_stay_aligned()
     {
         using var directory = new TestDirectory();

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -253,6 +253,156 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Equal(0, handler.RequestCount);
     }
 
+    // ── Resumability tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Acquire_failed_mid_run_leaves_completed_parts_cached_for_resumption()
+    {
+        using var directory = new TestDirectory();
+        // Part 0 (request 1) succeeds; part 1 (requests 2-4) exhausts all retries.
+        var handler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var request = CreateRequest(); // 3 steps × 1 region = 3 parts
+
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await provider.AcquireAsync(request, null, CancellationToken.None));
+
+        // Part 0 is durably cached in the parts subdirectory.
+        Assert.Equal(4, handler.RequestCount); // 1 success + 3 retries exhausted
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
+        Assert.Single(Directory.EnumerateFiles(partsDirectory));
+        // Final artifact is absent from the main cache root.
+        Assert.Empty(Directory.EnumerateFiles(directory.Path));
+    }
+
+    [Fact]
+    public async Task Acquire_resumes_by_requesting_only_missing_parts()
+    {
+        using var directory = new TestDirectory();
+        // First attempt: part 0 succeeds, part 1 fails permanently.
+        var firstHandler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var firstClient = new HttpClient(firstHandler);
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await CreateProvider(directory.Path, firstClient)
+                .AcquireAsync(CreateRequest(), null, CancellationToken.None));
+
+        // Second attempt: all succeed.  Only the 2 missing parts are fetched.
+        var secondHandler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var secondClient = new HttpClient(secondHandler);
+        var acquisition = await CreateProvider(directory.Path, secondClient)
+            .AcquireAsync(CreateRequest(), null, CancellationToken.None);
+
+        Assert.Equal(ForecastAcquisitionSource.Remote, acquisition.Source);
+        Assert.Equal(2, secondHandler.RequestCount); // parts 1 and 2 only
+        Assert.Equal(3L * "GRIBpayload7777"u8.Length, new FileInfo(acquisition.Artifact.Path).Length);
+    }
+
+    [Fact]
+    public async Task Acquire_assembles_final_artifact_in_deterministic_forecast_hour_and_region_order()
+    {
+        using var directory = new TestDirectory();
+        // Each request returns unique GRIB content tagged with the request sequence number.
+        var handler = new RecordingHttpHandler((_, count, _) =>
+        {
+            var bytes = System.Text.Encoding.ASCII.GetBytes($"GRIB{count:D4}7777");
+            return Task.FromResult(RecordingHttpHandler.GribResponse(bytes));
+        });
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        // 2 steps (f002, f003) × 2 regions (straddles Greenwich) = 4 parts.
+        // Expected manifest order: (f002, r0), (f002, r1), (f003, r0), (f003, r1).
+        var request = new ForecastRequest(
+            ForecastModel.NoaaGfs,
+            new GeographicBounds(-5.11, 5.11, -5.11, 5.11),
+            new DateTimeOffset(2026, 7, 14, 8, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 7, 14, 9, 0, 0, TimeSpan.Zero));
+
+        var acquisition = await provider.AcquireAsync(request, null, CancellationToken.None);
+
+        Assert.Equal(4, handler.RequestCount);
+        var expected = System.Text.Encoding.ASCII
+            .GetBytes("GRIB00017777GRIB00027777GRIB00037777GRIB00047777");
+        var actual = await File.ReadAllBytesAsync(acquisition.Artifact.Path);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task Acquire_cancellation_leaves_no_final_artifact_in_cache()
+    {
+        using var directory = new TestDirectory();
+        var firstPartDone = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new RecordingHttpHandler((_, count, _) =>
+        {
+            if (count == 1)
+            {
+                firstPartDone.SetResult();
+            }
+
+            return Task.FromResult(RecordingHttpHandler.GribResponse());
+        });
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(
+            directory.Path,
+            client,
+            TestOptions() with { MinimumRequestInterval = TimeSpan.FromMinutes(1) });
+        using var cancellation = new CancellationTokenSource();
+
+        var acquisition = provider.AcquireAsync(
+            CreateRequest(), null, cancellation.Token).AsTask();
+        await firstPartDone.Task;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => acquisition);
+        // The main cache directory must contain no final artifact (partial writes are atomic).
+        Assert.Empty(Directory.EnumerateFiles(directory.Path));
+    }
+
+    [Fact]
+    public async Task Acquire_progress_reports_resumed_and_downloaded_parts()
+    {
+        using var directory = new TestDirectory();
+        // First run: only part 0 succeeds (part 1 fails).
+        var failHandler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var failClient = new HttpClient(failHandler);
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await CreateProvider(directory.Path, failClient)
+                .AcquireAsync(CreateRequest(), null, CancellationToken.None));
+
+        // Second run: observe progress to confirm resumed and fresh parts are distinguishable.
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var progress = new List<ForecastProgress>();
+
+        await provider.AcquireAsync(
+            CreateRequest(),
+            new SynchronousProgress<ForecastProgress>(progress.Add),
+            CancellationToken.None);
+
+        // At least one progress entry should mention a resumed part.
+        Assert.Contains(progress, p =>
+            p.Stage == ForecastProgressStage.Downloading &&
+            p.Message != null &&
+            p.Message.Contains("Resumed", StringComparison.OrdinalIgnoreCase));
+        // Final stage is Completed.
+        Assert.Equal(ForecastProgressStage.Completed, progress[^1].Stage);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
     private static NoaaGfsForecastProvider CreateProvider(
         string path,
         HttpClient client,

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -306,6 +306,26 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
+    public async Task Acquire_sweeps_orphaned_partial_files_from_a_prior_process()
+    {
+        using var directory = new TestDirectory();
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
+        Directory.CreateDirectory(partsDirectory);
+        var orphan = Path.Combine(partsDirectory, "f000-r0.grib2.deadbeefcafe.partial");
+        await File.WriteAllTextAsync(orphan, "incomplete download from a killed process");
+
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+
+        await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None);
+
+        Assert.False(File.Exists(orphan));
+        Assert.Empty(Directory.EnumerateFiles(partsDirectory, "*.partial"));
+    }
+
+    [Fact]
     public async Task Acquire_releases_gate_after_completion_so_gates_do_not_leak()
     {
         using var directory = new TestDirectory();

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -401,6 +401,24 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Equal(ForecastProgressStage.Completed, progress[^1].Stage);
     }
 
+    [Fact]
+    public async Task Estimate_matches_manifest_without_sending_http_request()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var request = CreateRequest(new GeographicBounds(40, 45, -5, 5));
+
+        var estimate = provider.Estimate(request);
+
+        Assert.Equal(0, handler.RequestCount);
+        await provider.AcquireAsync(request, null, CancellationToken.None);
+        Assert.Equal(handler.RequestCount, estimate.PartCount);
+        Assert.Equal(2, estimate.RegionCount);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private static NoaaGfsForecastProvider CreateProvider(

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -274,7 +274,7 @@ public sealed class NoaaGfsForecastProviderTests
         // Part 0 is durably cached in the parts subdirectory.
         Assert.Equal(4, handler.RequestCount); // 1 success + 3 retries exhausted
         var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
-        Assert.Single(Directory.EnumerateFiles(partsDirectory));
+        Assert.Single(Directory.EnumerateFiles(partsDirectory, "*.grib2", SearchOption.AllDirectories));
         // Final artifact is absent from the main cache root.
         Assert.Empty(Directory.EnumerateFiles(directory.Path));
     }
@@ -309,20 +309,33 @@ public sealed class NoaaGfsForecastProviderTests
     public async Task Acquire_sweeps_orphaned_partial_files_from_a_prior_process()
     {
         using var directory = new TestDirectory();
-        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
-        Directory.CreateDirectory(partsDirectory);
-        var orphan = Path.Combine(partsDirectory, "f000-r0.grib2.deadbeefcafe.partial");
+
+        // A first attempt fails mid-run, leaving this cache key's isolated parts
+        // subdirectory behind.
+        var failingHandler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var failingClient = new HttpClient(failingHandler);
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await CreateProvider(directory.Path, failingClient)
+                .AcquireAsync(CreateRequest(), null, CancellationToken.None));
+
+        // Simulate a process killed mid-download by dropping a stray ".partial" into that
+        // subdirectory.
+        var partsSubdirectory = Directory.EnumerateDirectories(
+            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
+        var orphan = Path.Combine(partsSubdirectory, "f000-r0.grib2.deadbeefcafe.partial");
         await File.WriteAllTextAsync(orphan, "incomplete download from a killed process");
 
+        // Resuming the same request sweeps the orphan before assembling.
         var handler = new RecordingHttpHandler((_, _, _) =>
             Task.FromResult(RecordingHttpHandler.GribResponse()));
         using var client = new HttpClient(handler);
-        var provider = CreateProvider(directory.Path, client);
-
-        await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None);
+        await CreateProvider(directory.Path, client)
+            .AcquireAsync(CreateRequest(), null, CancellationToken.None);
 
         Assert.False(File.Exists(orphan));
-        Assert.Empty(Directory.EnumerateFiles(partsDirectory, "*.partial"));
     }
 
     [Fact]
@@ -371,7 +384,8 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Empty(
             Directory.EnumerateFiles(
                 Path.Combine(directory.Path, "noaa-gfs-parts"),
-                "*.partial"));
+                "*.partial",
+                SearchOption.AllDirectories));
     }
 
     [Fact]
@@ -397,7 +411,8 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Empty(
             Directory.EnumerateFiles(
                 Path.Combine(directory.Path, "noaa-gfs-parts"),
-                "*.partial"));
+                "*.partial",
+                SearchOption.AllDirectories));
     }
 
     [Fact]
@@ -430,7 +445,8 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Empty(
             Directory.EnumerateFiles(
                 Path.Combine(directory.Path, "noaa-gfs-parts"),
-                "*.grib2"));
+                "*.grib2",
+                SearchOption.AllDirectories));
     }
 
     [Fact]
@@ -510,8 +526,21 @@ public sealed class NoaaGfsForecastProviderTests
     public async Task Acquire_prunes_abandoned_parts_to_cache_bounds()
     {
         using var directory = new TestDirectory();
-        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
-        Directory.CreateDirectory(partsDirectory);
+
+        // A first attempt fails mid-run so this cache key's isolated parts subdirectory
+        // exists with one completed part.
+        var seedHandler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var seedClient = new HttpClient(seedHandler);
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await CreateProvider(directory.Path, seedClient)
+                .AcquireAsync(CreateRequest(), null, CancellationToken.None));
+        var partsDirectory = Directory.EnumerateDirectories(
+            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
+
+        // Seed abandoned parts beyond the cache bounds into that subdirectory.
         for (var index = 0; index < 8; index++)
         {
             await File.WriteAllBytesAsync(
@@ -519,8 +548,10 @@ public sealed class NoaaGfsForecastProviderTests
                 "old"u8.ToArray());
         }
 
+        // A second attempt for the same request fails again, but its prune trims the
+        // abandoned parts down to the cache bounds while protecting its own manifest.
         var handler = new RecordingHttpHandler((_, count, _) =>
-            count == 1
+            count <= 1
                 ? Task.FromResult(RecordingHttpHandler.GribResponse())
                 : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
         using var client = new HttpClient(handler);
@@ -536,6 +567,48 @@ public sealed class NoaaGfsForecastProviderTests
             await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None));
 
         Assert.True(Directory.EnumerateFiles(partsDirectory, "*.grib2").Count() <= 3);
+    }
+
+    [Fact]
+    public async Task Acquire_does_not_prune_parts_belonging_to_a_different_cache_key()
+    {
+        using var directory = new TestDirectory();
+
+        // Leave a completed part behind for cache key A via a failed mid-run acquisition.
+        var requestA = CreateRequest(new GeographicBounds(40, 45, -70, -60));
+        var failingHandler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var failingClient = new HttpClient(failingHandler);
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await CreateProvider(directory.Path, failingClient)
+                .AcquireAsync(requestA, null, CancellationToken.None));
+        var subdirectoryA = Directory.EnumerateDirectories(
+            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
+        var partsA = Directory.EnumerateFiles(subdirectoryA, "*.grib2").ToList();
+        Assert.NotEmpty(partsA);
+
+        // A full acquisition for a different cache key B, under cache bounds its parts
+        // exceed, must not touch key A's isolated subdirectory.
+        var requestB = CreateRequest(new GeographicBounds(10, 15, 20, 30));
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(
+            directory.Path,
+            client,
+            cacheOptions: new AtomicFileCacheOptions(
+                directory.Path,
+                maximumBytes: 1_024,
+                maximumEntries: 1));
+
+        await provider.AcquireAsync(requestB, null, CancellationToken.None);
+
+        foreach (var part in partsA)
+        {
+            Assert.True(File.Exists(part), $"Key A part was pruned by a different key: {part}");
+        }
     }
 
     [Fact]

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -306,6 +306,32 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
+    public async Task Acquire_serializes_concurrent_requests_for_the_same_cache_key()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler(async (_, _, cancellationToken) =>
+        {
+            await Task.Delay(10, cancellationToken);
+            return RecordingHttpHandler.GribResponse();
+        });
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var request = CreateRequest();
+
+        var first = provider.AcquireAsync(request, null, CancellationToken.None).AsTask();
+        var second = provider.AcquireAsync(request, null, CancellationToken.None).AsTask();
+        var acquisitions = await Task.WhenAll(first, second);
+
+        Assert.Equal(3, handler.RequestCount);
+        Assert.Contains(acquisitions, item => item.Source == ForecastAcquisitionSource.Remote);
+        Assert.Contains(acquisitions, item => item.Source == ForecastAcquisitionSource.Cache);
+        Assert.Empty(
+            Directory.EnumerateFiles(
+                Path.Combine(directory.Path, "noaa-gfs-parts"),
+                "*.partial"));
+    }
+
+    [Fact]
     public async Task Acquire_assembles_final_artifact_in_deterministic_forecast_hour_and_region_order()
     {
         using var directory = new TestDirectory();
@@ -332,6 +358,10 @@ public sealed class NoaaGfsForecastProviderTests
             .GetBytes("GRIB00017777GRIB00027777GRIB00037777GRIB00047777");
         var actual = await File.ReadAllBytesAsync(acquisition.Artifact.Path);
         Assert.Equal(expected, actual);
+        Assert.Empty(
+            Directory.EnumerateFiles(
+                Path.Combine(directory.Path, "noaa-gfs-parts"),
+                "*.grib2"));
     }
 
     [Fact]
@@ -397,8 +427,46 @@ public sealed class NoaaGfsForecastProviderTests
             p.Stage == ForecastProgressStage.Downloading &&
             p.Message != null &&
             p.Message.Contains("Resumed", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(progress, p =>
+            p.Message != null &&
+            p.Message.Contains("new this run", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(progress, p =>
+            p.Message != null &&
+            p.Message.Contains("HTTP requests", StringComparison.OrdinalIgnoreCase));
         // Final stage is Completed.
         Assert.Equal(ForecastProgressStage.Completed, progress[^1].Stage);
+    }
+
+    [Fact]
+    public async Task Acquire_prunes_abandoned_parts_to_cache_bounds()
+    {
+        using var directory = new TestDirectory();
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
+        Directory.CreateDirectory(partsDirectory);
+        for (var index = 0; index < 8; index++)
+        {
+            await File.WriteAllBytesAsync(
+                Path.Combine(partsDirectory, $"stale-{index}.grib2"),
+                "old"u8.ToArray());
+        }
+
+        var handler = new RecordingHttpHandler((_, count, _) =>
+            count == 1
+                ? Task.FromResult(RecordingHttpHandler.GribResponse())
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(
+            directory.Path,
+            client,
+            cacheOptions: new AtomicFileCacheOptions(
+                directory.Path,
+                maximumBytes: 1_024,
+                maximumEntries: 2));
+
+        await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None));
+
+        Assert.True(Directory.EnumerateFiles(partsDirectory, "*.grib2").Count() <= 3);
     }
 
     [Fact]
@@ -424,10 +492,11 @@ public sealed class NoaaGfsForecastProviderTests
     private static NoaaGfsForecastProvider CreateProvider(
         string path,
         HttpClient client,
-        NoaaGfsOptions? options = null) =>
+        NoaaGfsOptions? options = null,
+        AtomicFileCacheOptions? cacheOptions = null) =>
         new(
             client,
-            new AtomicFileCache(new AtomicFileCacheOptions(path)),
+            new AtomicFileCache(cacheOptions ?? new AtomicFileCacheOptions(path)),
             new FixedTimeProvider(Now),
             options ?? TestOptions());
 

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -357,7 +357,7 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
-    public async Task Acquire_captures_the_clock_once_so_gate_and_stored_keys_stay_aligned()
+    public async Task Acquire_reads_the_run_selection_clock_once_so_gate_and_stored_keys_stay_aligned()
     {
         using var directory = new TestDirectory();
         var handler = new RecordingHttpHandler(async (_, _, cancellationToken) =>
@@ -367,9 +367,12 @@ public sealed class NoaaGfsForecastProviderTests
         });
         using var client = new HttpClient(handler);
 
-        // Advance the clock by a full 6h GFS run cadence on every read: if AcquireAsync
-        // read "now" more than once, the gate key (computed up front) and the run selected
-        // inside the gated core would land in different run windows and diverge.
+        // Advance the clock by a full 6h GFS run cadence on every read. Run selection, the
+        // steps, the aligned bounds, and the cache key are all fixed up front from a single
+        // read; if AcquireAsync read "now" again to reselect the run inside the gated core,
+        // the gate key and the stored artifact key would land in different run windows and
+        // diverge. Exactly two reads are expected: read #1 fixes the run and cache key, and
+        // read #2 stamps cache freshness from the actual store time after the download loop.
         var timeProvider = new CountingTimeProvider(Now, TimeSpan.FromHours(6));
         var provider = new NoaaGfsForecastProvider(
             client,
@@ -379,7 +382,7 @@ public sealed class NoaaGfsForecastProviderTests
 
         var acquisition = await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None);
 
-        Assert.Equal(1, timeProvider.Reads);
+        Assert.Equal(2, timeProvider.Reads);
         Assert.Equal(ForecastAcquisitionSource.Remote, acquisition.Source);
         Assert.Empty(
             Directory.EnumerateFiles(

--- a/tests/Navtool.Infrastructure.Tests/TestSupport.cs
+++ b/tests/Navtool.Infrastructure.Tests/TestSupport.cs
@@ -29,6 +29,22 @@ internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
     public override DateTimeOffset GetUtcNow() => utcNow;
 }
 
+// Returns a strictly increasing "now" on every read and records how many reads
+// happened. Used to prove AcquireAsync captures the clock exactly once, so its gate
+// key and the stored artifact key cannot diverge across a run-publish boundary.
+internal sealed class CountingTimeProvider(DateTimeOffset start, TimeSpan step) : TimeProvider
+{
+    private long _reads;
+
+    public int Reads => (int)Interlocked.Read(ref _reads);
+
+    public override DateTimeOffset GetUtcNow()
+    {
+        var index = Interlocked.Increment(ref _reads) - 1;
+        return start + TimeSpan.FromTicks(step.Ticks * index);
+    }
+}
+
 internal sealed class RecordingHttpHandler(
     Func<HttpRequestMessage, int, CancellationToken, Task<HttpResponseMessage>> respond)
     : HttpMessageHandler


### PR DESCRIPTION
Long NOAA forecast windows require many NOMADS subset requests, so a late failure should not discard completed work. Navtool also needs to fail before downloading when its native routing runtime is unavailable and let sailors use a GRIB they already have.

## What changed

- Derives an antimeridian-safe, distance-based passage corridor and shows its NOAA forecast part estimate before calculation.
- Adds a required passage duration, defaulting to 3 days with a 10-day safety limit, so NOAA and local-file coverage match the intended voyage.
- Caches each NOAA forecast-hour/longitude-window response atomically, resumes completed parts, and assembles the final GRIB deterministically.
- Adds an Existing GRIB file source with an Avalonia native file picker (Finder on macOS).
- Inspects GRIB content through an additive ecCodes-backed native ABI, detects NOAA GFS or ECMWF IFS metadata, and validates paired 10 m wind fields, time range, and buffered geographic coverage.
- Preflights the native bridge before remote acquisition and separates routing-runtime, forecast-acquisition, and route-calculation errors.
- Adds macOS/Linux and Windows launchers that build and test the native bridge before starting the app, with final-route fallback for router-lib checkouts that predate streaming callbacks.

Online ECMWF acquisition remains intentionally separate and is tracked in #6.

## Testing

- `NAVTOOL_ROUTER_BRIDGE_PATH="$PWD/native/Navtool.RouterBridge/build" NAVTOOL_ROUTER_SAMPLE_GRIB=/path/to/router-lib/samples/sample.grib dotnet test Navtool.sln --no-restore --nologo --verbosity:minimal` (94 passed)
- `SAILROUTE_SOURCE_DIR=/path/to/router-lib ./scripts/build-native.sh` (native bridge test passed)
- `dotnet format Navtool.sln --verify-no-changes --no-restore --verbosity minimal`