### PR TITLE
Harden logging flush and NOAA retry stream contracts

### DIFF
--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -801,15 +801,27 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         ArgumentNullException.ThrowIfNull(destination);
 
         const string message = "The NOAA download destination must support rollback (seek, write, and set-length).";
+        long checkpoint;
+        try
+        {
+            checkpoint = destination.Position;
+        }
+        catch (Exception exception) when (
+            exception is NotSupportedException or IOException or ObjectDisposedException)
+        {
+            throw new ArgumentException(message, nameof(destination), exception);
+        }
+
         if (!destination.CanSeek || !destination.CanWrite)
         {
             throw new ArgumentException(message, nameof(destination));
         }
 
-        var checkpoint = destination.Position;
         try
         {
-            destination.SetLength(checkpoint);
+            var length = destination.Length;
+            destination.Position = checkpoint;
+            destination.SetLength(length);
             destination.Position = checkpoint;
         }
         catch (Exception exception) when (

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -665,8 +665,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             .ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            // HttpClient follows valid redirects by default; a 3xx that reaches this provider
-            // is treated as a transient response that was not followed.
+            // Redirect behavior depends on the configured HttpClient handler chain.
+            // Any 3xx response that reaches this provider is treated as transient.
             var location = response.Headers.Location is null
                 ? string.Empty
                 : $" Redirect location: '{response.Headers.Location}'.";

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -581,15 +581,12 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         }
     }
 
