### PR TITLE
Default native build to released router-lib v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,6 @@ It targets macOS, Windows, and Linux.
 - CMake 3.20 or newer
 - A C++20 compiler
 - ECMWF ecCodes development libraries
-- `router-lib` beside this directory, by default:
-
-  ```text
-  Demo/
-  ├── Navtool/
-  └── router-lib/
-  ```
 
 On macOS:
 
@@ -73,8 +66,21 @@ dotnet test Navtool.sln
 
 The application discovers the development bridge automatically. For a custom
 location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
-directory. If `router-lib` is not beside this checkout, set
-`SAILROUTE_SOURCE_DIR` before using either native script.
+directory. Native builds fetch and compile `router-lib` from release `v0.1` by
+default. Set `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when
+testing non-released changes.
+
+To build against a different released `router-lib` version, configure CMake
+with a release tag override before building:
+
+```sh
+cmake -S native/Navtool.RouterBridge -B native/Navtool.RouterBridge/build \
+  -DNAVTOOL_ROUTER_LIB_RELEASE_TAG=v0.2
+cmake --build native/Navtool.RouterBridge/build --config Release --parallel
+```
+
+`NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` can also be overridden if you need to
+fetch releases from a different fork.
 
 ## Streaming route visualization
 
@@ -128,7 +134,9 @@ also be installed or packaged according to the target platform.
 | Variable | Purpose |
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
-| `SAILROUTE_SOURCE_DIR` | `router-lib` checkout used by native build/run scripts |
+| `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Released `router-lib` tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.1`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | Released `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |
 | `NAVTOOL_CACHE_ROOT` | Forecast cache directory |

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -3,35 +3,58 @@ cmake_minimum_required(VERSION 3.20)
 project(NavtoolRouterBridge VERSION 1.0.0 LANGUAGES C CXX)
 
 option(NAVTOOL_ROUTER_BRIDGE_BUILD_TESTS "Build native bridge tests" ON)
