### PR TITLE
Add radial map action foundation

### DIFF
--- a/src/Navtool.App/Models/MapInteractionState.cs
+++ b/src/Navtool.App/Models/MapInteractionState.cs
@@ -22,21 +22,32 @@ public sealed class MapInteractionState
         Mode = mode;
     }
 
+    public void SetStart(Coordinate coordinate)
+    {
+        Start = coordinate;
+        Mode = MapInteractionMode.Browse;
+    }
+
+    public void SetDestination(Coordinate coordinate)
+    {
+        Destination = coordinate;
+        Mode = MapInteractionMode.Browse;
+    }
+
     public bool HandleMapClick(Coordinate coordinate)
     {
         switch (Mode)
         {
             case MapInteractionMode.SetStart:
-                Start = coordinate;
+                SetStart(coordinate);
                 break;
             case MapInteractionMode.SetDestination:
-                Destination = coordinate;
+                SetDestination(coordinate);
                 break;
             default:
                 return false;
         }
 
-        Mode = MapInteractionMode.Browse;
         return true;
     }
 }

--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -1,0 +1,261 @@
+using System.Collections.Immutable;
+using Navtool.App.Models;
+
+namespace Navtool.App.Services;
+
+public enum RadialMenuAction
+{
+    SetStart,
+    SetDestination,
+    Inspect
+}
+
+public enum RadialMenuLayout
+{
+    Radial,
+    Linear
+}
+
+public readonly record struct ScreenSize(double Width, double Height);
+
+public readonly record struct ScreenRect(double X, double Y, double Width, double Height)
+{
+    public double Right => X + Width;
+
+    public double Bottom => Y + Height;
+
+    public ScreenPoint Center => new(X + (Width / 2), Y + (Height / 2));
+
+    public bool Contains(ScreenRect other) =>
+        other.X >= X &&
+        other.Y >= Y &&
+        other.Right <= Right &&
+        other.Bottom <= Bottom;
+}
+
+public readonly record struct RadialMenuConnector(ScreenPoint Start, ScreenPoint End);
+
+public sealed record RadialMenuActionPlacement(
+    RadialMenuAction Action,
+    ScreenRect Bounds)
+{
+    public ScreenPoint Center => Bounds.Center;
+}
+
+public sealed record RadialMenuPlacementResult(
+    ScreenPoint Anchor,
+    ScreenPoint Center,
+    ImmutableArray<RadialMenuActionPlacement> Actions,
+    RadialMenuLayout Layout,
+    RadialMenuConnector? Connector)
+{
+    public bool NeedsConnector => Connector is not null;
+}
+
+public static class RadialMenuPlacement
+{
+    private const double LinearGap = 8;
+    private const double ConnectorEpsilon = 0.001;
+    private static readonly ImmutableArray<RadialMenuAction> ActionOrder =
+    [
+        RadialMenuAction.SetStart,
+        RadialMenuAction.SetDestination,
+        RadialMenuAction.Inspect
+    ];
+
+    public static RadialMenuPlacementResult Calculate(
+        ScreenRect visibleBounds,
+        ScreenPoint anchor,
+        ScreenSize actionSize,
+        double radius,
+        double safeMargin)
+    {
+        Validate(visibleBounds, anchor, actionSize, radius, safeMargin);
+
+        var safeBounds = new ScreenRect(
+            visibleBounds.X + safeMargin,
+            visibleBounds.Y + safeMargin,
+            visibleBounds.Width - (safeMargin * 2),
+            visibleBounds.Height - (safeMargin * 2));
+        if (TryCreateRadial(safeBounds, anchor, actionSize, radius, out var center, out var actions))
+        {
+            return CreateResult(anchor, center, actions, RadialMenuLayout.Radial);
+        }
+
+        var linear = CreateLinear(safeBounds, anchor, actionSize);
+        return CreateResult(anchor, linear.Center, linear.Actions, RadialMenuLayout.Linear);
+    }
+
+    private static bool TryCreateRadial(
+        ScreenRect safeBounds,
+        ScreenPoint anchor,
+        ScreenSize actionSize,
+        double radius,
+        out ScreenPoint center,
+        out ImmutableArray<RadialMenuActionPlacement> actions)
+    {
+        var offsets = CreateRadialOffsets(radius);
+        var minimumOffsetX = offsets.Min(offset => offset.X - (actionSize.Width / 2));
+        var maximumOffsetX = offsets.Max(offset => offset.X + (actionSize.Width / 2));
+        var minimumOffsetY = offsets.Min(offset => offset.Y - (actionSize.Height / 2));
+        var maximumOffsetY = offsets.Max(offset => offset.Y + (actionSize.Height / 2));
+        var minimumCenterX = safeBounds.X - minimumOffsetX;
+        var maximumCenterX = safeBounds.Right - maximumOffsetX;
+        var minimumCenterY = safeBounds.Y - minimumOffsetY;
+        var maximumCenterY = safeBounds.Bottom - maximumOffsetY;
+
+        if (minimumCenterX > maximumCenterX || minimumCenterY > maximumCenterY)
+        {
+            center = default;
+            actions = default;
+            return false;
+        }
+
+        center = new ScreenPoint(
+            Math.Clamp(anchor.X, minimumCenterX, maximumCenterX),
+            Math.Clamp(anchor.Y, minimumCenterY, maximumCenterY));
+        actions = CreatePlacements(center, actionSize, offsets);
+        return true;
+    }
+
+    private static (ScreenPoint Center, ImmutableArray<RadialMenuActionPlacement> Actions) CreateLinear(
+        ScreenRect safeBounds,
+        ScreenPoint anchor,
+        ScreenSize actionSize)
+    {
+        var horizontalGap = AvailableGap(safeBounds.Width, actionSize.Width);
+        var verticalGap = AvailableGap(safeBounds.Height, actionSize.Height);
+        var canUseHorizontal = horizontalGap is not null && actionSize.Height <= safeBounds.Height;
+        var canUseVertical = verticalGap is not null && actionSize.Width <= safeBounds.Width;
+        var useHorizontal = canUseHorizontal &&
+                            (!canUseVertical || safeBounds.Width >= safeBounds.Height);
+        ImmutableArray<ScreenPoint> offsets;
+        double halfWidth;
+        double halfHeight;
+
+        if (useHorizontal)
+        {
+            var step = actionSize.Width + horizontalGap!.Value;
+            offsets = [new ScreenPoint(-step, 0), new ScreenPoint(0, 0), new ScreenPoint(step, 0)];
+            halfWidth = step + (actionSize.Width / 2);
+            halfHeight = actionSize.Height / 2;
+        }
+        else if (canUseVertical)
+        {
+            var step = actionSize.Height + verticalGap.Value;
+            offsets = [new ScreenPoint(0, -step), new ScreenPoint(0, 0), new ScreenPoint(0, step)];
+            halfWidth = actionSize.Width / 2;
+            halfHeight = step + (actionSize.Height / 2);
+        }
+        else
+        {
+            throw new ArgumentException(
+                "Visible bounds cannot contain a non-overlapping three-action menu.",
+                nameof(safeBounds));
+        }
+
+        var center = new ScreenPoint(
+            Math.Clamp(anchor.X, safeBounds.X + halfWidth, safeBounds.Right - halfWidth),
+            Math.Clamp(anchor.Y, safeBounds.Y + halfHeight, safeBounds.Bottom - halfHeight));
+        return (center, CreatePlacements(center, actionSize, offsets));
+    }
+
+    private static double? AvailableGap(double availableLength, double actionLength)
+    {
+        var remaining = availableLength - (actionLength * ActionOrder.Length);
+        return remaining < 0 ? null : Math.Min(LinearGap, remaining / (ActionOrder.Length - 1));
+    }
+
+    private static ImmutableArray<ScreenPoint> CreateRadialOffsets(double radius)
+    {
+        var lowerX = radius * Math.Sqrt(3) / 2;
+        var lowerY = radius / 2;
+        return
+        [
+            new ScreenPoint(0, -radius),
+            new ScreenPoint(lowerX, lowerY),
+            new ScreenPoint(-lowerX, lowerY)
+        ];
+    }
+
+    private static ImmutableArray<RadialMenuActionPlacement> CreatePlacements(
+        ScreenPoint center,
+        ScreenSize actionSize,
+        ImmutableArray<ScreenPoint> offsets)
+    {
+        var placements = ImmutableArray.CreateBuilder<RadialMenuActionPlacement>(ActionOrder.Length);
+        for (var index = 0; index < ActionOrder.Length; index++)
+        {
+            var actionCenter = new ScreenPoint(
+                center.X + offsets[index].X,
+                center.Y + offsets[index].Y);
+            placements.Add(new RadialMenuActionPlacement(
+                ActionOrder[index],
+                new ScreenRect(
+                    actionCenter.X - (actionSize.Width / 2),
+                    actionCenter.Y - (actionSize.Height / 2),
+                    actionSize.Width,
+                    actionSize.Height)));
+        }
+
+        return placements.MoveToImmutable();
+    }
+
+    private static RadialMenuPlacementResult CreateResult(
+        ScreenPoint anchor,
+        ScreenPoint center,
+        ImmutableArray<RadialMenuActionPlacement> actions,
+        RadialMenuLayout layout)
+    {
+        var connector = anchor.DistanceTo(center) > ConnectorEpsilon
+            ? new RadialMenuConnector(anchor, center)
+            : null;
+        return new RadialMenuPlacementResult(anchor, center, actions, layout, connector);
+    }
+
+    private static void Validate(
+        ScreenRect visibleBounds,
+        ScreenPoint anchor,
+        ScreenSize actionSize,
+        double radius,
+        double safeMargin)
+    {
+        if (!IsFinite(visibleBounds.X) ||
+            !IsFinite(visibleBounds.Y) ||
+            !IsFinite(visibleBounds.Width) ||
+            !IsFinite(visibleBounds.Height) ||
+            visibleBounds.Width <= 0 ||
+            visibleBounds.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(visibleBounds));
+        }
+
+        if (!IsFinite(anchor.X) || !IsFinite(anchor.Y))
+        {
+            throw new ArgumentOutOfRangeException(nameof(anchor));
+        }
+
+        if (!IsFinite(actionSize.Width) ||
+            !IsFinite(actionSize.Height) ||
+            actionSize.Width <= 0 ||
+            actionSize.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(actionSize));
+        }
+
+        if (!IsFinite(radius) || radius < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius));
+        }
+
+        if (!IsFinite(safeMargin) ||
+            safeMargin < 0 ||
+            (safeMargin * 2) >= visibleBounds.Width ||
+            (safeMargin * 2) >= visibleBounds.Height)
+        {
+            throw new ArgumentOutOfRangeException(nameof(safeMargin));
+        }
+    }
+
+    private static bool IsFinite(double value) => double.IsFinite(value);
+}

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -304,11 +304,21 @@ public partial class MainViewModel : ViewModelBase
 
     public void SetEndpoints(Coordinate start, Coordinate destination)
     {
-        _interaction.Activate(MapInteractionMode.SetStart);
-        _interaction.HandleMapClick(start);
-        _interaction.Activate(MapInteractionMode.SetDestination);
-        _interaction.HandleMapClick(destination);
+        _interaction.SetStart(start);
+        _interaction.SetDestination(destination);
         NotifyInteractionChanged();
+    }
+
+    public void SetStartAt(Coordinate coordinate)
+    {
+        _interaction.SetStart(coordinate);
+        CompleteEndpointPlacement();
+    }
+
+    public void SetDestinationAt(Coordinate coordinate)
+    {
+        _interaction.SetDestination(coordinate);
+        CompleteEndpointPlacement();
     }
 
     public void DisplayRoutes(IEnumerable<RouteResult> routes)
