### PR TITLE
Add unit test GitHub Action

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install native dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes libeccodes-dev
+          sudo apt-get install --yes libeccodes-dev libeccodes-tools
 
       - name: Restore managed dependencies
         run: dotnet restore Navtool.sln

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,46 @@
+name: Unit tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Run all unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+          cache: true
+          cache-dependency-path: |
+            src/**/*.csproj
+            tests/**/*.csproj
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libeccodes-dev
+
+      - name: Restore managed dependencies
+        run: dotnet restore Navtool.sln
+
+      - name: Build and test native bridge
+        run: ./scripts/build-native.sh
+
+      - name: Run managed unit tests
+        run: dotnet test Navtool.sln --configuration Release --no-restore


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for pull requests and pushes to `main`
- build and test the native router bridge with its ecCodes dependency
- run every managed test project in `Navtool.sln`

## Test plan
- `./scripts/build-native.sh`
- `dotnet restore Navtool.sln --nologo`
- `dotnet test Navtool.sln --configuration Release --no-restore --nologo`