### PR TITLE
Make streaming isochrones visible on the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ updates are posted through the application's progress pipeline to the Avalonia
 UI context.
 
 Each model uses its normal route color. Completed isochrone frontiers accumulate
-as thin low-opacity lines, while the model's provisional route is replaced by
-the latest snapshot. Successful search overlays remain visible with the final
-route. Failed model overlays and all cancelled-calculation overlays are cleared.
-Frontiers, routes, and map-fit bounds are unwrapped safely at the antimeridian.
+as thin red lines, while the model's provisional route is replaced by the latest
+snapshot. Successful search overlays remain visible with the final route. Failed
+model overlays and all cancelled-calculation overlays are cleared. Frontiers,
+routes, and map-fit bounds are unwrapped safely at the antimeridian.
 
 The final route result remains authoritative and may differ from the last
 provisional route. Router-lib progress is notification-only: cancelling in

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -21,11 +21,14 @@ public sealed class RouteMapLayers
 {
     public static readonly MapsuiColor NoaaColor = MapsuiColor.FromString("#0072B2");
     public static readonly MapsuiColor EcmwfColor = MapsuiColor.FromString("#D55E00");
+    public static readonly MapsuiColor IsochroneColor = MapsuiColor.FromString("#D32F2F");
+    public const double IsochroneLineWidth = 1.5;
+    public const float IsochroneOpacity = 0.85f;
 
     private readonly MemoryLayer _noaaRoutes = CreateRouteLayer("NOAA GFS routes", NoaaColor);
     private readonly MemoryLayer _ecmwfRoutes = CreateRouteLayer("ECMWF IFS routes", EcmwfColor);
-    private readonly MemoryLayer _noaaIsochrones = CreateIsochroneLayer("NOAA GFS isochrones", NoaaColor);
-    private readonly MemoryLayer _ecmwfIsochrones = CreateIsochroneLayer("ECMWF IFS isochrones", EcmwfColor);
+    private readonly MemoryLayer _noaaIsochrones = CreateIsochroneLayer("NOAA GFS isochrones");
+    private readonly MemoryLayer _ecmwfIsochrones = CreateIsochroneLayer("ECMWF IFS isochrones");
     private readonly MemoryLayer _noaaProvisionalRoute = CreateProvisionalRouteLayer(
         "NOAA GFS provisional route",
         NoaaColor);
@@ -250,16 +253,16 @@ public sealed class RouteMapLayers
             }
         };
 
-    private static MemoryLayer CreateIsochroneLayer(string name, MapsuiColor color) =>
+    private static MemoryLayer CreateIsochroneLayer(string name) =>
         new(name)
         {
             Style = new VectorStyle
             {
-                Line = new Pen(color, 1.5)
+                Line = new Pen(IsochroneColor, IsochroneLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round
                 },
-                Opacity = 0.28f
+                Opacity = IsochroneOpacity
             }
         };
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -388,11 +388,12 @@
                                                Grid.Column="1"
                                                Text="ECMWF IFS"
                                                FontSize="11" />
-                                    <Border Grid.Row="2"
+                                    <Border x:Name="IsochroneLegendSwatch"
+                                            Grid.Row="2"
                                             Width="20"
                                             Height="2"
-                                            Opacity="0.28"
-                                            Background="#355866"
+                                            Opacity="0.85"
+                                            Background="#D32F2F"
                                             CornerRadius="1"
                                             VerticalAlignment="Center" />
                                     <TextBlock Grid.Row="2"

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -1,8 +1,10 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Media;
 using Mapsui;
 using Mapsui.Layers;
 using Mapsui.Nts;
+using Mapsui.Styles;
 using Mapsui.Tiling.Layers;
 using Mapsui.UI.Avalonia;
 using Navtool.App.Services;
@@ -58,6 +60,30 @@ public sealed class MapRenderingTests
             Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
             Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
             Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void MainWindowLegendShowsVisibleRedIsochrones()
+    {
+        var window = new MainWindow
+        {
+            DataContext = CreateViewModel(tilesEnabled: false)
+        };
+
+        try
+        {
+            window.Show();
+
+            var swatch = window.FindControl<Border>("IsochroneLegendSwatch");
+            Assert.NotNull(swatch);
+            var brush = Assert.IsType<SolidColorBrush>(swatch.Background);
+            Assert.Equal(Color.Parse("#D32F2F"), brush.Color);
+            Assert.Equal(0.85, swatch.Opacity);
         }
         finally
         {
@@ -159,6 +185,29 @@ public sealed class MapRenderingTests
 
         Assert.Equal(0, layers.GetIsochroneCount(ForecastModel.NoaaGfs));
         Assert.False(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
+    }
+
+    [Fact]
+    public void IsochroneLayersUseSharedVisibleRedStyle()
+    {
+        var map = new Map();
+        _ = new RouteMapLayers(map);
+
+        var isochroneLayers = map.Layers
+            .Where(layer => layer.Name?.EndsWith(" isochrones", StringComparison.Ordinal) is true)
+            .Cast<MemoryLayer>()
+            .ToArray();
+
+        Assert.Equal(2, isochroneLayers.Length);
+        Assert.All(isochroneLayers, layer =>
+        {
+            var style = Assert.IsType<VectorStyle>(layer.Style);
+            Assert.NotNull(style.Line);
+            Assert.Equal(RouteMapLayers.IsochroneColor, style.Line.Color);
+            Assert.Equal(RouteMapLayers.IsochroneLineWidth, style.Line.Width);
+            Assert.Equal(RouteMapLayers.IsochroneOpacity, style.Opacity);
+            Assert.Equal(PenStrokeCap.Round, style.Line.PenStrokeCap);
+        });
     }
 
     [Fact]


### PR DESCRIPTION
Isochrone snapshots were reaching the map, but the overlay used faint model-colored strokes instead of the expected thin red lines, making the accumulated frontiers difficult to see against the basemap.

## Summary

- render both model isochrone layers with a shared 1.5 px red stroke at 85% opacity
- align the map legend and streaming documentation with the actual overlay style
- cover both layer styling and the legend swatch with rendering tests

The router-lib callback already emits every retained frontier step, so this change addresses visibility rather than increasing calculation frequency. A separate upstream router-lib issue tracks future display-ready contour and progress-view improvements.

## Validation

- `dotnet test Navtool.sln --no-restore`
- native bridge tests with the current router-lib progress callback
- managed native streaming integration test