### PR TITLE
Set default chart view to Salish Sea region

### DIFF
--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -23,8 +23,16 @@ public enum ForecastInputMode
 
 public partial class MainViewModel : ViewModelBase
 {
+    private const double DefaultChartBufferNauticalMiles = 10;
     private const double RouteHitTolerancePixels = 10;
     private const double RoutePointHitTolerancePixels = 14;
+    private static readonly Coordinate[] DefaultChartLocations =
+    [
+        new(48.1163, -122.7583), // Port Townsend
+        new(48.5343, -123.0171), // Friday Harbor
+        new(48.5126, -122.6127), // Anacortes
+        new(48.9416, -125.5464)  // Ucluelet
+    ];
     private static readonly TimeSpan MaximumRouteWindow = TimeSpan.FromDays(10);
     private static readonly TimeSpan MaximumDepartureLeadTime = TimeSpan.FromDays(5);
     private static readonly TimeSpan WeatherDebounce = TimeSpan.FromMilliseconds(220);
@@ -207,9 +215,7 @@ public partial class MainViewModel : ViewModelBase
 
         _mapLayers = new RouteMapLayers(Map);
         UtcOffsetDisplay = FormatUtcOffset(localTimeZone.GetUtcOffset(timeProvider.GetLocalNow()));
-        Map.Navigator.CenterOnAndZoomTo(
-            MapProjection.ToMapPoint(new Coordinate(35, -55)),
-            25_000);
+        Map.Navigator.ZoomToBox(CreateDefaultChartExtent());
         UpdateForecastAreaSummary();
     }
 
@@ -1289,6 +1295,22 @@ public partial class MainViewModel : ViewModelBase
         {
             ForecastAreaSummary = $"{area} · estimate unavailable: {exception.Message}";
         }
+    }
+
+    private static MRect CreateDefaultChartExtent()
+    {
+        var bounds = GeographicBounds.FromCoordinates(DefaultChartLocations);
+        var latitudePadding = DefaultChartBufferNauticalMiles / 60d;
+        var south = bounds.South - latitudePadding;
+        var north = bounds.North + latitudePadding;
+        var polewardLatitude = Math.Max(Math.Abs(south), Math.Abs(north));
+        var longitudePadding = DefaultChartBufferNauticalMiles /
+            (60d * Math.Cos(polewardLatitude * Math.PI / 180d));
+        var lowerLeft = MapProjection.ToMapPoint(
+            new Coordinate(south, bounds.West - longitudePadding));
+        var upperRight = MapProjection.ToMapPoint(
+            new Coordinate(north, bounds.East + longitudePadding));
+        return new MRect(lowerLeft.X, lowerLeft.Y, upperRight.X, upperRight.Y);
     }
 
     private static string FormatBounds(GeographicBounds bounds) =>

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -34,13 +34,25 @@ public sealed class MapRenderingTests
             window.Show();
 
             var visible = viewModel.Map.Navigator.Viewport.ToExtent();
-            var expected = CreateDefaultChartExtent();
-            Assert.InRange(expected.Left, visible.Left, visible.Right);
-            Assert.InRange(expected.Right, visible.Left, visible.Right);
-            Assert.InRange(expected.Bottom, visible.Bottom, visible.Top);
-            Assert.InRange(expected.Top, visible.Bottom, visible.Top);
-            Assert.True(visible.Width < expected.Width * 1.25);
-            Assert.True(visible.Height < expected.Height * 1.75);
+            Coordinate[] requiredVisibleLocations =
+            [
+                new(48.1163, -122.7583), // Port Townsend
+                new(48.5343, -123.0171), // Friday Harbor
+                new(48.5126, -122.6127), // Anacortes
+                new(48.9416, -125.5464), // Ucluelet
+                new(47.95, -122.7583),   // 10 NM south
+                new(49.108, -125.5464),  // 10 NM north
+                new(48.9416, -125.8),    // 10 NM west
+                new(48.5126, -122.36)    // 10 NM east
+            ];
+            Assert.All(requiredVisibleLocations, location =>
+            {
+                var point = MapProjection.ToMapPoint(location);
+                Assert.InRange(point.X, visible.Left, visible.Right);
+                Assert.InRange(point.Y, visible.Bottom, visible.Top);
+            });
+            Assert.True(visible.Width < 500_000);
+            Assert.True(visible.Height < 400_000);
         }
         finally
         {
@@ -476,30 +488,6 @@ public sealed class MapRenderingTests
             TimeProvider.System,
             TimeZoneInfo.Utc,
             new OsmTileOptions(Enabled: tilesEnabled));