@@ -329,15 +339,22 @@ public partial class MainViewModel : ViewModelBase
         var coordinate = MapProjection.ToCoordinate(worldPosition);
         if (_interaction.HandleMapClick(coordinate))
         {
-            NotifyInteractionChanged();
-            StatusMessage = Start is not null && Destination is not null
-                ? "Endpoints ready. Choose forecast models and calculate."
-                : "Endpoint placed. Set the remaining endpoint.";
+            CompleteEndpointPlacement();
             return;
         }
 
+        InspectRouteAt(
+            worldPosition,
+            new ScreenPoint(screenPosition.X, screenPosition.Y));
+    }
+
+    public RouteMapSelection? FindRouteAt(
+        MPoint worldPosition,
+        ScreenPoint screenPosition)
+    {
+        ArgumentNullException.ThrowIfNull(worldPosition);
         var viewport = Map.Navigator.Viewport;
-        var hit = RouteHitTester.FindNearest(
+        return RouteHitTester.FindNearest(
             _mapLayers.Routes,
             (RouteResult route) => MapProjection
                 .ToContinuousMapPointsNear(
@@ -349,13 +366,29 @@ public partial class MainViewModel : ViewModelBase
                     return new ScreenPoint(projected.X, projected.Y);
                 })
                 .ToArray(),
-            new ScreenPoint(screenPosition.X, screenPosition.Y),
+            screenPosition,
             RouteHitTolerancePixels,
             RoutePointHitTolerancePixels);
+    }
+
+    public bool CanInspectRouteAt(
+        MPoint worldPosition,
+        ScreenPoint screenPosition) =>
+        FindRouteAt(worldPosition, screenPosition) is not null;
+
+    public bool InspectRouteAt(
+        MPoint worldPosition,
+        ScreenPoint screenPosition,
+        bool focus = true)
+    {
+        var hit = FindRouteAt(worldPosition, screenPosition);
         if (hit is not null)
         {
-            SelectRoutePoint(hit, focus: true);
+            SelectRoutePoint(hit, focus);
+            return true;
         }
+
+        return false;
     }
 
     public void SelectRoutePoint(RouteMapSelection selection, bool focus = true)
