### PR TITLE
Fix historical isochrone fill in CI

### DIFF
--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -200,6 +200,7 @@ public sealed class RouteMapLayers
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(ReachabilityColor, HistoricalFrontLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round


### PR DESCRIPTION
New pull requests inherit a failing map rendering test from `main` because Mapsui supplies an opaque white fill when historical isochrone styles leave `Fill` unspecified.

Set `Fill = null` explicitly so historical fronts remain line-only and the shared CI baseline returns to the intended rendering contract.

**Validation**
- Targeted historical-front style test
- Full managed solution test suite