### PR TITLE
Render isochrones as destination-facing arcs

### DIFF
--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -22,8 +22,10 @@ public sealed class RouteMapLayers
     public static readonly MapsuiColor NoaaColor = MapsuiColor.FromString("#0072B2");
     public static readonly MapsuiColor EcmwfColor = MapsuiColor.FromString("#D55E00");
     public static readonly MapsuiColor IsochroneColor = MapsuiColor.FromString("#D32F2F");
-    public const double IsochroneLineWidth = 1.5;
+    public const double IsochroneLineWidth = 1.0;
     public const float IsochroneOpacity = 0.85f;
+    private const double IsochroneHalfArcRadians = Math.PI / 2;
+    private const double AngularToleranceRadians = 1e-10;
 
     private readonly MemoryLayer _noaaRoutes = CreateRouteLayer("NOAA GFS routes", NoaaColor);
     private readonly MemoryLayer _ecmwfRoutes = CreateRouteLayer("ECMWF IFS routes", EcmwfColor);
@@ -310,7 +312,7 @@ public sealed class RouteMapLayers
 
     private static IFeature CreateIsochroneFeature(RouteCalculationSnapshot snapshot)
     {
-        var ordered = OrderFrontier(snapshot.Frontier);
+        var ordered = SelectIsochroneFront(snapshot);
         if (ordered.Length == 1)
         {
             var point = new PointFeature(MapProjection.ToMapPoint(ordered[0]))
@@ -320,7 +322,7 @@ public sealed class RouteMapLayers
             return point;
         }
 
-        var coordinates = MapProjection.ToContinuousMapPoints(ordered.Add(ordered[0]))
+        var coordinates = MapProjection.ToContinuousMapPoints(ordered)
             .Select(point => new NtsCoordinate(point.X, point.Y))
             .ToArray();
         var feature = new GeometryFeature(new LineString(coordinates))
@@ -330,10 +332,10 @@ public sealed class RouteMapLayers
         return feature;
     }
 
-    private static ImmutableArray<CoreCoordinate> OrderFrontier(
-        IEnumerable<CoreCoordinate> points)
+    private static ImmutableArray<CoreCoordinate> SelectIsochroneFront(
+        RouteCalculationSnapshot snapshot)
     {
-        var frontier = points.ToArray();
+        var frontier = snapshot.Frontier;
         var latitudeCenter = frontier.Average(point => point.Latitude);
         var longitudeSine = frontier.Sum(point =>
             Math.Sin(point.Longitude * Math.PI / 180));
@@ -344,22 +346,57 @@ public sealed class RouteMapLayers
                 ? Math.Atan2(longitudeSine, longitudeCosine) * 180 / Math.PI
                 : frontier[0].Longitude;
         var longitudeScale = Math.Cos(latitudeCenter * Math.PI / 180);
+        var optimalAngle = GetFrontierAngle(
+            snapshot.ProvisionalRoute[^1].Location,
+            latitudeCenter,
+            longitudeCenter,
+            longitudeScale);
 
-        return frontier
+        var angledFrontier = frontier
             .Select((point, index) => new
             {
                 Point = point,
                 Index = index,
-                Angle = Math.Atan2(
-                    point.Latitude - latitudeCenter,
-                    NormalizeLongitudeDelta(
-                        point.Longitude,
-                        longitudeCenter) * longitudeScale)
+                Offset = NormalizeAngle(
+                    GetFrontierAngle(
+                        point,
+                        latitudeCenter,
+                        longitudeCenter,
+                        longitudeScale) - optimalAngle)
             })
-            .OrderBy(item => item.Angle)
+            .ToArray();
+        var selected = angledFrontier
+            .Where(item =>
+                Math.Abs(item.Offset) <=
+                IsochroneHalfArcRadians + AngularToleranceRadians)
+            .OrderBy(item => item.Offset)
             .ThenBy(item => item.Index)
             .Select(item => item.Point)
             .ToImmutableArray();
+        return selected.IsEmpty
+            ? [angledFrontier.MinBy(item => Math.Abs(item.Offset))!.Point]
+            : selected;
+    }
+
+    private static double GetFrontierAngle(
+        CoreCoordinate point,
+        double latitudeCenter,
+        double longitudeCenter,
+        double longitudeScale) =>
+        Math.Atan2(
+            point.Latitude - latitudeCenter,
+            NormalizeLongitudeDelta(point.Longitude, longitudeCenter) * longitudeScale);
+
+    private static double NormalizeAngle(double angle)
+    {
+        if (angle < -Math.PI)
+        {
+            return angle + 2 * Math.PI;
+        }
+
+        return angle > Math.PI
+            ? angle - 2 * Math.PI
+            : angle;
     }
 
     private static double NormalizeLongitudeDelta(double longitude, double origin) =>

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -139,22 +139,14 @@ public sealed class MapRenderingTests
     {
         var map = new Map();
         var layers = new RouteMapLayers(map);
+        var firstFrontier = CreateDatelineFrontier(0);
         var first = CreateSnapshot(
             new DateTimeOffset(2026, 7, 15, 1, 0, 0, TimeSpan.Zero),
-            new[]
-            {
-                new Coordinate(10, 179),
-                new Coordinate(11, -179),
-                new Coordinate(9, -178)
-            });
+            firstFrontier);
+        var secondFrontier = CreateDatelineFrontier(-0.5);
         var second = CreateSnapshot(
             first.FrontierTime.AddHours(1),
-            new[]
-            {
-                new Coordinate(10, 178),
-                new Coordinate(12, -179),
-                new Coordinate(8, -177)
-            });
+            secondFrontier);
 
         layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, first);
         layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, second);