-    private async ValueTask DownloadGribWithRetryAsync(
+    internal async ValueTask DownloadGribWithRetryAsync(
         Uri uri,
         Stream destination,
         CancellationToken cancellationToken)
     {
-        if (!destination.CanSeek)
-        {
-            throw new ArgumentException("The NOAA download destination must support rollback.", nameof(destination));
-        }
+        EnsureRollbackDestination(destination);
 
         var checkpoint = destination.Position;
         Exception? lastFailure = null;
@@ -668,6 +665,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             .ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
+            // HttpClient follows valid redirects by default; a 3xx that reaches this provider
+            // is treated as a transient response that was not followed.
             var location = response.Headers.Location is null
                 ? string.Empty
                 : $" Redirect location: '{response.Headers.Location}'.";
@@ -796,6 +795,29 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         statusCode is HttpStatusCode.RequestTimeout or
             HttpStatusCode.TooManyRequests ||
         (int)statusCode is 425 or >= 300 and <= 399 or >= 500 and <= 599;
+
+    private static void EnsureRollbackDestination(Stream destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        const string message = "The NOAA download destination must support rollback (seek, write, and set-length).";
+        if (!destination.CanSeek || !destination.CanWrite)
+        {
+            throw new ArgumentException(message, nameof(destination));
+        }
+
+        var checkpoint = destination.Position;
+        try
+        {
+            destination.SetLength(checkpoint);
+            destination.Position = checkpoint;
+        }
+        catch (Exception exception) when (
+            exception is NotSupportedException or IOException or ObjectDisposedException)
+        {
+            throw new ArgumentException(message, nameof(destination), exception);
+        }
+    }
 
     private static void RollBack(Stream destination, long checkpoint)
     {

--- a/src/Navtool.Infrastructure/RollingFileLoggerProvider.cs
+++ b/src/Navtool.Infrastructure/RollingFileLoggerProvider.cs
@@ -105,7 +105,6 @@ public sealed class RollingFileLoggerProvider : ILoggerProvider
                 }
 
                 _writer!.WriteLine(line);
-                _writer.Flush();
             }
             catch (IOException ioException)
             {

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -160,8 +160,8 @@ public sealed class NoaaGfsForecastProviderTests
         using var directory = new TestDirectory();
         var handler = new RecordingHttpHandler((request, count, _) =>
         {
-            // Valid redirects are followed by HttpClient automatically; this simulated 3xx
-            // verifies retry behavior when a transient 3xx reaches the provider.
+            // This test intentionally returns a 3xx from the injected handler to confirm
+            // provider-level transient retry handling when a 3xx reaches provider code.
             if (count == 1)
             {
                 var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -713,10 +713,36 @@ public sealed class NoaaGfsForecastProviderTests
     private sealed class NonSeekableMemoryStream : MemoryStream
     {
         public override bool CanSeek => false;
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin loc) =>
+            throw new NotSupportedException();
     }
 
     private sealed class NonWritableMemoryStream : MemoryStream
     {
         public override bool CanWrite => false;
+
+        public override void Write(byte[] buffer, int offset, int count) =>
+            throw new NotSupportedException();
+
+        public override void Write(ReadOnlySpan<byte> buffer) =>
+            throw new NotSupportedException();
+
+        public override ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromException(new NotSupportedException());
+
+        public override void WriteByte(byte value) =>
+            throw new NotSupportedException();
+
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -113,11 +113,55 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
-    public async Task Acquire_retries_temporary_redirect_then_completes()
+    public async Task Download_with_retry_rejects_non_seekable_destination_before_http()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        await using var destination = new NonSeekableMemoryStream();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await provider.DownloadGribWithRetryAsync(
+                new Uri("https://example.test/noaa.grib2"),
+                destination,
+                CancellationToken.None));
+
+        Assert.Equal("destination", exception.ParamName);
+        Assert.Contains("rollback", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task Download_with_retry_rejects_non_writable_destination_before_http()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        await using var destination = new NonWritableMemoryStream();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await provider.DownloadGribWithRetryAsync(
+                new Uri("https://example.test/noaa.grib2"),
+                destination,
+                CancellationToken.None));
+
+        Assert.Equal("destination", exception.ParamName);
+        Assert.Contains("rollback", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task Acquire_retries_transient_3xx_response_then_completes()
     {
         using var directory = new TestDirectory();
         var handler = new RecordingHttpHandler((request, count, _) =>
         {
+            // Valid redirects are followed by HttpClient automatically; this simulated 3xx
+            // verifies retry behavior when a transient 3xx reaches the provider.
             if (count == 1)
             {
                 var redirect = new HttpResponseMessage(HttpStatusCode.Redirect);
@@ -664,5 +708,15 @@ public sealed class NoaaGfsForecastProviderTests
     private sealed class SynchronousProgress<T>(Action<T> action) : IProgress<T>
     {
         public void Report(T value) => action(value);
+    }
+
+    private sealed class NonSeekableMemoryStream : MemoryStream
+    {
+        public override bool CanSeek => false;
+    }
+
+    private sealed class NonWritableMemoryStream : MemoryStream
+    {
+        public override bool CanWrite => false;
     }
 }


### PR DESCRIPTION
## Why
Post-review hardening found two reliability gaps in NOAA retry destination handling and one misleading redirect test name/comment, plus unnecessary lock-held file I/O in logging. This updates those behaviors so contracts are explicit and tests match runtime semantics.

## What changed
- Removed the redundant per-entry `_writer.Flush()` in `RollingFileLoggerProvider.Write`; `AutoFlush` remains enabled for immediate readability.
- Hardened `NoaaGfsForecastProvider.DownloadGribWithRetryAsync` by validating rollback prerequisites before any HTTP request. Destination streams must support seek, write, and set-length rollback, and unsupported streams now fail with deterministic `ArgumentException` on `destination`.
- Clarified 3xx retry semantics:
  - Renamed the redirect test to `Acquire_retries_transient_3xx_response_then_completes`.
  - Added comments that valid redirects are followed by `HttpClient` by default; a 3xx reaching provider logic is treated as a transient response.
- Added focused NOAA tests proving unsupported destination streams fail before network activity:
  - `Download_with_retry_rejects_non_seekable_destination_before_http`
  - `Download_with_retry_rejects_non_writable_destination_before_http`

## Testing
- `dotnet test tests/Navtool.Infrastructure.Tests/Navtool.Infrastructure.Tests.csproj --filter "FullyQualifiedName~RollingFileLoggerProviderTests|FullyQualifiedName~NoaaGfsForecastProviderTests" --nologo`