### PR TITLE
Make wind speed tiles transparent so arrows don't block the map

### DIFF
--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -426,12 +426,11 @@ public sealed class RouteMapLayers
             new NtsCoordinate(center.X - halfWidth, center.Y - halfHeight)
         }));
         var feature = new GeometryFeature(polygon);
-        var knots = sample.Weather!.WindSpeedMetersPerSecond * 1.9438444924406;
         feature.Styles.Add(new VectorStyle
         {
-            Fill = new Brush(MapsuiColor.FromString(WindColorScale.GetHex(knots))),
-            Outline = new Pen(MapsuiColor.White, 0.5),
-            Opacity = 0.38f
+            Fill = new Brush(MapsuiColor.Transparent),
+            Outline = null,
+            Opacity = 0f
         });
         return feature;
     }
@@ -457,10 +456,11 @@ public sealed class RouteMapLayers
             ToLineString(shaft.End, headTwo)
         });
         var feature = new GeometryFeature(geometry);
+        var knots = weather.WindSpeedMetersPerSecond * 1.9438444924406;
         feature.Styles.Add(new VectorStyle
         {
-            Line = new Pen(MapsuiColor.FromString("#173440"), 1.4),
-            Opacity = 0.82f
+            Line = new Pen(MapsuiColor.FromString(WindColorScale.GetHex(knots)), 1.8),
+            Opacity = 0.95f
         });
         return feature;
     }


### PR DESCRIPTION
## Why

While fixing the weather GRIB downloads, a separate visual bug surfaced: when the weather route and winds are shown on the map, the wind arrows sat on opaque colored tiles that obscured the basemap underneath. Functionally everything worked, but you couldn't see the chart through the wind overlay.

## What changed

The weather overlay has two layers: a wind-speed heatmap (`_windCells`, colored polygons) and wind-direction arrows (`_windArrows`). The colored tiles were the culprit.

- **Tiles are now transparent.** `CreateWindCell` renders the polygons with a transparent fill, no outline, and zero opacity, so they no longer block the map. The "Wind speed" layer stays registered to keep the layer stacking order intact.
- **Arrows are colored by wind speed.** `CreateWindArrow` now derives its line color from the existing `WindColorScale.GetHex(knots)` (replacing the fixed dark color), with slightly thicker lines and higher opacity for legibility. This preserves the wind-speed information that the tiles used to convey, now encoded directly in the arrows.

Net effect: only the wind arrows are visible over the map, and wind speed is still readable via arrow color.

## Notes

- Purely visual. Routing and weather logic are untouched.
- No test changes needed: layer ordering, `WeatherCellCount`, and `WindColorScale` tests all still pass (21/21 in `Navtool.App.Tests`), and the build is clean with no warnings.