-
-set(
-    _navtool_router_default_source
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../router-lib")
-if(
-    NOT EXISTS "${_navtool_router_default_source}/CMakeLists.txt"
-    AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../router-lib/CMakeLists.txt")
-    set(
-        _navtool_router_default_source
-        "${CMAKE_CURRENT_SOURCE_DIR}/../../../router-lib")
-endif()
 set(
     SAILROUTE_SOURCE_DIR
-    "${_navtool_router_default_source}"
+    ""
     CACHE PATH
-    "Path to the router-lib source tree")
+    "Optional path to a router-lib source tree override")
+set(
+    NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY
+    "https://github.com/frye/router-lib.git"
+    CACHE STRING
+    "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
+set(
+    NAVTOOL_ROUTER_LIB_RELEASE_TAG
+    "v0.1"
+    CACHE STRING
+    "router-lib release tag used when SAILROUTE_SOURCE_DIR is unset")
+set(_navtool_router_effective_source_dir "")
 
 if(NOT TARGET sailroute::sailroute)
-    if(NOT EXISTS "${SAILROUTE_SOURCE_DIR}/CMakeLists.txt")
-        message(
-            FATAL_ERROR
-            "router-lib not found. Set SAILROUTE_SOURCE_DIR to its source directory.")
+    if(DEFINED SAILROUTE_SOURCE_DIR AND NOT "${SAILROUTE_SOURCE_DIR}" STREQUAL "")
+        if(NOT EXISTS "${SAILROUTE_SOURCE_DIR}/CMakeLists.txt")
+            message(
+                FATAL_ERROR
+                "router-lib not found. Set SAILROUTE_SOURCE_DIR to its source directory.")
+        endif()
+        set(_navtool_router_effective_source_dir "${SAILROUTE_SOURCE_DIR}")
+        set(SAILROUTE_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(SAILROUTE_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+        add_subdirectory(
+            "${SAILROUTE_SOURCE_DIR}"
+            "${CMAKE_CURRENT_BINARY_DIR}/router-lib"
+            EXCLUDE_FROM_ALL)
+    else()
+        include(FetchContent)
+        set(SAILROUTE_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(SAILROUTE_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
+        FetchContent_Declare(
+            sailroute
+            GIT_REPOSITORY "${NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY}"
+            GIT_TAG "${NAVTOOL_ROUTER_LIB_RELEASE_TAG}"
+            GIT_SHALLOW ON)
+        FetchContent_MakeAvailable(sailroute)
+        if(NOT TARGET sailroute::sailroute)
+            message(
+                FATAL_ERROR
+                "Failed to load router-lib from ${NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY} at ${NAVTOOL_ROUTER_LIB_RELEASE_TAG}.")
+        endif()
+        if(DEFINED sailroute_SOURCE_DIR)
+            set(_navtool_router_effective_source_dir "${sailroute_SOURCE_DIR}")
+        endif()
     endif()
-    set(SAILROUTE_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(SAILROUTE_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
-    add_subdirectory(
-        "${SAILROUTE_SOURCE_DIR}"
-        "${CMAKE_CURRENT_BINARY_DIR}/router-lib"
-        EXCLUDE_FROM_ALL)
+elseif(DEFINED SAILROUTE_SOURCE_DIR AND NOT "${SAILROUTE_SOURCE_DIR}" STREQUAL "")
+    set(_navtool_router_effective_source_dir "${SAILROUTE_SOURCE_DIR}")
 endif()
 
 if(TARGET sailroute)
@@ -66,7 +89,7 @@ add_library(Navtool::RouterBridge ALIAS NavtoolRouterBridge)
 file(
     GLOB_RECURSE
     _navtool_router_public_headers
-    "${SAILROUTE_SOURCE_DIR}/include/*.hpp")
+    "${_navtool_router_effective_source_dir}/include/*.hpp")
 set(_navtool_router_has_progress_callback OFF)
 foreach(_navtool_router_header IN LISTS _navtool_router_public_headers)
     file(READ "${_navtool_router_header}" _navtool_router_header_contents)
@@ -116,7 +139,7 @@ if(NAVTOOL_ROUTER_BRIDGE_BUILD_TESTS)
         navtool_router_bridge_tests
         PRIVATE
             NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK=$<BOOL:${_navtool_router_has_progress_callback}>
-            NAVTOOL_ROUTER_SAMPLE_GRIB="${SAILROUTE_SOURCE_DIR}/samples/sample.grib")
+            NAVTOOL_ROUTER_SAMPLE_GRIB="${_navtool_router_effective_source_dir}/samples/sample.grib")
     target_link_libraries(
         navtool_router_bridge_tests
         PRIVATE Navtool::RouterBridge ECCODES::eccodes)

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -5,20 +5,24 @@ param(
 
 $ErrorActionPreference = "Stop"
 $Root = Split-Path -Parent $PSScriptRoot
-if ([string]::IsNullOrWhiteSpace($RouterSource)) {
-    $RouterSource = Join-Path $Root "..\router-lib"
-}
 if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 
-if (-not (Test-Path (Join-Path $RouterSource "CMakeLists.txt"))) {
-    throw "router-lib was not found at '$RouterSource'. Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again."
+if ([string]::IsNullOrWhiteSpace($RouterSource)) {
+    cmake -S (Join-Path $Root "native\Navtool.RouterBridge") -B $BuildDirectory `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
 }
+else {
+    if (-not (Test-Path (Join-Path $RouterSource "CMakeLists.txt"))) {
+        throw "router-lib was not found at '$RouterSource'. Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again."
+    }
 
-cmake -S (Join-Path $Root "native\Navtool.RouterBridge") -B $BuildDirectory `
-    -DCMAKE_BUILD_TYPE=Release `
-    -DSAILROUTE_SOURCE_DIR="$RouterSource" `
-    -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
+    cmake -S (Join-Path $Root "native\Navtool.RouterBridge") -B $BuildDirectory `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DSAILROUTE_SOURCE_DIR="$RouterSource" `
+        -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
+}
 cmake --build $BuildDirectory --config Release --parallel
 ctest --test-dir $BuildDirectory -C Release --output-on-failure

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -2,18 +2,23 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-router_source=${SAILROUTE_SOURCE_DIR:-"$root/../router-lib"}
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
 
-if [ ! -f "$router_source/CMakeLists.txt" ]; then
-  echo "router-lib was not found at $router_source." >&2
-  echo "Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again." >&2
-  exit 1
+if [ -n "${SAILROUTE_SOURCE_DIR:-}" ]; then
+  router_source=$SAILROUTE_SOURCE_DIR
+  if [ ! -f "$router_source/CMakeLists.txt" ]; then
+    echo "router-lib was not found at $router_source." >&2
+    echo "Set SAILROUTE_SOURCE_DIR to your router-lib checkout and try again." >&2
+    exit 1
+  fi
+  cmake -S "$root/native/Navtool.RouterBridge" -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DSAILROUTE_SOURCE_DIR="$router_source" \
+    -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
+else
+  cmake -S "$root/native/Navtool.RouterBridge" -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
 fi
-
-cmake -S "$root/native/Navtool.RouterBridge" -B "$build_dir" \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DSAILROUTE_SOURCE_DIR="$router_source" \
-  -DNAVTOOL_ROUTER_BRIDGE_BUILD_TESTS=ON
 cmake --build "$build_dir" --config Release --parallel
 ctest --test-dir "$build_dir" -C Release --output-on-failure


### PR DESCRIPTION
## Why
Native bridge builds currently depend on a local sibling `router-lib` checkout. That makes default setup brittle and blocks clean builds when the override path is not configured.

## What changed
This switches the default to the released `router-lib` artifact and keeps local-source overrides available for development testing.

- `native/Navtool.RouterBridge/CMakeLists.txt`
  - Adds release-source defaults:
    - `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` (`https://github.com/frye/router-lib.git`)
    - `NAVTOOL_ROUTER_LIB_RELEASE_TAG` (`v0.1`)
  - Uses `FetchContent` to pull/build router-lib when `SAILROUTE_SOURCE_DIR` is unset.
  - Preserves existing `SAILROUTE_SOURCE_DIR` behavior as the explicit override path for non-released/local versions.
  - Routes header/sample lookup through the effective source dir (override or fetched content).
- `scripts/build-native.sh` and `scripts/build-native.ps1`
  - Pass `-DSAILROUTE_SOURCE_DIR=...` only when explicitly set.
  - Otherwise let CMake use the release-fetch default.
- `README.md`
  - Documents default release behavior.
  - Adds instructions for changing release version with `-DNAVTOOL_ROUTER_LIB_RELEASE_TAG=...`.
  - Documents optional release repository override and updates config table entries.

## Notes for reviewers
The default release is intentionally pinned to `v0.1` rather than auto-tracking latest, so upgrades are explicit and predictable.