@@ -199,6 +191,7 @@ public sealed class MapRenderingTests
             .ToArray();
 
         Assert.Equal(2, isochroneLayers.Length);
+        Assert.Equal(1.0, RouteMapLayers.IsochroneLineWidth);
         Assert.All(isochroneLayers, layer =>
         {
             var style = Assert.IsType<VectorStyle>(layer.Style);
@@ -208,6 +201,54 @@ public sealed class MapRenderingTests
             Assert.Equal(RouteMapLayers.IsochroneOpacity, style.Opacity);
             Assert.Equal(PenStrokeCap.Round, style.Line.PenStrokeCap);
         });
+    }
+
+    [Fact]
+    public void IsochronesRenderOpenDestinationFacingHalfFront()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        var east = new Coordinate(0, 2);
+        var frontier = new[]
+        {
+            new Coordinate(1, -1),
+            new Coordinate(-1, 1),
+            new Coordinate(0, -2),
+            new Coordinate(2, 0),
+            east,
+            new Coordinate(-2, 0),
+            new Coordinate(1, 1),
+            new Coordinate(-1, -1)
+        };
+        var expectedArc = new[]
+        {
+            new Coordinate(-2, 0),
+            new Coordinate(-1, 1),
+            east,
+            new Coordinate(1, 1),
+            new Coordinate(2, 0)
+        };
+        var snapshot = CreateSnapshot(
+            new DateTimeOffset(2026, 7, 15, 1, 0, 0, TimeSpan.Zero),
+            frontier,
+            east);
+
+        layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, snapshot);
+
+        var isochrones = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS isochrones"));
+        var feature = Assert.IsType<GeometryFeature>(Assert.Single(isochrones.Features));
+        var line = Assert.IsType<LineString>(feature.Geometry);
+        var expectedPoints = MapProjection.ToContinuousMapPoints(expectedArc);
+
+        Assert.Equal(expectedPoints.Count, line.Coordinates.Length);
+        for (var index = 0; index < expectedPoints.Count; index++)
+        {
+            Assert.Equal(expectedPoints[index].X, line.Coordinates[index].X, 6);
+            Assert.Equal(expectedPoints[index].Y, line.Coordinates[index].Y, 6);
+        }
+
+        Assert.NotEqual(line.Coordinates[0], line.Coordinates[^1]);
     }
 
     [Fact]
@@ -242,17 +283,41 @@ public sealed class MapRenderingTests
 
     private static RouteCalculationSnapshot CreateSnapshot(
         DateTimeOffset frontierTime,
-        IEnumerable<Coordinate> frontier)
+        IEnumerable<Coordinate> frontier,
+        Coordinate? optimalPoint = null)
     {
+        var frontierPoints = frontier.ToArray();
         var start = new Coordinate(10, 170);
         return new RouteCalculationSnapshot(
             frontierTime,
-            frontier,
+            frontierPoints,
             new[]
             {
                 new RoutePoint(start, frontierTime.AddHours(-1), 90, 6, 15, 180, 0),
-                new RoutePoint(frontier.First(), frontierTime, 90, 6, 15, 180, 10)
+                new RoutePoint(
+                    optimalPoint ?? frontierPoints[0],
+                    frontierTime,
+                    90,
+                    6,
+                    15,
+                    180,
+                    10)
             },
             new RouteDiagnostics(10, 20, 5, (int)(frontierTime.Hour + 1)));
     }
+
+    private static Coordinate[] CreateDatelineFrontier(double longitudeOffset) =>
+    [
+        new Coordinate(10, NormalizeLongitude(-179 + longitudeOffset)),
+        new Coordinate(11, NormalizeLongitude(-179.3 + longitudeOffset)),
+        new Coordinate(11.5, NormalizeLongitude(180 + longitudeOffset)),
+        new Coordinate(11, NormalizeLongitude(179.3 + longitudeOffset)),
+        new Coordinate(10, NormalizeLongitude(179 + longitudeOffset)),
+        new Coordinate(9, NormalizeLongitude(179.3 + longitudeOffset)),
+        new Coordinate(8.5, NormalizeLongitude(180 + longitudeOffset)),
+        new Coordinate(9, NormalizeLongitude(-179.3 + longitudeOffset))
+    ];
+
+    private static double NormalizeLongitude(double longitude) =>
+        (longitude + 540) % 360 - 180;
 }


### PR DESCRIPTION
Isochrones currently appear as heavy closed contours, which obscures the useful routing front. This changes them to thin, open fronts centered on the optimal provisional-route endpoint.

## Changes

- Render only the frontier points within +/-90 degrees of the selected optimal endpoint, producing a 180-degree destination-facing arc.
- Leave arc endpoints open instead of reconnecting the first and last points.
- Reduce the shared isochrone stroke from 1.5 px to 1.0 px.
- Preserve antimeridian continuity and handle sparse frontier edge cases.
- Add rendering coverage for arc orientation, openness, styling, and dateline behavior.

## Testing

- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --no-restore`