@@ -1212,6 +1245,14 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsSettingStart));
         OnPropertyChanged(nameof(IsSettingDestination));
         UpdateForecastAreaSummary();
+    }
+
+    private void CompleteEndpointPlacement()
+    {
+        NotifyInteractionChanged();
+        StatusMessage = Start is not null && Destination is not null
+            ? "Endpoints ready. Choose forecast models and calculate."
+            : "Endpoint placed. Set the remaining endpoint.";
     }
 
     private bool TryGetPassageDuration(out TimeSpan duration, out string? error)

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -14,6 +14,52 @@ public sealed class MainViewModelWorkflowTests
         new(2026, 7, 14, 16, 0, 0, TimeSpan.Zero);
 
     [Fact]
+    public void DirectContextualEndpointAssignmentPreservesInteractionWorkflow()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            new FixedTimeProvider(Now),
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+        var notifications = new HashSet<string>();
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is not null)
+            {
+                notifications.Add(args.PropertyName);
+            }
+        };
+        var start = new Coordinate(34, -64);
+        var destination = new Coordinate(39, -52);
+
+        viewModel.SetDestinationCommand.Execute(null);
+        viewModel.SetStartAt(start);
+
+        Assert.Equal(start, viewModel.Start);
+        Assert.Null(viewModel.Destination);
+        Assert.Equal(MapInteractionMode.Browse, viewModel.InteractionMode);
+        Assert.Equal("Endpoint placed. Set the remaining endpoint.", viewModel.StatusMessage);
+        Assert.Equal("Set both endpoints to estimate the forecast download.", viewModel.ForecastAreaSummary);
+
+        notifications.Clear();
+        viewModel.SetStartCommand.Execute(null);
+        viewModel.SetDestinationAt(destination);
+
+        Assert.Equal(start, viewModel.Start);
+        Assert.Equal(destination, viewModel.Destination);
+        Assert.Equal(MapInteractionMode.Browse, viewModel.InteractionMode);
+        Assert.Equal("Endpoints ready. Choose forecast models and calculate.", viewModel.StatusMessage);
+        Assert.StartsWith("Buffered area ", viewModel.ForecastAreaSummary);
+        Assert.Contains(nameof(MainViewModel.Start), notifications);
+        Assert.Contains(nameof(MainViewModel.Destination), notifications);
+        Assert.Contains(nameof(MainViewModel.StartDisplay), notifications);
+        Assert.Contains(nameof(MainViewModel.DestinationDisplay), notifications);
+        Assert.Contains(nameof(MainViewModel.InteractionMode), notifications);
+        Assert.Contains(nameof(MainViewModel.MapInstruction), notifications);
+    }
+
+    [Fact]
     public void LocalDepartureConversionHandlesUtcAndDstEdgeCases()
     {
         Assert.True(LocalDepartureConverter.TryConvertToUtc(
@@ -628,6 +674,52 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task CapturedPointRouteInspectionUsesOriginalPointAndSharedSelectionPath()
+    {
+        var providers = new[]
+        {
+            new DelegateForecastProvider(
+                ForecastModel.NoaaGfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request))),
+            new DelegateForecastProvider(
+                ForecastModel.EcmwfIfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request)))
+        };
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(
+                request,
+                forecast.Request.Model,
+                midpointLatitudeOffset: forecast.Request.Model == ForecastModel.EcmwfIfs ? 4 : 0)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(providers, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.UseEcmwf = true;
+        await viewModel.CalculateRoutesAsync();
+        var ecmwf = viewModel.SuccessfulRoutes.Single(
+            route => route.Model == ForecastModel.EcmwfIfs);
+        var capturedWorldPoint = MapProjection.ToMapPoint(ecmwf.Points[1].Location);
+        var projected = viewModel.Map.Navigator.Viewport.WorldToScreen(capturedWorldPoint);
+        var capturedScreenPoint = new ScreenPoint(projected.X, projected.Y);
+
+        Assert.True(viewModel.CanInspectRouteAt(capturedWorldPoint, capturedScreenPoint));
+        Assert.False(viewModel.CanInspectRouteAt(
+            capturedWorldPoint,
+            new ScreenPoint(capturedScreenPoint.X + 100, capturedScreenPoint.Y + 100)));
+
+        Assert.True(viewModel.InspectRouteAt(
+            capturedWorldPoint,
+            capturedScreenPoint,
+            focus: false));
+
+        Assert.Same(ecmwf, viewModel.SelectedRoutePoint!.Route);
+        Assert.Equal(1, viewModel.SelectedRoutePoint.PointIndex);
+        Assert.Equal(ecmwf.Points[1].Timestamp, viewModel.SelectedTimelineUtc);
+        Assert.Equal(ForecastModel.EcmwfIfs, viewModel.ActiveWeatherModel);
+        Assert.Contains("ECMWF", viewModel.StatusMessage);
+    }
+
+    [Fact]
     public async Task WeatherRefreshSuppressesStaleSamples()
     {
         var provider = new DelegateForecastProvider(
@@ -735,10 +827,12 @@ public sealed class MainViewModelWorkflowTests
         RouteRequest request,
         ForecastModel model,
         int stepHours = 3,
-        RouteLandAvoidance? landAvoidance = null)
+        RouteLandAvoidance? landAvoidance = null,
+        double midpointLatitudeOffset = 0)
     {
         var midpoint = new Coordinate(
-            (request.Origin.Latitude + request.Destination.Latitude) / 2,
+            ((request.Origin.Latitude + request.Destination.Latitude) / 2) +
+            midpointLatitudeOffset,
             (request.Origin.Longitude + request.Destination.Longitude) / 2);
         var route = new RouteResult(
             request,

--- a/tests/Navtool.App.Tests/MapInteractionStateTests.cs
+++ b/tests/Navtool.App.Tests/MapInteractionStateTests.cs
@@ -39,4 +39,26 @@ public sealed class MapInteractionStateTests
         Assert.Null(state.Start);
         Assert.Null(state.Destination);
     }
+
+    [Fact]
+    public void DirectAssignmentsSetOnlyTheirEndpointAndReturnToBrowse()
+    {
+        var state = new MapInteractionState();
+        var start = new Coordinate(41.2, -70.4);
+        var destination = new Coordinate(36.8, -54.1);
+
+        state.Activate(MapInteractionMode.SetDestination);
+        state.SetStart(start);
+
+        Assert.Equal(start, state.Start);
+        Assert.Null(state.Destination);
+        Assert.Equal(MapInteractionMode.Browse, state.Mode);
+
+        state.Activate(MapInteractionMode.SetStart);
+        state.SetDestination(destination);
+
+        Assert.Equal(start, state.Start);
+        Assert.Equal(destination, state.Destination);
+        Assert.Equal(MapInteractionMode.Browse, state.Mode);
+    }
 }

