### PR TITLE
Fix wind overlay tiles painting a background grid over the map

### DIFF
--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -37,8 +37,8 @@ public sealed class RouteMapLayers
         [ForecastModel.NoaaGfs] = new List<IFeature>(),
         [ForecastModel.EcmwfIfs] = new List<IFeature>()
     };
-    private readonly MemoryLayer _windCells = new("Wind speed");
-    private readonly MemoryLayer _windArrows = new("Wind direction");
+    private readonly MemoryLayer _windCells = new("Wind speed") { Style = null };
+    private readonly MemoryLayer _windArrows = new("Wind direction") { Style = null };
     private readonly MemoryLayer _endpoints = new("Route endpoints");
     private readonly MemoryLayer _timelinePoints = new("Timeline route points");
     private readonly MemoryLayer _selection = new("Selected route point");

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -93,6 +93,22 @@ public sealed class MapRenderingTests
     }
 
     [Fact]
+    public void WindOverlayLayersHaveNoDefaultLayerStyle()
+    {
+        var viewModel = CreateViewModel(tilesEnabled: true);
+        var layers = viewModel.Map.Layers.ToArray();
+
+        var windSpeed = layers.Single(layer => layer.Name == "Wind speed");
+        var windDirection = layers.Single(layer => layer.Name == "Wind direction");
+
+        // A MemoryLayer with no explicit Style falls back to Mapsui's default
+        // VectorStyle (gray fill + outline), which would paint a grid over the map.
+        // Only per-feature styles should render, so the layer Style must be null.
+        Assert.Null(windSpeed.Style);
+        Assert.Null(windDirection.Style);
+    }
+
+    [Fact]
     public void StreamingLayersAccumulateFrontiersReplaceProvisionalRoutesAndClearPerModel()
     {
         var map = new Map();


### PR DESCRIPTION
## Why

On the route map, the wind overlay rendered as a grid of light tiles (one per sample) that covered the OpenStreetMap base layer. Only the wind arrows should be visible; the sample cells should be fully transparent so the map shows through.

## Root cause

The blocking tiles were not map tiles, they were the wind overlay itself. In `RouteMapLayers`, every other overlay layer (routes, isochrones, provisional routes) is created with an explicit layer-level `Style`, and its features carry no per-feature styles. The two wind layers, however, were created with no layer `Style`:

```csharp
private readonly MemoryLayer _windCells = new("Wind speed");
private readonly MemoryLayer _windArrows = new("Wind direction");
```

A Mapsui `MemoryLayer` with no `Style` falls back to a default gray `VectorStyle` (fill + outline) that it paints on every feature, in addition to any per-feature styles. So each wind cell was drawn twice: once by the default gray fill/outline (the visible grid) and once by the per-feature transparent style (invisible). An earlier "make cells transparent" change only touched the per-feature style, so the default fill kept painting, which is why the tiles still blocked the map.

## Fix

Set `Style = null` on both wind layers so only per-feature styles render:

- `_windCells`: only the per-feature transparent style remains, so cells draw nothing and the map shows through.
- `_windArrows`: only the per-feature speed-colored line remains (this also removes a faint default outline halo under the arrows).

This is a minimal, surgical change that matches how styling is applied everywhere else in the file. `WeatherCellCount` is derived from the sample count rather than the cells layer, and nothing hit-tests the wind cells, so behavior is otherwise unchanged.

## Testing

- Added a regression test asserting the "Wind speed" and "Wind direction" layers expose `Style == null`, guarding against reintroducing a default layer fill.
- `Navtool.App.Tests`: 31 passed, 0 failed.