### PR TITLE
Add apparent wind angle to the route point data box

### DIFF
--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -265,6 +265,7 @@ public partial class MainViewModel : ViewModelBase
                    $"{point.Location.Latitude:0.0000}°, {point.Location.Longitude:0.0000}° · " +
                    $"heading {point.HeadingDegrees:0}° · boat {point.BoatSpeedKnots:0.0} kt\n" +
                    $"true wind {point.TrueWindSpeedKnots:0.0} kt @ {point.TrueWindDirectionDegrees:0}° · " +
+                   $"{FormatApparentWind(point)} · " +
                    $"cumulative {point.CumulativeDistanceNauticalMiles:0.0} NM\n" +
                    $"{ModelName(selection.Route.Model)} · arrival {selection.Route.ArrivalTime:yyyy-MM-dd HH:mm} UTC · " +
                    $"distance {selection.Route.Points[^1].CumulativeDistanceNauticalMiles:0.0} NM · {forecast}";
@@ -1272,6 +1273,23 @@ public partial class MainViewModel : ViewModelBase
         ForecastModel.EcmwfIfs => "ECMWF IFS (experimental)",
         _ => model.ToString()
     };
+
+    private static string FormatApparentWind(RoutePoint point)
+    {
+        var roundedAngle = (int)Math.Round(point.ApparentWindAngleDegrees, MidpointRounding.AwayFromZero);
+        if (roundedAngle <= 0)
+        {
+            return "apparent wind 0° ahead";
+        }
+
+        if (roundedAngle >= 180)
+        {
+            return "apparent wind 180° astern";
+        }
+
+        var side = point.ApparentWindAngleSignedDegrees > 0d ? "starboard" : "port";
+        return $"apparent wind {roundedAngle:0}° {side}";
+    }
 
     private static string FormatOverDuration(TimeSpan overrun)
     {

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -263,9 +263,9 @@ public partial class MainViewModel : ViewModelBase
                   $"{acquisition.Source} · {acquisition.Artifact.Path}";
             return $"{point.Timestamp:yyyy-MM-dd HH:mm:ss} UTC\n" +
                    $"{point.Location.Latitude:0.0000}°, {point.Location.Longitude:0.0000}° · " +
-                   $"heading {point.HeadingDegrees:0}° · boat {point.BoatSpeedKnots:0.0} kt\n" +
+                   $"heading {point.HeadingDegrees:0}° · boat {point.BoatSpeedKnots:0.0} kt · " +
+                   $"{FormatApparentWind(point)}\n" +
                    $"true wind {point.TrueWindSpeedKnots:0.0} kt @ {point.TrueWindDirectionDegrees:0}° · " +
-                   $"{FormatApparentWind(point)} · " +
                    $"cumulative {point.CumulativeDistanceNauticalMiles:0.0} NM\n" +
                    $"{ModelName(selection.Route.Model)} · arrival {selection.Route.ArrivalTime:yyyy-MM-dd HH:mm} UTC · " +
                    $"distance {selection.Route.Points[^1].CumulativeDistanceNauticalMiles:0.0} NM · {forecast}";

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -1276,7 +1276,8 @@ public partial class MainViewModel : ViewModelBase
 
     private static string FormatApparentWind(RoutePoint point)
     {
-        var roundedAngle = (int)Math.Round(point.ApparentWindAngleDegrees, MidpointRounding.AwayFromZero);
+        var signedAngle = point.ApparentWindAngleSignedDegrees;
+        var roundedAngle = (int)Math.Round(Math.Abs(signedAngle), MidpointRounding.AwayFromZero);
         if (roundedAngle <= 0)
         {
             return "apparent wind 0° ahead";
@@ -1287,7 +1288,7 @@ public partial class MainViewModel : ViewModelBase
             return "apparent wind 180° astern";
         }
 
-        var side = point.ApparentWindAngleSignedDegrees > 0d ? "starboard" : "port";
+        var side = signedAngle > 0d ? "starboard" : "port";
         return $"apparent wind {roundedAngle:0}° {side}";
     }
 

--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -196,6 +196,53 @@ public sealed record RoutePoint
 
     public double CumulativeDistanceNauticalMiles { get; }
 
+    public double ApparentWindAngleSignedDegrees
+    {
+        get
+        {
+            var (trueWindEast, trueWindNorth) = ToVectorToward(
+                TrueWindSpeedKnots,
+                NormalizeDirection(TrueWindDirectionDegrees + 180d));
+            var (boatEast, boatNorth) = ToVectorToward(BoatSpeedKnots, HeadingDegrees);
+            var apparentEast = trueWindEast - boatEast;
+            var apparentNorth = trueWindNorth - boatNorth;
+            if (Math.Abs(apparentEast) < 1e-9 && Math.Abs(apparentNorth) < 1e-9)
+            {
+                return 0d;
+            }
+
+            var apparentFromDirection = NormalizeDirection(
+                Math.Atan2(-apparentEast, -apparentNorth) * (180d / Math.PI));
+            return NormalizeSignedAngle(apparentFromDirection - HeadingDegrees);
+        }
+    }
+
+    public double ApparentWindAngleDegrees => Math.Abs(ApparentWindAngleSignedDegrees);
+
+    private static (double East, double North) ToVectorToward(double speed, double directionDegrees)
+    {
+        var radians = directionDegrees * (Math.PI / 180d);
+        return (speed * Math.Sin(radians), speed * Math.Cos(radians));
+    }
+
+    private static double NormalizeDirection(double value)
+    {
+        var normalized = value % 360d;
+        return normalized < 0d ? normalized + 360d : normalized;
+    }
+
+    private static double NormalizeSignedAngle(double value)
+    {
+        var normalized = (value + 180d) % 360d;
+        if (normalized < 0d)
+        {
+            normalized += 360d;
+        }
+
+        normalized -= 180d;
+        return normalized <= -180d ? 180d : normalized;
+    }
+
     private static void ValidateDirection(double value, string parameterName)
     {
         if (!double.IsFinite(value) || value is < 0 or >= 360)

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -96,6 +96,24 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task SelectedRouteDetailsIncludeApparentWindAngle()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Contains("apparent wind 31° starboard", viewModel.SelectedRouteDetails);
+    }
+
+    [Fact]
     public async Task PassageDurationControlsForecastWindow()
     {
         var noaa = new DelegateForecastProvider(

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -82,7 +82,7 @@ public sealed class MapRenderingTests
             var swatch = window.FindControl<Border>("IsochroneLegendSwatch");
             Assert.NotNull(swatch);
             var brush = Assert.IsType<SolidColorBrush>(swatch.Background);
-            Assert.Equal(Color.Parse("#D32F2F"), brush.Color);
+            Assert.Equal(Avalonia.Media.Color.Parse("#D32F2F"), brush.Color);
             Assert.Equal(0.85, swatch.Opacity);
         }
         finally

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -60,6 +60,32 @@ public sealed class NativeBridgeContractTests
         Assert.Equal(81.2, point.CumulativeDistanceNauticalMiles);
     }
 
+    [Theory]
+    [InlineData(90, 6, 15, 180, 68.19859051364824)]
+    [InlineData(90, 6, 15, 0, -68.19859051364818)]
+    [InlineData(90, 6, 0, 0, 0)]
+    [InlineData(90, 6, 15, 270, 180)]
+    [InlineData(350, 5, 20, 20, 24.133261210456055)]
+    public void Route_point_derives_apparent_wind_angle(
+        double headingDegrees,
+        double boatSpeedKnots,
+        double trueWindSpeedKnots,
+        double trueWindDirectionDegrees,
+        double expectedSignedAngle)
+    {
+        var point = new RoutePoint(
+            new Coordinate(42, -60),
+            new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero),
+            headingDegrees,
+            boatSpeedKnots,
+            trueWindSpeedKnots,
+            trueWindDirectionDegrees,
+            81.2);
+
+        Assert.Equal(expectedSignedAngle, point.ApparentWindAngleSignedDegrees, 6);
+        Assert.Equal(Math.Abs(expectedSignedAngle), point.ApparentWindAngleDegrees, 6);
+    }
+
     [Fact]
     public void Route_point_rejects_invalid_native_detail_values()
     {


### PR DESCRIPTION
## Why
When inspecting a selected route point under the map, the data box showed heading, boat speed, and true wind, but it did not show apparent wind angle. That made sail trim interpretation harder during point-by-point review.

## What changed
- Derive apparent wind angle directly on `RoutePoint` from existing values (heading, boat speed, true wind speed/direction) using vector math.
- Expose both signed and absolute apparent wind angle on `RoutePoint`.
- Update `SelectedRouteDetails` to display apparent wind in `0-180°` form with side labeling (`port`/`starboard`) and explicit edge cases (`ahead`/`astern`).
- Add focused core tests for starboard, port, ahead, astern, and wraparound cases.
- Add an app workflow test asserting the selected-route data box includes apparent wind text.
- Disambiguate `Color.Parse(...)` in `MapRenderingTests` to keep app tests compiling.

## Validation
- `dotnet test tests/Navtool.Core.Tests/Navtool.Core.Tests.csproj --filter FullyQualifiedName~NativeBridgeContractTests`
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --filter FullyQualifiedName~MainViewModelWorkflowTests.SelectedRouteDetailsIncludeApparentWindAngle`