--- a/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
+++ b/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
@@ -1,0 +1,83 @@
+using Navtool.App.Models;
+using Navtool.App.Services;
+
+namespace Navtool.App.Tests;
+
+public sealed class RadialMenuPlacementTests
+{
+    [Fact]
+    public void ArrangesActionsClockwiseAroundUnchangedAnchor()
+    {
+        var result = RadialMenuPlacement.Calculate(
+            new ScreenRect(0, 0, 500, 400),
+            new ScreenPoint(250, 200),
+            new ScreenSize(80, 40),
+            radius: 80,
+            safeMargin: 12);
+
+        Assert.Equal(RadialMenuLayout.Radial, result.Layout);
+        Assert.Equal(result.Anchor, result.Center);
+        Assert.False(result.NeedsConnector);
+        Assert.Equal(
+            [
+                RadialMenuAction.SetStart,
+                RadialMenuAction.SetDestination,
+                RadialMenuAction.Inspect
+            ],
+            result.Actions.Select(action => action.Action));
+        Assert.True(result.Actions[0].Center.Y < result.Center.Y);
+        Assert.True(result.Actions[1].Center.X > result.Center.X);
+        Assert.True(result.Actions[1].Center.Y > result.Center.Y);
+        Assert.True(result.Actions[2].Center.X < result.Center.X);
+        Assert.True(result.Actions[2].Center.Y > result.Center.Y);
+    }
+
+    [Fact]
+    public void ClampsCenterSoEveryActionStaysInsideSafeBounds()
+    {
+        var visibleBounds = new ScreenRect(100, 50, 400, 300);
+        const double margin = 16;
+        var safeBounds = new ScreenRect(
+            visibleBounds.X + margin,
+            visibleBounds.Y + margin,
+            visibleBounds.Width - (margin * 2),
+            visibleBounds.Height - (margin * 2));
+        var anchor = new ScreenPoint(490, 55);
+
+        var result = RadialMenuPlacement.Calculate(
+            visibleBounds,
+            anchor,
+            new ScreenSize(88, 44),
+            radius: 72,
+            safeMargin: margin);
+
+        Assert.Equal(RadialMenuLayout.Radial, result.Layout);
+        Assert.NotEqual(anchor, result.Center);
+        Assert.True(result.NeedsConnector);
+        Assert.Equal(new RadialMenuConnector(anchor, result.Center), result.Connector);
+        Assert.All(result.Actions, action => Assert.True(safeBounds.Contains(action.Bounds)));
+    }
+
+    [Fact]
+    public void UsesCompactLinearFallbackWhenRadialGeometryCannotFit()
+    {
+        var visibleBounds = new ScreenRect(0, 0, 280, 90);
+        var safeBounds = new ScreenRect(8, 8, 264, 74);
+
+        var result = RadialMenuPlacement.Calculate(
+            visibleBounds,
+            new ScreenPoint(20, 45),
+            new ScreenSize(80, 40),
+            radius: 70,
+            safeMargin: 8);
+
+        Assert.Equal(RadialMenuLayout.Linear, result.Layout);
+        Assert.True(result.NeedsConnector);
+        Assert.All(result.Actions, action => Assert.True(safeBounds.Contains(action.Bounds)));
+        Assert.True(result.Actions[0].Center.X < result.Actions[1].Center.X);
+        Assert.True(result.Actions[1].Center.X < result.Actions[2].Center.X);
+        Assert.All(
+            result.Actions,
+            action => Assert.Equal(result.Center.Y, action.Center.Y, 6));
+    }
+}


### PR DESCRIPTION
## Summary
- add pure radial action placement geometry with safe-bound clamping, connector output, stable clockwise ordering, and compact linear fallback
- add direct start/destination assignment while preserving one-shot interaction behavior and view-model notifications
- expose captured-point route hit testing and inspection through the existing route-selection path
- add focused headless tests for placement, endpoint assignment, and contextual route inspection

## Tests
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --no-restore --filter "FullyQualifiedName~RadialMenuPlacementTests|FullyQualifiedName~MapInteractionStateTests|FullyQualifiedName~MainViewModelWorkflowTests.DirectContextualEndpointAssignmentPreservesInteractionWorkflow|FullyQualifiedName~MainViewModelWorkflowTests.CapturedPointRouteInspectionUsesOriginalPointAndSharedSelectionPath" --logger "console;verbosity=minimal"`
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --no-restore --logger "console;verbosity=minimal"`