-
-    private static MRect CreateDefaultChartExtent()
-    {
-        const double bufferNauticalMiles = 10;
-        Coordinate[] locations =
-        [
-            new(48.1163, -122.7583),
-            new(48.5343, -123.0171),
-            new(48.5126, -122.6127),
-            new(48.9416, -125.5464)
-        ];
-        var bounds = GeographicBounds.FromCoordinates(locations);
-        var latitudePadding = bufferNauticalMiles / 60d;
-        var south = bounds.South - latitudePadding;
-        var north = bounds.North + latitudePadding;
-        var polewardLatitude = Math.Max(Math.Abs(south), Math.Abs(north));
-        var longitudePadding = bufferNauticalMiles /
-            (60d * Math.Cos(polewardLatitude * Math.PI / 180d));
-        var lowerLeft = MapProjection.ToMapPoint(
-            new Coordinate(south, bounds.West - longitudePadding));
-        var upperRight = MapProjection.ToMapPoint(
-            new Coordinate(north, bounds.East + longitudePadding));
-        return new MRect(lowerLeft.X, lowerLeft.Y, upperRight.X, upperRight.Y);
-    }
 
     private static RouteCalculationSnapshot CreateSnapshot(
         DateTimeOffset frontierTime,

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 using Mapsui;
+using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Nts;
 using Mapsui.Styles;
@@ -19,6 +20,34 @@ namespace Navtool.App.Tests;
 
 public sealed class MapRenderingTests
 {
+    [AvaloniaFact]
+    public void MainWindowOpensOnBufferedSalishSeaRegion()
+    {
+        var viewModel = CreateViewModel(tilesEnabled: false);
+        var window = new MainWindow
+        {
+            DataContext = viewModel
+        };
+
+        try
+        {
+            window.Show();
+
+            var visible = viewModel.Map.Navigator.Viewport.ToExtent();
+            var expected = CreateDefaultChartExtent();
+            Assert.InRange(expected.Left, visible.Left, visible.Right);
+            Assert.InRange(expected.Right, visible.Left, visible.Right);
+            Assert.InRange(expected.Bottom, visible.Bottom, visible.Top);
+            Assert.InRange(expected.Top, visible.Bottom, visible.Top);
+            Assert.True(visible.Width < expected.Width * 1.25);
+            Assert.True(visible.Height < expected.Height * 1.75);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [AvaloniaFact]
     public void MainWindowLeavesMapsuiSurfaceUncoveredAndEnablesContinuousZoom()
     {
@@ -447,6 +476,30 @@ public sealed class MapRenderingTests
             TimeProvider.System,
             TimeZoneInfo.Utc,
             new OsmTileOptions(Enabled: tilesEnabled));
+
+    private static MRect CreateDefaultChartExtent()
+    {
+        const double bufferNauticalMiles = 10;
+        Coordinate[] locations =
+        [
+            new(48.1163, -122.7583),
+            new(48.5343, -123.0171),
+            new(48.5126, -122.6127),
+            new(48.9416, -125.5464)
+        ];
+        var bounds = GeographicBounds.FromCoordinates(locations);
+        var latitudePadding = bufferNauticalMiles / 60d;
+        var south = bounds.South - latitudePadding;
+        var north = bounds.North + latitudePadding;
+        var polewardLatitude = Math.Max(Math.Abs(south), Math.Abs(north));
+        var longitudePadding = bufferNauticalMiles /
+            (60d * Math.Cos(polewardLatitude * Math.PI / 180d));
+        var lowerLeft = MapProjection.ToMapPoint(
+            new Coordinate(south, bounds.West - longitudePadding));
+        var upperRight = MapProjection.ToMapPoint(
+            new Coordinate(north, bounds.East + longitudePadding));
+        return new MRect(lowerLeft.X, lowerLeft.Y, upperRight.X, upperRight.Y);
+    }
 
     private static RouteCalculationSnapshot CreateSnapshot(
         DateTimeOffset frontierTime,


### PR DESCRIPTION
The chart currently opens over the North Atlantic instead of the Pacific Northwest waters targeted by this app.

This changes the startup viewport to fit Port Townsend, Friday Harbor, Anacortes, and Ucluelet within a 10 nautical mile buffered envelope. Mapsui fits the projected bounds to the available chart area, preserving aspect ratio without clipping the requested region or zooming out excessively.

## Testing

- Added headless coverage for the initial buffered viewport
- Ran the map rendering test suite