### PR TITLE
Update default router-lib to v0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dotnet test Navtool.sln
 
 The application discovers the development bridge automatically. For a custom
 location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
-directory. Native builds fetch and compile `router-lib` from release `v0.1` by
+directory. Native builds fetch and compile `router-lib` from release `v0.1.1` by
 default. Set `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when
 testing non-released changes.
 
@@ -135,7 +135,7 @@ also be installed or packaged according to the target platform.
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
 | `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
-| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Released `router-lib` tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.1`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Released `router-lib` tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.1.1`) |
 | `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | Released `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -15,7 +15,7 @@ set(
     "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
 set(
     NAVTOOL_ROUTER_LIB_RELEASE_TAG
-    "v0.1"
+    "v0.1.1"
     CACHE STRING
     "router-lib release tag used when SAILROUTE_SOURCE_DIR is unset")
 set(_navtool_router_effective_source_dir "")

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -82,7 +82,7 @@ public sealed class MapRenderingTests
 
             var swatch = window.FindControl<Border>("IsochroneLegendSwatch");
             Assert.NotNull(swatch);
-            var brush = Assert.IsType<SolidColorBrush>(swatch.Background);
+            var brush = Assert.IsAssignableFrom<ISolidColorBrush>(swatch.Background);
             Assert.Equal(AvaloniaColor.Parse("#D32F2F"), brush.Color);
             Assert.Equal(0.85, swatch.Opacity);
         }


### PR DESCRIPTION
Native builds should consume the latest router-lib release by default rather than requiring a manual tag override.

## Summary

- Change the default router-lib release tag from `v0.1` to `v0.1.1` and update the documented default.
- Make the isochrone legend test assert the `ISolidColorBrush` contract, since Avalonia validly materializes XAML color literals as immutable brushes.

## Testing

- Native CMake build and CTest against router-lib `v0.1.1`: 1/1 passed
- `dotnet test Navtool.sln`: 129/129 passed