### PR TITLE
Add play-button launch configurations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csdevkit"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Navtool",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "Navtool: Build",
+      "program": "${workspaceFolder}/src/Navtool.App/bin/Debug/net9.0/Navtool.App.dll",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NAVTOOL_ROUTER_BRIDGE_PATH": "${workspaceFolder}/native/Navtool.RouterBridge/build"
+      },
+      "windows": {
+        "env": {
+          "NAVTOOL_ROUTER_BRIDGE_PATH": "${workspaceFolder}\\native\\Navtool.RouterBridge\\build\\Release"
+        }
+      },
+      "console": "integratedTerminal",
+      "stopAtEntry": false
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,64 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Navtool: Build native bridge",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/build-native.sh",
+      "windows": {
+        "command": "powershell.exe",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}\\scripts\\build-native.ps1"
+        ]
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Navtool: Build managed app",
+      "type": "process",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/Navtool.App/Navtool.App.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Navtool: Build",
+      "dependsOrder": "sequence",
+      "dependsOn": [
+        "Navtool: Build native bridge",
+        "Navtool: Build managed app"
+      ],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Navtool: Run",
+      "type": "shell",
+      "command": "${workspaceFolder}/scripts/run.sh",
+      "windows": {
+        "command": "powershell.exe",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}\\scripts\\run.ps1"
+        ]
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ On Windows:
 .\scripts\run.ps1
 ```
 
+In GitHub Copilot App or VS Code, select the **Navtool** run configuration and
+press the play button (or press `F5`). To launch without the debugger, run the
+**Navtool: Run** task. Both options build the native bridge before starting the
+app.
+
 The launcher builds and tests the bridge before starting Avalonia, preventing a
 long forecast download from completing only to discover that routing is not
 available. To build or test separately:


### PR DESCRIPTION
Navtool already had platform-specific launch scripts, but editor and Copilot App users could not start the application from the standard play button.

This adds a checked-in `Navtool` debug configuration and cross-platform tasks that build the native bridge and managed app before launch. It also recommends the C# Dev Kit extension and documents both the play-button and task-based workflows.