### PR TITLE
Improve isochrone display consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ dotnet test Navtool.sln
 The application discovers the development bridge automatically. For a custom
 location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
 directory. Native builds fetch and compile the immutable `router-lib` revision
-`v0.2.0` by default. Set
+`v0.3.0` by default. Set
 `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when testing other
 revisions.
 
@@ -103,15 +103,18 @@ returns promptly; Mapsui updates are posted through the application's progress
 pipeline to the Avalonia UI context.
 
 At every routing time step, Navtool accumulates the router-provided open,
-destination-facing front as thin, translucent historical context. Display-only
-corner cutting softens angular joins without changing routing points, closing a
-front, or joining separate antimeridian segments. One stronger red line shows
-only the latest front. Its source points are ordered port-to-starboard and
-exclude internal search clusters. The model's provisional route is also replaced
-by the latest snapshot. Successful and forecast-limited search overlays remain
-visible with the final route. Failed model overlays and all cancelled-calculation
-overlays are cleared. Fronts, routes, and map-fit bounds are unwrapped safely at
-the antimeridian.
+destination-facing front as thin, translucent historical context. The front
+uses a 120-degree aperture on each side of the destination bearing to preserve
+useful port and starboard context without drawing the backward envelope.
+Display-only corner cutting softens angular joins without changing routing
+points, closing a front, or joining separate antimeridian segments. One-point
+segments are omitted rather than rendered as zero-length marks. One stronger red
+line shows only the latest front. Its source points are ordered port-to-starboard
+and exclude internal search clusters. The model's provisional route is also
+replaced by the latest snapshot. Successful and forecast-limited search overlays
+remain visible with the final route. Failed model overlays and all
+cancelled-calculation overlays are cleared. Fronts, routes, and map-fit bounds
+are unwrapped safely at the antimeridian.
 
 When forecast coverage ends before the destination is reached, Navtool promotes
 the final provisional route to a selectable forecast-limited estimate, retains
@@ -154,7 +157,7 @@ also be installed or packaged according to the target platform.
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
 | `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
-| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.2.0`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.3.0`) |
 | `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -15,7 +15,7 @@ set(
     "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
 set(
     NAVTOOL_ROUTER_LIB_RELEASE_TAG
-    "v0.2.0"
+    "v0.3.0"
     CACHE STRING
     "Immutable router-lib revision used when SAILROUTE_SOURCE_DIR is unset")
 set(_navtool_router_effective_source_dir "")

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -31,6 +31,7 @@ struct navtool_router_forecast_v1 {
 namespace {
 
 thread_local std::string last_error;
+constexpr double destination_front_half_angle_degrees = 120.0;
 
 void clear_error() {
     last_error.clear();
@@ -454,6 +455,8 @@ navtool_router_status_v1 calculate_route_with_fronts(
     request.options.progress.payload =
         sailroute::RoutingProgressPayload::destination_front |
         sailroute::RoutingProgressPayload::provisional_route;
+    request.options.progress.destination_front.half_angle_degrees =
+        destination_front_half_angle_degrees;
     if (is_segment_eligible != nullptr) {
         request.options.segment_eligibility =
             [is_segment_eligible, segment_eligibility_user_data](
@@ -567,6 +570,8 @@ navtool_router_status_v1 calculate_route_with_display(
         sailroute::RoutingProgressPayload::display_contours |
         sailroute::RoutingProgressPayload::destination_front |
         sailroute::RoutingProgressPayload::provisional_route;
+    request.options.progress.destination_front.half_angle_degrees =
+        destination_front_half_angle_degrees;
     if (is_segment_eligible != nullptr) {
         request.options.segment_eligibility =
             [is_segment_eligible, segment_eligibility_user_data](

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -10,7 +10,7 @@ if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 if ([string]::IsNullOrWhiteSpace($RouterRevision)) {
-    $RouterRevision = "97487755fae6250023226b3c45affbb1a710ce49"
+    $RouterRevision = "v0.3.0"
 }
 
 if ([string]::IsNullOrWhiteSpace($RouterSource)) {

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -3,7 +3,7 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
-router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"97487755fae6250023226b3c45affbb1a710ce49"}
+router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"v0.3.0"}
 
 if [ -n "${SAILROUTE_SOURCE_DIR:-}" ]; then
   router_source=$SAILROUTE_SOURCE_DIR

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -269,16 +269,17 @@ public sealed class RouteMapLayers
             snapshot.ProvisionalRoute.Select(point => point.Location))[^1].X;
         foreach (var segment in snapshot.FrontSegments)
         {
+            if (segment.Points.Length < 2)
+            {
+                continue;
+            }
+
             var coordinates = MapProjection.ToContinuousMapPointsNear(
                     segment.Points,
                     referenceX)
                 .Select(point => new NtsCoordinate(point.X, point.Y))
                 .ToArray();
             coordinates = SmoothOpenLine(coordinates, IsochroneSmoothingIterations);
-            if (coordinates.Length == 1)
-            {
-                coordinates = new[] { coordinates[0], coordinates[0] };
-            }
 
             yield return new GeometryFeature(new LineString(coordinates))
             {

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -323,7 +323,7 @@ public sealed class MapRenderingTests
     }
 
     [Fact]
-    public void IsochroneLayersRetainSingletonsWithoutInventingExtent()
+    public void IsochroneLayersOmitSingletonsInsteadOfDrawingZeroLengthLines()
     {
         var map = new Map();
         var layers = new RouteMapLayers(map);
@@ -353,14 +353,12 @@ public sealed class MapRenderingTests
         layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, snapshot);
         layers.SetRoutes(new[] { route });
 
-        var historical = Assert.IsType<GeometryFeature>(Assert.Single(Assert.IsType<MemoryLayer>(
-            map.Layers.Single(layer => layer.Name == "NOAA GFS isochrone fronts")).Features));
-        var historicalLine = Assert.IsType<LineString>(historical.Geometry);
-        Assert.Equal(historicalLine.Coordinates[0], historicalLine.Coordinates[1]);
-        var front = Assert.IsType<GeometryFeature>(Assert.Single(Assert.IsType<MemoryLayer>(
-            map.Layers.Single(layer => layer.Name == "NOAA GFS latest isochrone front")).Features));
-        var frontLine = Assert.IsType<LineString>(front.Geometry);
-        Assert.Equal(frontLine.Coordinates[0], frontLine.Coordinates[1]);
+        Assert.Equal(0, layers.GetIsochroneFrontCount(ForecastModel.NoaaGfs));
+        Assert.False(layers.HasLatestIsochroneFront(ForecastModel.NoaaGfs));
+        Assert.Empty(Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS isochrone fronts")).Features);
+        Assert.Empty(Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS latest isochrone front")).Features);
         Assert.Empty(Assert.IsType<MemoryLayer>(
             map.Layers.Single(layer => layer.Name == "NOAA GFS provisional route")).Features);
         Assert.Empty(Assert.IsType<MemoryLayer>(


### PR DESCRIPTION
Isochrone fronts can appear on only one side of a route or collapse into tiny marks near departure because the router's fixed 90-degree display aperture removes useful frontier context and the map renders singleton segments as zero-length lines.

This change upgrades the native router dependency to v0.3.0 and configures a 120-degree destination-front aperture in every streaming path. The wider aperture preserves useful port and starboard context without exposing the full backward reachability envelope. Singleton fronts remain valid routing data but are omitted from map rendering instead of being converted into misleading line artifacts.

The native build pins and streaming visualization documentation are updated accordingly, with regression coverage for singleton suppression while preserving open-front smoothing and antimeridian segmentation.

**Validation**
- Full managed test suite
- Fresh native bridge build and tests against router-lib v0.3.0
- Managed native bridge integration test