### PR TITLE
Add resizing map drawers and radial input

### DIFF
--- a/src/Navtool.App/Navtool.App.csproj
+++ b/src/Navtool.App/Navtool.App.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\Navtool.Core\Navtool.Core.csproj" />
     <ProjectReference Include="..\Navtool.Infrastructure\Navtool.Infrastructure.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Navtool.App.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -142,7 +142,7 @@ public static class RadialMenuPlacement
         }
         else if (canUseVertical)
         {
-            var step = actionSize.Height + verticalGap.Value;
+            var step = actionSize.Height + verticalGap!.Value;
             offsets = [new ScreenPoint(0, -step), new ScreenPoint(0, 0), new ScreenPoint(0, step)];
             halfWidth = actionSize.Width / 2;
             halfHeight = step + (actionSize.Height / 2);
@@ -207,7 +207,7 @@ public static class RadialMenuPlacement
         ImmutableArray<RadialMenuActionPlacement> actions,
         RadialMenuLayout layout)
     {
-        var connector = anchor.DistanceTo(center) > ConnectorEpsilon
+        RadialMenuConnector? connector = anchor.DistanceTo(center) > ConnectorEpsilon
             ? new RadialMenuConnector(anchor, center)
             : null;
         return new RadialMenuPlacementResult(anchor, center, actions, layout, connector);

--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -133,16 +133,16 @@ public static class RadialMenuPlacement
         double halfWidth;
         double halfHeight;
 
-        if (useHorizontal)
+        if (useHorizontal && horizontalGap is { } horizontalSpacing)
         {
-            var step = actionSize.Width + horizontalGap!.Value;
+            var step = actionSize.Width + horizontalSpacing;
             offsets = [new ScreenPoint(-step, 0), new ScreenPoint(0, 0), new ScreenPoint(step, 0)];
             halfWidth = step + (actionSize.Width / 2);
             halfHeight = actionSize.Height / 2;
         }
-        else if (canUseVertical)
+        else if (canUseVertical && verticalGap is { } verticalSpacing)
         {
-            var step = actionSize.Height + verticalGap!.Value;
+            var step = actionSize.Height + verticalSpacing;
             offsets = [new ScreenPoint(0, -step), new ScreenPoint(0, 0), new ScreenPoint(0, step)];
             halfWidth = actionSize.Width / 2;
             halfHeight = step + (actionSize.Height / 2);

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -200,6 +200,7 @@ public sealed class RouteMapLayers
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(ReachabilityColor, HistoricalFrontLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round
@@ -213,6 +214,7 @@ public sealed class RouteMapLayers
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(ReachabilityColor, DestinationFrontLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round
@@ -226,6 +228,7 @@ public sealed class RouteMapLayers
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(color, 2.5)
                 {
                     PenStrokeCap = PenStrokeCap.Round

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -34,11 +34,14 @@
         <Setter Property="BorderBrush" Value="{DynamicResource OverlayBorderColor}" />
         <Setter Property="BorderThickness" Value="1" />
     </Style>
+    <Style Selector="Button">
+        <Setter Property="MinHeight" Value="44" />
+    </Style>
     <Style Selector="Button.primary">
         <Setter Property="Background" Value="{DynamicResource AccentColor}" />
         <Setter Property="Foreground" Value="{DynamicResource AccentTextColor}" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="MinHeight" Value="38" />
+        <Setter Property="MinHeight" Value="44" />
     </Style>
     <Style Selector="Button.primary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource AccentHoverColor}" />
@@ -57,7 +60,7 @@
         <Setter Property="BorderThickness" Value="2" />
     </Style>
     <Style Selector="ToggleButton.map-tool">
-        <Setter Property="MinHeight" Value="38" />
+        <Setter Property="MinHeight" Value="44" />
         <Setter Property="HorizontalContentAlignment" Value="Left" />
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
@@ -86,10 +89,53 @@
         <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
         <Setter Property="BorderThickness" Value="2" />
     </Style>
+    <Style Selector="ToggleButton.edge-handle">
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="0" />
+    </Style>
+    <Style Selector="ToggleButton.edge-handle:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlHoverColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="ToggleButton.edge-handle:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlPressedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="ToggleButton.edge-handle:focus-visible /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
+        <Setter Property="BorderThickness" Value="2" />
+    </Style>
+    <Style Selector="Button.radial-action">
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource AccentColor}" />
+        <Setter Property="BorderThickness" Value="2" />
+        <Setter Property="CornerRadius" Value="24" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="10,0" />
+    </Style>
+    <Style Selector="Button.radial-action:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlHoverColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="Button.radial-action:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlPressedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="Button.radial-action:focus-visible /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
+        <Setter Property="BorderThickness" Value="3" />
+    </Style>
     <Style Selector="ComboBox.theme-picker">
         <Setter Property="MinWidth" Value="128" />
-        <Setter Property="Foreground" Value="{DynamicResource HeaderTextColor}" />
-        <Setter Property="Background" Value="{DynamicResource HeaderBadgeBackgroundColor}" />
+        <Setter Property="MinHeight" Value="44" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
     </Style>
     <Style Selector="ComboBox.theme-picker:pointerover /template/ Border#Background">

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -237,6 +237,12 @@ public partial class MainViewModel : ViewModelBase
 
     public bool IsSettingDestination => InteractionMode == MapInteractionMode.SetDestination;
 
+    public bool IsEndpointPlacementArmed => InteractionMode != MapInteractionMode.Browse;
+
+    public bool HasWarning => !string.IsNullOrWhiteSpace(WarningMessage);
+
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+
     public string LocalGribDisplay => LocalForecast is null
         ? "No file selected"
         : $"{Path.GetFileName(LocalForecast.Artifact.Path)} · {ModelName(LocalForecast.Model)}\n" +
@@ -301,6 +307,12 @@ public partial class MainViewModel : ViewModelBase
     public int SuccessfulRouteCount => _mapLayers.Routes.Count;
 
     public IReadOnlyList<RouteResult> SuccessfulRoutes => _mapLayers.Routes;
+
+    partial void OnWarningMessageChanged(string? value) =>
+        OnPropertyChanged(nameof(HasWarning));
+
+    partial void OnErrorMessageChanged(string? value) =>
+        OnPropertyChanged(nameof(HasError));
 
     public void SetEndpoints(Coordinate start, Coordinate destination)
     {
@@ -1244,6 +1256,7 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(MapInstruction));
         OnPropertyChanged(nameof(IsSettingStart));
         OnPropertyChanged(nameof(IsSettingDestination));
+        OnPropertyChanged(nameof(IsEndpointPlacementArmed));
         UpdateForecastAreaSummary();
     }
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -21,84 +21,51 @@
         <vm:MainViewModel />
     </Design.DataContext>
 
-    <Grid RowDefinitions="58,*">
-        <Border Grid.Row="0"
-                Background="{DynamicResource HeaderBackgroundColor}"
-                Padding="20,0">
-            <Grid ColumnDefinitions="Auto,*,Auto">
-                <StackPanel VerticalAlignment="Center"
-                            Spacing="1">
-                    <TextBlock Text="NAVTOOL"
-                               Foreground="{DynamicResource HeaderTextColor}"
-                               FontSize="18"
-                               FontWeight="Bold"
-                               LetterSpacing="1.5" />
-                    <TextBlock Text="OFFSHORE WEATHER ROUTING"
-                               Foreground="{DynamicResource HeaderMutedTextColor}"
-                               FontSize="9"
-                               LetterSpacing="0.8" />
-                </StackPanel>
-                <StackPanel Grid.Column="2"
-                            Orientation="Horizontal"
-                            Spacing="8"
-                            VerticalAlignment="Center">
-                    <StackPanel Orientation="Horizontal"
-                               Spacing="6"
-                               VerticalAlignment="Center">
-                        <TextBlock Text="THEME"
-                                  Foreground="{DynamicResource HeaderMutedTextColor}"
-                                  FontSize="10"
-                                  FontWeight="SemiBold"
-                                  VerticalAlignment="Center" />
-                        <ComboBox x:Name="ThemeSelector"
-                                 Classes="theme-picker" />
-                    </StackPanel>
-                    <Border Background="{DynamicResource DangerBackgroundColor}"
-                            CornerRadius="12"
-                            Padding="10,5">
-                        <TextBlock Text="NOT NAVIGATION CERTIFIED"
-                                  Foreground="{DynamicResource DangerSoftColor}"
-                                   FontSize="10"
-                                   FontWeight="Bold" />
-                    </Border>
-                    <Border Background="{DynamicResource HeaderBadgeBackgroundColor}"
-                            CornerRadius="12"
-                            Padding="10,5">
-                        <TextBlock Text="Route planning workspace"
-                                   Foreground="{DynamicResource HeaderBadgeTextColor}"
-                                   FontSize="11" />
-                    </Border>
-                </StackPanel>
-            </Grid>
-        </Border>
+    <Grid x:Name="ShellGrid">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="44" />
+            <ColumnDefinition Width="*" MinWidth="560" />
+            <ColumnDefinition Width="44" />
+        </Grid.ColumnDefinitions>
 
-        <Grid Grid.Row="1"
-              ColumnDefinitions="350,*">
-            <Border Grid.Column="0"
+        <Grid x:Name="PlanningDrawer"
+              Grid.Column="0"
+              Background="{DynamicResource SidebarBackgroundColor}">
+            <Border x:Name="PlanningDrawerContent"
                     Background="{DynamicResource SidebarBackgroundColor}"
                     BorderBrush="{DynamicResource BorderColor}"
-                    BorderThickness="0,0,1,0">
+                    BorderThickness="0,0,1,0"
+                    Padding="0,0,44,0"
+                    IsVisible="False">
                 <ScrollViewer>
-                    <StackPanel Margin="16"
-                                Spacing="14">
-                        <StackPanel Spacing="4">
-                            <TextBlock Text="Plan a passage"
-                                       FontSize="22"
-                                       FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextPrimaryColor}" />
-                            <TextBlock Classes="muted"
-                                       Text="Choose endpoints, departure, and forecast models." />
-                        </StackPanel>
+                    <StackPanel Margin="14"
+                                Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <StackPanel Spacing="2">
+                                <TextBlock Text="Plan a passage"
+                                           FontSize="20"
+                                           FontWeight="SemiBold" />
+                                <TextBlock Classes="muted"
+                                           Text="Endpoints, timing, and forecast inputs." />
+                            </StackPanel>
+                            <TextBlock Grid.Column="1"
+                                       Text="NAVTOOL"
+                                       FontSize="10"
+                                       FontWeight="Bold"
+                                       Foreground="{DynamicResource TextSecondaryColor}"
+                                       VerticalAlignment="Center" />
+                        </Grid>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="10">
+                            <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
-                                           Text="1  ROUTE ENDPOINTS" />
+                                           Text="ROUTE ENDPOINTS" />
                                 <ToggleButton x:Name="SetStartButton"
                                               Classes="map-tool"
                                               IsChecked="{Binding IsSettingStart, Mode=OneWay}"
-                                              Command="{Binding SetStartCommand}">
-                                    <Grid ColumnDefinitions="14,10,*">
+                                              Command="{Binding SetStartCommand}"
+                                              ToolTip.Tip="Arm start placement, then select the map">
+                                    <Grid ColumnDefinitions="14,9,*">
                                         <Ellipse Width="12"
                                                  Height="12"
                                                  Fill="#009E73"
@@ -115,8 +82,9 @@
                                 <ToggleButton x:Name="SetDestinationButton"
                                               Classes="map-tool"
                                               IsChecked="{Binding IsSettingDestination, Mode=OneWay}"
-                                              Command="{Binding SetDestinationCommand}">
-                                    <Grid ColumnDefinitions="14,10,*">
+                                              Command="{Binding SetDestinationCommand}"
+                                              ToolTip.Tip="Arm destination placement, then select the map">
+                                    <Grid ColumnDefinitions="14,9,*">
                                         <Ellipse Width="12"
                                                  Height="12"
                                                  Fill="#CC3311"
@@ -134,21 +102,18 @@
                         </Border>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="10">
+                            <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
-                                           Text="2  LOCAL DEPARTURE" />
-                                <Grid ColumnDefinitions="*,110"
-                                      ColumnSpacing="8">
+                                           Text="DEPARTURE &amp; DURATION" />
+                                <Grid ColumnDefinitions="*,104"
+                                      ColumnSpacing="7">
                                     <DatePicker SelectedDate="{Binding DepartureDate}" />
                                     <TimePicker Grid.Column="1"
                                                 SelectedTime="{Binding DepartureTime}"
                                                 ClockIdentifier="24HourClock" />
                                 </Grid>
-                                <TextBlock Text="Expected passage duration"
-                                           FontWeight="SemiBold"
-                                           Margin="0,4,0,0" />
                                 <Grid ColumnDefinitions="*,*"
-                                      ColumnSpacing="8">
+                                      ColumnSpacing="7">
                                     <StackPanel Spacing="3">
                                         <TextBlock Text="Days"
                                                    Classes="muted" />
@@ -188,58 +153,37 @@
                         <Border Classes="card">
                             <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
-                                           Text="3  FORECAST SOURCE" />
-                                <StackPanel Orientation="Horizontal"
-                                            Spacing="14">
-                                    <RadioButton x:Name="DownloadForecastSource"
-                                                 GroupName="ForecastSource"
-                                                 Content="Download forecast"
-                                                 IsChecked="{Binding IsDownloadForecast, Mode=OneWay}"
-                                                 Command="{Binding SelectDownloadSourceCommand}" />
-                                    <RadioButton x:Name="LocalForecastSource"
-                                                 GroupName="ForecastSource"
-                                                 Content="Existing GRIB file"
-                                                 IsChecked="{Binding IsLocalForecast, Mode=OneWay}"
-                                                 Command="{Binding SelectLocalFileSourceCommand}" />
-                                </StackPanel>
+                                           Text="FORECAST SOURCE" />
+                                <RadioButton x:Name="DownloadForecastSource"
+                                             GroupName="ForecastSource"
+                                             Content="Download forecast"
+                                             IsChecked="{Binding IsDownloadForecast, Mode=OneWay}"
+                                             Command="{Binding SelectDownloadSourceCommand}" />
+                                <RadioButton x:Name="LocalForecastSource"
+                                             GroupName="ForecastSource"
+                                             Content="Existing GRIB file"
+                                             IsChecked="{Binding IsLocalForecast, Mode=OneWay}"
+                                             Command="{Binding SelectLocalFileSourceCommand}" />
                                 <StackPanel IsVisible="{Binding IsDownloadForecast}"
                                             Spacing="7">
                                     <CheckBox IsChecked="{Binding UseNoaa}">
                                         <StackPanel>
                                             <TextBlock Text="NOAA GFS"
                                                        FontWeight="SemiBold" />
-                                            <TextBlock Text="Global Forecast System"
-                                                       Classes="muted" />
+                                            <TextBlock Text="{Binding NoaaStatus}"
+                                                       Classes="muted"
+                                                       TextWrapping="Wrap" />
                                         </StackPanel>
                                     </CheckBox>
-                                    <TextBlock Text="{Binding NoaaStatus}"
-                                           Classes="muted"
-                                           Margin="24,0,0,2"
-                                           TextWrapping="Wrap" />
                                     <CheckBox IsChecked="{Binding UseEcmwf}">
-                                        <Grid ColumnDefinitions="*,Auto">
-                                            <StackPanel>
-                                                <TextBlock Text="ECMWF IFS"
-                                                           FontWeight="SemiBold" />
-                                                <TextBlock Text="European model"
-                                                           Classes="muted" />
-                                            </StackPanel>
-                                            <Border Grid.Column="1"
-                                                    Background="{DynamicResource ExperimentalBackgroundColor}"
-                                                    CornerRadius="10"
-                                                    Padding="7,3"
-                                                    VerticalAlignment="Center">
-                                                <TextBlock Text="EXPERIMENTAL"
-                                                           Foreground="{DynamicResource ExperimentalTextColor}"
-                                                           FontSize="9"
-                                                           FontWeight="Bold" />
-                                            </Border>
-                                        </Grid>
+                                        <StackPanel>
+                                            <TextBlock Text="ECMWF IFS · EXPERIMENTAL"
+                                                       FontWeight="SemiBold" />
+                                            <TextBlock Text="{Binding EcmwfStatus}"
+                                                       Classes="muted"
+                                                       TextWrapping="Wrap" />
+                                        </StackPanel>
                                     </CheckBox>
-                                    <TextBlock Text="{Binding EcmwfStatus}"
-                                           Classes="muted"
-                                           Margin="24,0,0,0"
-                                           TextWrapping="Wrap" />
                                 </StackPanel>
                                 <StackPanel IsVisible="{Binding IsLocalForecast}"
                                             Spacing="7">
@@ -248,16 +192,16 @@
                                             IsEnabled="{Binding !IsInspectingLocalGrib}"
                                             Content="Choose GRIB file..." />
                                     <TextBlock Text="{Binding LocalGribDisplay}"
-                                           FontWeight="SemiBold"
-                                           TextWrapping="Wrap" />
+                                               FontWeight="SemiBold"
+                                               TextWrapping="Wrap" />
                                     <TextBlock Text="{Binding LocalGribStatus}"
-                                           Classes="muted"
-                                           TextWrapping="Wrap" />
+                                               Classes="muted"
+                                               TextWrapping="Wrap" />
                                 </StackPanel>
                                 <Border Classes="subtle">
                                     <TextBlock Text="{Binding ForecastAreaSummary}"
-                                           Classes="muted"
-                                           TextWrapping="Wrap" />
+                                               Classes="muted"
+                                               TextWrapping="Wrap" />
                                 </Border>
                             </StackPanel>
                         </Border>
@@ -272,7 +216,7 @@
                                     Grid.Column="1"
                                     Command="{Binding CancelCommand}"
                                     Content="Cancel"
-                                    MinWidth="76" />
+                                    MinWidth="72" />
                         </Grid>
 
                         <Border Classes="card">
@@ -293,7 +237,7 @@
                                            Classes="muted" />
                                 <TextBlock Text="{Binding WarningMessage}"
                                            TextWrapping="Wrap"
-                                           Foreground="#D97706"
+                                           Foreground="{DynamicResource WarningTextColor}"
                                            FontSize="12"
                                            FontWeight="SemiBold" />
                                 <TextBlock Text="{Binding ErrorMessage}"
@@ -306,58 +250,245 @@
                                            FontWeight="SemiBold" />
                             </StackPanel>
                         </Border>
+
                         <Border Background="{DynamicResource WarningBackgroundColor}"
                                 BorderBrush="{DynamicResource WarningBorderColor}"
                                 BorderThickness="1"
                                 CornerRadius="7"
                                 Padding="10,8">
-                            <TextBlock Text="Planning aid only. Verify all weather and routing information independently; not certified for navigation."
+                            <TextBlock Text="Planning aid only. Verify weather and routing information independently; not certified for navigation."
                                        TextWrapping="Wrap"
                                        Foreground="{DynamicResource WarningTextColor}"
                                        FontSize="11"
                                        FontWeight="SemiBold" />
                         </Border>
+
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="section-title"
+                                       Text="COLOR SCHEME" />
+                            <ComboBox x:Name="ThemeSelector"
+                                      Classes="theme-picker" />
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </Border>
 
-            <Grid Grid.Column="1"
-                  RowDefinitions="*,176">
-                <Border Grid.Row="0"
-                        Margin="14,14,14,8"
-                        BorderBrush="{DynamicResource StrongBorderColor}"
-                        BorderThickness="1"
-                        CornerRadius="9"
-                        ClipToBounds="True">
-                    <Grid>
-                        <mapsui:MapControl x:Name="MapView"
-                                           Map="{Binding Map}"
-                                           UseContinuousMouseWheelZoom="True" />
+            <ToggleButton x:Name="PlanningDrawerHandle"
+                          Classes="edge-handle"
+                          Width="44"
+                          MinHeight="44"
+                          HorizontalAlignment="Right"
+                          VerticalAlignment="Stretch"
+                          Click="OnPlanningDrawerClicked"
+                          ToolTip.Tip="Open or close passage planning"
+                          AutomationProperties.Name="Passage planning drawer"
+                          Content="›" />
+        </Grid>
 
-                        <Border HorizontalAlignment="Center"
-                                VerticalAlignment="Top"
-                                Margin="16"
-                                Classes="map-overlay"
-                                CornerRadius="16"
-                                Padding="14,7">
-                            <TextBlock Text="{Binding MapInstruction}"
-                                       Foreground="{DynamicResource TextPrimaryColor}"
-                                       FontSize="12"
+        <Grid Grid.Column="1"
+              x:Name="MapShell"
+              MinWidth="560"
+              Background="{DynamicResource WindowBackgroundColor}">
+            <mapsui:MapControl x:Name="MapView"
+                               Map="{Binding Map}"
+                               Focusable="True"
+                               UseContinuousMouseWheelZoom="True"
+                               AutomationProperties.Name="Route planning map" />
+
+            <Border HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Margin="14"
+                    Classes="map-overlay"
+                    CornerRadius="6"
+                    Padding="10,7"
+                    IsHitTestVisible="False">
+                <StackPanel Spacing="0">
+                    <TextBlock Text="NAVTOOL"
+                               FontSize="12"
+                               FontWeight="Bold"
+                               LetterSpacing="1.2" />
+                    <TextBlock Text="WEATHER ROUTING"
+                               Classes="muted"
+                               FontSize="8" />
+                </StackPanel>
+            </Border>
+
+            <Border x:Name="InstrumentRail"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Margin="14"
+                    MaxWidth="720"
+                    Classes="map-overlay"
+                    CornerRadius="18"
+                    Padding="14,7"
+                    IsHitTestVisible="False">
+                <StackPanel Orientation="Horizontal"
+                            Spacing="11">
+                    <TextBlock Text="{Binding SelectedRouteTitle}"
+                               FontWeight="SemiBold"
+                               FontSize="11"
+                               MaxWidth="150"
+                               TextTrimming="CharacterEllipsis" />
+                    <Border Width="1"
+                            Background="{DynamicResource OverlayBorderColor}" />
+                    <TextBlock Text="{Binding StatusMessage}"
+                               Classes="muted"
+                               FontSize="11"
+                               MaxWidth="210"
+                               TextTrimming="CharacterEllipsis" />
+                    <Border Width="1"
+                            Background="{DynamicResource OverlayBorderColor}" />
+                    <TextBlock Text="{Binding ActiveWeatherDisplay}"
+                               Classes="muted"
+                               FontSize="11"
+                               MaxWidth="140"
+                               TextTrimming="CharacterEllipsis" />
+                    <TextBlock Text="{Binding TimelineDisplay}"
+                               Classes="muted"
+                               FontSize="11"
+                               MaxWidth="160"
+                               TextTrimming="CharacterEllipsis" />
+                    <TextBlock Text="!"
+                               Foreground="{DynamicResource WarningTextColor}"
+                               FontWeight="Bold"
+                               IsVisible="{Binding HasWarning}"
+                               ToolTip.Tip="{Binding WarningMessage}" />
+                    <TextBlock Text="!"
+                               Foreground="{DynamicResource DangerTextColor}"
+                               FontWeight="Bold"
+                               IsVisible="{Binding HasError}"
+                               ToolTip.Tip="{Binding ErrorMessage}" />
+                </StackPanel>
+            </Border>
+
+            <Border HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Margin="14,60,14,0"
+                    Classes="map-overlay"
+                    CornerRadius="14"
+                    Padding="12,7"
+                    IsVisible="{Binding IsEndpointPlacementArmed}"
+                    IsHitTestVisible="False">
+                <TextBlock Text="{Binding MapInstruction}"
+                           FontSize="12"
+                           FontWeight="SemiBold" />
+            </Border>
+
+            <Canvas x:Name="RadialMenuLayer"
+                    IsVisible="False">
+                <Line x:Name="RadialConnector"
+                      IsVisible="False"
+                      Stroke="{DynamicResource FocusColor}"
+                      StrokeThickness="2"
+                      IsHitTestVisible="False" />
+                <Ellipse x:Name="RadialAnchor"
+                         Width="10"
+                         Height="10"
+                         IsVisible="False"
+                         Fill="{DynamicResource AccentColor}"
+                         Stroke="{DynamicResource MarkerOutlineColor}"
+                         StrokeThickness="2"
+                         IsHitTestVisible="False" />
+                <Button x:Name="SetStartRadialButton"
+                        Classes="radial-action"
+                        Click="OnSetStartRadialClicked"
+                        ToolTip.Tip="Set passage start at this map point"
+                        AutomationProperties.Name="Set start here"
+                        Content="Set start" />
+                <Button x:Name="SetDestinationRadialButton"
+                        Classes="radial-action"
+                        Click="OnSetDestinationRadialClicked"
+                        ToolTip.Tip="Set passage destination at this map point"
+                        AutomationProperties.Name="Set destination here"
+                        Content="Set destination" />
+                <Button x:Name="InspectRadialButton"
+                        Classes="radial-action"
+                        Click="OnInspectRadialClicked"
+                        ToolTip.Tip="Inspect the captured route point"
+                        AutomationProperties.Name="Inspect route point"
+                        Content="Inspect" />
+            </Canvas>
+        </Grid>
+
+        <Grid x:Name="RouteDrawer"
+              Grid.Column="2"
+              Background="{DynamicResource SidebarBackgroundColor}">
+            <Border x:Name="RouteDrawerContent"
+                    Background="{DynamicResource SidebarBackgroundColor}"
+                    BorderBrush="{DynamicResource BorderColor}"
+                    BorderThickness="1,0,0,0"
+                    Padding="44,0,0,0"
+                    IsVisible="False">
+                <ScrollViewer>
+                    <StackPanel Margin="14"
+                                Spacing="12">
+                        <StackPanel Spacing="2">
+                            <TextBlock Text="Route &amp; weather"
+                                       FontSize="20"
                                        FontWeight="SemiBold" />
+                            <TextBlock Classes="muted"
+                                       Text="Selected point and shared UTC timeline." />
+                        </StackPanel>
+
+                        <Border Classes="card">
+                            <StackPanel Spacing="9">
+                                <TextBlock Text="{Binding SelectedRouteTitle}"
+                                           FontSize="16"
+                                           FontWeight="SemiBold" />
+                                <TextBlock Text="{Binding SelectedRouteDetails}"
+                                           Classes="muted"
+                                           TextWrapping="Wrap" />
+                                <Button Command="{Binding FocusSelectedRoutePointCommand}"
+                                        Content="Focus on map"
+                                        HorizontalAlignment="Stretch"
+                                        ToolTip.Tip="Center the selected route point" />
+                            </StackPanel>
                         </Border>
 
-                        <Border HorizontalAlignment="Left"
-                                VerticalAlignment="Bottom"
-                                Margin="14"
-                                Classes="map-overlay"
-                                CornerRadius="7"
-                                Padding="11,9">
-                            <StackPanel Spacing="6">
-                                <TextBlock Text="ROUTES"
-                                           Classes="section-title" />
+                        <Border Classes="card">
+                            <StackPanel Spacing="9">
+                                <TextBlock Classes="section-title"
+                                           Text="TIMELINE" />
+                                <Grid ColumnDefinitions="44,44,*,Auto"
+                                      ColumnSpacing="7">
+                                    <Button x:Name="PreviousTimelineButton"
+                                            Content="◀"
+                                            ToolTip.Tip="Previous point"
+                                            AutomationProperties.Name="Previous timeline point"
+                                            Command="{Binding PreviousTimelineCommand}"
+                                            MinWidth="44" />
+                                    <Button x:Name="NextTimelineButton"
+                                            Grid.Column="1"
+                                            Content="▶"
+                                            ToolTip.Tip="Next point"
+                                            AutomationProperties.Name="Next timeline point"
+                                            Command="{Binding NextTimelineCommand}"
+                                            MinWidth="44" />
+                                    <Slider x:Name="TimelineSlider"
+                                            Grid.Column="2"
+                                            Minimum="0"
+                                            Maximum="1"
+                                            Value="{Binding TimelinePosition}"
+                                            IsEnabled="{Binding HasTimeline}"
+                                            VerticalAlignment="Center" />
+                                    <TextBlock Grid.Column="3"
+                                               Text="{Binding TimelineDisplay}"
+                                               Classes="muted"
+                                               VerticalAlignment="Center"
+                                               MaxWidth="92"
+                                               TextWrapping="Wrap" />
+                                </Grid>
+                            </StackPanel>
+                        </Border>
+
+                        <Expander x:Name="RouteDetailsExpander"
+                                  Header="Route legend"
+                                  IsExpanded="False">
+                            <Border Classes="card"
+                                    Margin="0,7,0,0">
                                 <Grid ColumnDefinitions="24,*"
                                       RowDefinitions="Auto,Auto,Auto,Auto,Auto"
-                                      RowSpacing="5">
+                                      RowSpacing="7">
                                     <Border Width="20"
                                             Height="4"
                                             Background="#0072B2"
@@ -412,106 +543,74 @@
                                                Text="Latest provisional route"
                                                FontSize="11" />
                                 </Grid>
-                            </StackPanel>
-                        </Border>
+                            </Border>
+                        </Expander>
 
-                        <Border HorizontalAlignment="Right"
-                                VerticalAlignment="Top"
-                                Margin="14"
-                                Classes="map-overlay"
-                                CornerRadius="7"
-                                Padding="11,9">
-                            <StackPanel Spacing="6">
-                                <TextBlock Text="WIND OVERLAY"
-                                           Classes="section-title" />
-                                <StackPanel Orientation="Horizontal"
-                                            Spacing="8">
-                                    <RadioButton Content="NOAA GFS"
-                                                 Command="{Binding ActivateNoaaWeatherCommand}"
-                                                 IsChecked="{Binding IsNoaaWeatherActive, Mode=OneWay}"
-                                                 IsVisible="{Binding HasNoaaWeather}" />
-                                    <RadioButton Content="ECMWF experimental"
-                                                 Command="{Binding ActivateEcmwfWeatherCommand}"
-                                                 IsChecked="{Binding IsEcmwfWeatherActive, Mode=OneWay}"
-                                                 IsVisible="{Binding HasEcmwfWeather}" />
+                        <Expander x:Name="WeatherDetailsExpander"
+                                  Header="Weather overlay"
+                                  IsExpanded="False">
+                            <Border Classes="card"
+                                    Margin="0,7,0,0">
+                                <StackPanel Spacing="8">
+                                    <StackPanel Spacing="5">
+                                        <RadioButton Content="NOAA GFS"
+                                                     Command="{Binding ActivateNoaaWeatherCommand}"
+                                                     IsChecked="{Binding IsNoaaWeatherActive, Mode=OneWay}"
+                                                     IsVisible="{Binding HasNoaaWeather}" />
+                                        <RadioButton Content="ECMWF experimental"
+                                                     Command="{Binding ActivateEcmwfWeatherCommand}"
+                                                     IsChecked="{Binding IsEcmwfWeatherActive, Mode=OneWay}"
+                                                     IsVisible="{Binding HasEcmwfWeather}" />
+                                    </StackPanel>
+                                    <TextBlock Text="{Binding ActiveWeatherDisplay}"
+                                               Classes="muted" />
+                                    <StackPanel Orientation="Horizontal"
+                                                Spacing="3">
+                                        <Border Width="19" Height="8" Background="#5BC0EB" />
+                                        <Border Width="19" Height="8" Background="#00A6A6" />
+                                        <Border Width="19" Height="8" Background="#7FB800" />
+                                        <Border Width="19" Height="8" Background="#F4D35E" />
+                                        <Border Width="19" Height="8" Background="#E4572E" />
+                                        <Border Width="19" Height="8" Background="#9B2C67" />
+                                    </StackPanel>
+                                    <TextBlock Text="0   5   10   15   25   35+ knots"
+                                               FontSize="10"
+                                               Foreground="{DynamicResource TextSecondaryColor}" />
+                                    <TextBlock Text="{Binding WeatherLayerError}"
+                                               TextWrapping="Wrap"
+                                               Classes="error"
+                                               FontSize="11" />
                                 </StackPanel>
-                                <TextBlock Text="{Binding ActiveWeatherDisplay}"
-                                           Classes="muted" />
-                                <StackPanel Orientation="Horizontal"
-                                            Spacing="3">
-                                    <Border Width="19" Height="8" Background="#5BC0EB" />
-                                    <Border Width="19" Height="8" Background="#00A6A6" />
-                                    <Border Width="19" Height="8" Background="#7FB800" />
-                                    <Border Width="19" Height="8" Background="#F4D35E" />
-                                    <Border Width="19" Height="8" Background="#E4572E" />
-                                    <Border Width="19" Height="8" Background="#9B2C67" />
-                                </StackPanel>
-                                <TextBlock Text="0   5   10   15   25   35+ knots"
-                                           FontSize="10"
-                                           Foreground="{DynamicResource TextSecondaryColor}" />
-                                <TextBlock Text="{Binding WeatherLayerError}"
+                            </Border>
+                        </Expander>
+
+                        <Border Classes="subtle">
+                            <StackPanel Spacing="5">
+                                <TextBlock Text="{Binding StatusMessage}"
                                            TextWrapping="Wrap"
-                                           MaxWidth="280"
-                                           Classes="error"
-                                           FontSize="11" />
+                                           Classes="muted" />
+                                <TextBlock Text="{Binding WarningMessage}"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource WarningTextColor}" />
+                                <TextBlock Text="{Binding ErrorMessage}"
+                                           TextWrapping="Wrap"
+                                           Classes="error" />
                             </StackPanel>
                         </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </Border>
 
-                    </Grid>
-                </Border>
-
-                <Border Grid.Row="1"
-                        Margin="14,0,14,14"
-                        Classes="card">
-                    <Grid RowDefinitions="Auto,*"
-                          ColumnDefinitions="*,Auto">
-                        <StackPanel Spacing="3">
-                            <TextBlock Text="{Binding SelectedRouteTitle}"
-                                       FontSize="15"
-                                       FontWeight="SemiBold"
-                                       Foreground="{DynamicResource TextPrimaryColor}" />
-                            <TextBlock Text="{Binding SelectedRouteDetails}"
-                                       Classes="muted"
-                                       TextWrapping="Wrap" />
-                        </StackPanel>
-                        <Button Grid.Column="1"
-                                Command="{Binding FocusSelectedRoutePointCommand}"
-                                Content="Focus on map"
-                                Padding="12,6" />
-
-                        <Grid Grid.Row="1"
-                              Grid.ColumnSpan="2"
-                              Margin="0,14,0,0"
-                              ColumnDefinitions="Auto,Auto,Auto,*,Auto"
-                              ColumnSpacing="8">
-                            <Button Content="◀"
-                                    ToolTip.Tip="Previous point"
-                                    Command="{Binding PreviousTimelineCommand}"
-                                    MinWidth="38" />
-                            <Button Grid.Column="1"
-                                    Content="●"
-                                    ToolTip.Tip="Selected shared UTC time"
-                                    IsEnabled="{Binding HasTimeline}"
-                                    MinWidth="38" />
-                            <Button Grid.Column="2"
-                                    Content="▶|"
-                                    ToolTip.Tip="Next point"
-                                    Command="{Binding NextTimelineCommand}"
-                                    MinWidth="38" />
-                            <Slider Grid.Column="3"
-                                    Minimum="0"
-                                    Maximum="1"
-                                    Value="{Binding TimelinePosition}"
-                                    IsEnabled="{Binding HasTimeline}"
-                                    VerticalAlignment="Center" />
-                            <TextBlock Grid.Column="4"
-                                       Text="{Binding TimelineDisplay}"
-                                       Classes="muted"
-                                       VerticalAlignment="Center" />
-                        </Grid>
-                    </Grid>
-                </Border>
-            </Grid>
+            <ToggleButton x:Name="RouteDrawerHandle"
+                          Classes="edge-handle"
+                          Width="44"
+                          MinHeight="44"
+                          HorizontalAlignment="Left"
+                          VerticalAlignment="Stretch"
+                          Click="OnRouteDrawerClicked"
+                          ToolTip.Tip="Open or close route and weather details"
+                          AutomationProperties.Name="Route and weather drawer"
+                          Content="‹" />
         </Grid>
     </Grid>
 </Window>

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -293,7 +293,7 @@ public partial class MainWindow : Window
             screenPosition);
     }
 
-    private void OpenRadialMenu(MPoint worldPoint, ScreenPoint screenPoint)
+    internal void OpenRadialMenu(MPoint worldPoint, ScreenPoint screenPoint)
     {
         if (_mapControl is null ||
             _radialMenuLayer is null ||
@@ -309,6 +309,7 @@ public partial class MainWindow : Window
             return;
         }
 
+        _lastPointerPosition = screenPoint;
         _capturedWorldPoint = worldPoint;
         _capturedRouteSelection = viewModel.FindRouteAt(worldPoint, screenPoint);
         _inspectRadialButton.IsEnabled = _capturedRouteSelection is not null;

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -1,16 +1,41 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Shapes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Mapsui;
+using Mapsui.Extensions;
+using Mapsui.Manipulations;
 using Mapsui.UI.Avalonia;
 using Navtool.App.Models;
 using Navtool.App.Services;
 using Navtool.App.ViewModels;
+using Navtool.Infrastructure;
 
 namespace Navtool.App.Views;
 
 public partial class MainWindow : Window
 {
+    private enum DrawerSide
+    {
+        Planning,
+        Route
+    }
+
+    internal const double DrawerBreakpoint = 1220;
+    internal const double ClosedDrawerWidth = 44;
+    internal const double PlanningDrawerWidth = 320;
+    internal const double RouteDrawerWidth = 340;
+
+    private const double RadialActionWidth = 112;
+    private const double RadialActionHeight = 48;
+    private const double RadialRadius = 82;
+    private const double RadialSafeMargin = 16;
     private static AppThemeService? _defaultThemeService;
     private static readonly FilePickerFileType GribFileType = new("GRIB forecasts")
     {
@@ -20,6 +45,23 @@ public partial class MainWindow : Window
 
     private readonly AppThemeService _themeService;
     private Navigator? _subscribedNavigator;
+    private MapControl? _mapControl;
+    private ColumnDefinition? _planningDrawerColumn;
+    private ColumnDefinition? _routeDrawerColumn;
+    private Border? _planningDrawerContent;
+    private Border? _routeDrawerContent;
+    private ToggleButton? _planningDrawerHandle;
+    private ToggleButton? _routeDrawerHandle;
+    private Canvas? _radialMenuLayer;
+    private Button? _setStartRadialButton;
+    private Button? _setDestinationRadialButton;
+    private Button? _inspectRadialButton;
+    private Line? _radialConnector;
+    private Ellipse? _radialAnchor;
+    private ScreenPoint? _lastPointerPosition;
+    private MPoint? _capturedWorldPoint;
+    private RouteMapSelection? _capturedRouteSelection;
+    private DrawerSide? _lastOpenedDrawer;
 
     public MainWindow() : this(GetDefaultThemeService())
     {
@@ -30,17 +72,57 @@ public partial class MainWindow : Window
         ArgumentNullException.ThrowIfNull(themeService);
         _themeService = themeService;
         AvaloniaXamlLoader.Load(this);
+        InitializeControls();
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+        SizeChanged += OnWindowSizeChanged;
+        Deactivated += OnWindowDeactivated;
+        KeyDown += OnWindowKeyDown;
+        AddHandler(PointerPressedEvent, OnWindowPointerPressed, RoutingStrategies.Tunnel);
+    }
+
+    internal bool IsPlanningDrawerOpen { get; private set; }
+
+    internal bool IsRouteDrawerOpen { get; private set; }
+
+    internal bool IsRadialMenuOpen => _radialMenuLayer?.IsVisible is true;
+
+    internal static bool AllowsBothDrawers(double width) => width >= DrawerBreakpoint;
+
+    private void InitializeControls()
+    {
         var themeSelector = this.FindControl<ComboBox>("ThemeSelector")!;
         themeSelector.ItemsSource = AppThemeService.AvailableThemes;
         themeSelector.SelectedItem = AppThemeService.AvailableThemes.Single(
             option => option.Theme == _themeService.SelectedTheme);
         themeSelector.SelectionChanged += OnThemeSelectionChanged;
-        this.FindControl<MapControl>("MapView")!.MapTapped += OnMapTapped;
-        Loaded += OnLoaded;
-        Closed += OnClosed;
+
+        _mapControl = this.FindControl<MapControl>("MapView")!;
+        _mapControl.MapTapped += OnMapTapped;
+        _mapControl.PointerMoved += OnMapPointerMoved;
+        _mapControl.AddHandler(
+            PointerPressedEvent,
+            OnMapPointerPressed,
+            RoutingStrategies.Tunnel);
+
+        var shellGrid = this.FindControl<Grid>("ShellGrid")!;
+        _planningDrawerColumn = shellGrid.ColumnDefinitions[0];
+        _routeDrawerColumn = shellGrid.ColumnDefinitions[2];
+        _planningDrawerContent = this.FindControl<Border>("PlanningDrawerContent")!;
+        _routeDrawerContent = this.FindControl<Border>("RouteDrawerContent")!;
+        _planningDrawerHandle = this.FindControl<ToggleButton>("PlanningDrawerHandle")!;
+        _routeDrawerHandle = this.FindControl<ToggleButton>("RouteDrawerHandle")!;
+
+        _radialMenuLayer = this.FindControl<Canvas>("RadialMenuLayer")!;
+        _setStartRadialButton = this.FindControl<Button>("SetStartRadialButton")!;
+        _setDestinationRadialButton = this.FindControl<Button>("SetDestinationRadialButton")!;
+        _inspectRadialButton = this.FindControl<Button>("InspectRadialButton")!;
+        _radialConnector = this.FindControl<Line>("RadialConnector")!;
+        _radialAnchor = this.FindControl<Ellipse>("RadialAnchor")!;
+        ApplyDrawerState();
     }
 
-    private void OnLoaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private void OnLoaded(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not MainViewModel viewModel)
         {
@@ -49,16 +131,30 @@ public partial class MainWindow : Window
 
         _subscribedNavigator = viewModel.Map.Navigator;
         _subscribedNavigator.ViewportChanged += OnViewportChanged;
-        viewModel.RequestWeatherRefreshFromViewport();
+        ScheduleWeatherRefresh();
     }
 
     private void OnClosed(object? sender, EventArgs e)
     {
         this.FindControl<ComboBox>("ThemeSelector")!.SelectionChanged -= OnThemeSelectionChanged;
+        if (_mapControl is not null)
+        {
+            _mapControl.MapTapped -= OnMapTapped;
+            _mapControl.PointerMoved -= OnMapPointerMoved;
+            _mapControl.RemoveHandler(PointerPressedEvent, OnMapPointerPressed);
+        }
+
         if (_subscribedNavigator is not null)
         {
             _subscribedNavigator.ViewportChanged -= OnViewportChanged;
         }
+
+        Loaded -= OnLoaded;
+        Closed -= OnClosed;
+        SizeChanged -= OnWindowSizeChanged;
+        Deactivated -= OnWindowDeactivated;
+        KeyDown -= OnWindowKeyDown;
+        RemoveHandler(PointerPressedEvent, OnWindowPointerPressed);
     }
 
     private void OnThemeSelectionChanged(object? sender, SelectionChangedEventArgs e)
@@ -71,6 +167,7 @@ public partial class MainWindow : Window
 
     private void OnViewportChanged(object? sender, ViewportChangedEventArgs e)
     {
+        CloseRadialMenu();
         if (DataContext is MainViewModel viewModel)
         {
             viewModel.RequestWeatherRefreshFromViewport();
@@ -79,24 +176,349 @@ public partial class MainWindow : Window
 
     private void OnMapTapped(object? sender, MapEventArgs e)
     {
-        if (DataContext is MainViewModel viewModel)
+        if (e.GestureType == GestureType.LongPress)
+        {
+            OpenRadialMenu(
+                e.WorldPosition,
+                new ScreenPoint(e.ScreenPosition.X, e.ScreenPosition.Y));
+            e.Handled = true;
+            return;
+        }
+
+        if (e.GestureType == GestureType.SingleTap &&
+            DataContext is MainViewModel viewModel)
         {
             viewModel.HandleMapClick(e.WorldPosition, e.ScreenPosition);
             e.Handled = true;
         }
     }
 
-    private async void OnChooseGribFileClicked(
-        object? sender,
-        Avalonia.Interactivity.RoutedEventArgs e)
+    internal static bool IsRadialGesture(GestureType gestureType) =>
+        gestureType == GestureType.LongPress;
+
+    private void OnMapPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (_mapControl is null ||
+            !e.GetCurrentPoint(_mapControl).Properties.IsRightButtonPressed)
+        {
+            return;
+        }
+
+        // Tunneling handles the secondary press before Mapsui starts a manipulation.
+        e.Handled = true;
+        var position = e.GetPosition(_mapControl);
+        var screenPosition = new ScreenPoint(position.X, position.Y);
+        _lastPointerPosition = screenPosition;
+        OpenRadialMenu(
+            _mapControl.Map.Navigator.Viewport.ScreenToWorld(position.X, position.Y),
+            screenPosition);
+    }
+
+    private void OnMapPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_mapControl is null)
+        {
+            return;
+        }
+
+        var position = e.GetPosition(_mapControl);
+        _lastPointerPosition = new ScreenPoint(position.X, position.Y);
+    }
+
+    private void OnWindowPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!IsRadialMenuOpen || IsRadialActionSource(e.Source))
+        {
+            return;
+        }
+
+        CloseRadialMenu();
+    }
+
+    private bool IsRadialActionSource(object? source)
+    {
+        if (source is Button button)
+        {
+            return button == _setStartRadialButton ||
+                   button == _setDestinationRadialButton ||
+                   button == _inspectRadialButton;
+        }
+
+        return source is Visual visual &&
+               visual.GetVisualAncestors().OfType<Button>().Any(button =>
+                   button == _setStartRadialButton ||
+                   button == _setDestinationRadialButton ||
+                   button == _inspectRadialButton);
+    }
+
+    private void OnWindowKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape && IsRadialMenuOpen)
+        {
+            e.Handled = true;
+            CloseRadialMenu();
+            return;
+        }
+
+        if (_mapControl?.IsKeyboardFocusWithin is true &&
+            (e.Key == Key.Apps ||
+             (e.Key == Key.F10 && e.KeyModifiers.HasFlag(KeyModifiers.Shift))))
+        {
+            e.Handled = true;
+            OpenRadialMenuFromKeyboard();
+        }
+    }
+
+    private void OpenRadialMenuFromKeyboard()
+    {
+        if (_mapControl is null)
+        {
+            return;
+        }
+
+        var width = _mapControl.Bounds.Width;
+        var height = _mapControl.Bounds.Height;
+        var screenPosition = _lastPointerPosition is { } last &&
+                             last.X >= 0 &&
+                             last.Y >= 0 &&
+                             last.X <= width &&
+                             last.Y <= height
+            ? last
+            : new ScreenPoint(width / 2, height / 2);
+        OpenRadialMenu(
+            _mapControl.Map.Navigator.Viewport.ScreenToWorld(
+                screenPosition.X,
+                screenPosition.Y),
+            screenPosition);
+    }
+
+    private void OpenRadialMenu(MPoint worldPoint, ScreenPoint screenPoint)
+    {
+        if (_mapControl is null ||
+            _radialMenuLayer is null ||
+            _setStartRadialButton is null ||
+            _setDestinationRadialButton is null ||
+            _inspectRadialButton is null ||
+            _radialConnector is null ||
+            _radialAnchor is null ||
+            DataContext is not MainViewModel viewModel ||
+            _mapControl.Bounds.Width <= 0 ||
+            _mapControl.Bounds.Height <= 0)
+        {
+            return;
+        }
+
+        _capturedWorldPoint = worldPoint;
+        _capturedRouteSelection = viewModel.FindRouteAt(worldPoint, screenPoint);
+        _inspectRadialButton.IsEnabled = _capturedRouteSelection is not null;
+
+        var placement = RadialMenuPlacement.Calculate(
+            new ScreenRect(0, 0, _mapControl.Bounds.Width, _mapControl.Bounds.Height),
+            screenPoint,
+            new ScreenSize(RadialActionWidth, RadialActionHeight),
+            RadialRadius,
+            RadialSafeMargin);
+        PositionRadialAction(_setStartRadialButton, placement.Actions[0].Bounds);
+        PositionRadialAction(_setDestinationRadialButton, placement.Actions[1].Bounds);
+        PositionRadialAction(_inspectRadialButton, placement.Actions[2].Bounds);
+        ApplyConnector(placement);
+        _radialMenuLayer.IsVisible = true;
+        _setStartRadialButton.Focus();
+    }
+
+    private void ApplyConnector(RadialMenuPlacementResult placement)
+    {
+        if (_radialConnector is null || _radialAnchor is null)
+        {
+            return;
+        }
+
+        _radialConnector.IsVisible = placement.Connector is not null;
+        _radialAnchor.IsVisible = placement.Connector is not null;
+        if (placement.Connector is not { } connector)
+        {
+            return;
+        }
+
+        _radialConnector.StartPoint = new Point(connector.Start.X, connector.Start.Y);
+        _radialConnector.EndPoint = new Point(connector.End.X, connector.End.Y);
+        Canvas.SetLeft(_radialAnchor, connector.Start.X - (_radialAnchor.Width / 2));
+        Canvas.SetTop(_radialAnchor, connector.Start.Y - (_radialAnchor.Height / 2));
+    }
+
+    private static void PositionRadialAction(Control control, ScreenRect bounds)
+    {
+        control.Width = bounds.Width;
+        control.Height = bounds.Height;
+        Canvas.SetLeft(control, bounds.X);
+        Canvas.SetTop(control, bounds.Y);
+    }
+
+    private void OnSetStartRadialClicked(object? sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        if (_capturedWorldPoint is { } worldPoint &&
+            DataContext is MainViewModel viewModel)
+        {
+            viewModel.SetStartAt(MapProjection.ToCoordinate(worldPoint));
+        }
+
+        CloseRadialMenu();
+    }
+
+    private void OnSetDestinationRadialClicked(object? sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        if (_capturedWorldPoint is { } worldPoint &&
+            DataContext is MainViewModel viewModel)
+        {
+            viewModel.SetDestinationAt(MapProjection.ToCoordinate(worldPoint));
+        }
+
+        CloseRadialMenu();
+    }
+
+    private void OnInspectRadialClicked(object? sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        if (_capturedRouteSelection is { } selection &&
+            DataContext is MainViewModel viewModel)
+        {
+            viewModel.SelectRoutePoint(selection);
+        }
+
+        CloseRadialMenu();
+    }
+
+    private void CloseRadialMenu()
+    {
+        if (_radialMenuLayer is null || !_radialMenuLayer.IsVisible)
+        {
+            return;
+        }
+
+        _radialMenuLayer.IsVisible = false;
+        _capturedWorldPoint = null;
+        _capturedRouteSelection = null;
+        _mapControl?.Focus();
+    }
+
+    private void OnPlanningDrawerClicked(object? sender, RoutedEventArgs e)
+    {
+        SetPlanningDrawerOpen(!IsPlanningDrawerOpen);
+    }
+
+    private void OnRouteDrawerClicked(object? sender, RoutedEventArgs e)
+    {
+        SetRouteDrawerOpen(!IsRouteDrawerOpen);
+    }
+
+    internal void SetPlanningDrawerOpen(bool isOpen)
+    {
+        if (isOpen && !AllowsBothDrawers(Bounds.Width))
+        {
+            IsRouteDrawerOpen = false;
+        }
+
+        IsPlanningDrawerOpen = isOpen;
+        if (isOpen)
+        {
+            _lastOpenedDrawer = DrawerSide.Planning;
+        }
+
+        ApplyDrawerState();
+    }
+
+    internal void SetRouteDrawerOpen(bool isOpen)
+    {
+        if (isOpen && !AllowsBothDrawers(Bounds.Width))
+        {
+            IsPlanningDrawerOpen = false;
+        }
+
+        IsRouteDrawerOpen = isOpen;
+        if (isOpen)
+        {
+            _lastOpenedDrawer = DrawerSide.Route;
+        }
+
+        ApplyDrawerState();
+    }
+
+    private void ApplyDrawerState()
+    {
+        if (_planningDrawerColumn is null ||
+            _routeDrawerColumn is null ||
+            _planningDrawerContent is null ||
+            _routeDrawerContent is null ||
+            _planningDrawerHandle is null ||
+            _routeDrawerHandle is null)
+        {
+            return;
+        }
+
+        CloseRadialMenu();
+        _planningDrawerColumn.Width = new GridLength(
+            IsPlanningDrawerOpen ? PlanningDrawerWidth : ClosedDrawerWidth);
+        _routeDrawerColumn.Width = new GridLength(
+            IsRouteDrawerOpen ? RouteDrawerWidth : ClosedDrawerWidth);
+        _planningDrawerContent.IsVisible = IsPlanningDrawerOpen;
+        _routeDrawerContent.IsVisible = IsRouteDrawerOpen;
+        _planningDrawerHandle.IsChecked = IsPlanningDrawerOpen;
+        _routeDrawerHandle.IsChecked = IsRouteDrawerOpen;
+        _planningDrawerHandle.Content = IsPlanningDrawerOpen ? "‹" : "›";
+        _routeDrawerHandle.Content = IsRouteDrawerOpen ? "›" : "‹";
+        ScheduleWeatherRefresh();
+    }
+
+    private void OnWindowSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (!AllowsBothDrawers(e.NewSize.Width) &&
+            IsPlanningDrawerOpen &&
+            IsRouteDrawerOpen)
+        {
+            if (_lastOpenedDrawer == DrawerSide.Route)
+            {
+                IsPlanningDrawerOpen = false;
+            }
+            else
+            {
+                IsRouteDrawerOpen = false;
+            }
+
+            ApplyDrawerState();
+            return;
+        }
+
+        ScheduleWeatherRefresh();
+    }
+
+    private void OnWindowDeactivated(object? sender, EventArgs e)
+    {
+        CloseRadialMenu();
+    }
+
+    private void ScheduleWeatherRefresh()
+    {
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                if (DataContext is MainViewModel viewModel)
+                {
+                    viewModel.RequestWeatherRefreshFromViewport();
+                }
+            },
+            DispatcherPriority.Loaded);
+    }
+
+    private async void OnChooseGribFileClicked(object? sender, RoutedEventArgs e)
     {
         if (DataContext is not MainViewModel viewModel)
         {
             return;
         }
 
-        // async void event handler: any unhandled exception here would be raised on the
-        // UI sync context and crash the app, so guard availability and catch failures.
+        // async void is required by the UI event; surface all picker failures in the drawer.
         var storageProvider = StorageProvider;
         if (storageProvider is null || !storageProvider.CanOpen)
         {

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -233,6 +233,7 @@ public partial class MainWindow : Window
         }
 
         CloseRadialMenu();
+        e.Handled = true;
     }
 
     private bool IsRadialActionSource(object? source)

--- a/tests/Navtool.App.Tests/AppThemeTests.cs
+++ b/tests/Navtool.App.Tests/AppThemeTests.cs
@@ -30,6 +30,7 @@ public sealed class AppThemeTests
         try
         {
             window.Show();
+            window.SetPlanningDrawerOpen(true);
             var selector = Assert.IsType<ComboBox>(window.FindControl<ComboBox>("ThemeSelector"));
             var startButton = Assert.IsType<ToggleButton>(
                 window.FindControl<ToggleButton>("SetStartButton"));
@@ -219,6 +220,7 @@ public sealed class AppThemeTests
 
     private static Color GetPresenterBackground(TemplatedControl control)
     {
+        control.ApplyTemplate();
         var presenter = control.GetVisualDescendants()
             .OfType<ContentPresenter>()
             .Single(candidate => candidate.Name == "PART_ContentPresenter");

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Mapsui.Extensions;
 using Mapsui.Layers;
 using Navtool.App.Models;
 using Navtool.App.Services;
@@ -696,16 +697,28 @@ public sealed class MainViewModelWorkflowTests
                 ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
         viewModel.UseEcmwf = true;
         await viewModel.CalculateRoutesAsync();
+        viewModel.Map.Navigator.SetSize(1280, 800);
         var ecmwf = viewModel.SuccessfulRoutes.Single(
             route => route.Model == ForecastModel.EcmwfIfs);
         var capturedWorldPoint = MapProjection.ToMapPoint(ecmwf.Points[1].Location);
-        var projected = viewModel.Map.Navigator.Viewport.WorldToScreen(capturedWorldPoint);
+        var viewport = viewModel.Map.Navigator.Viewport;
+        var projected = viewport.WorldToScreen(capturedWorldPoint);
         var capturedScreenPoint = new ScreenPoint(projected.X, projected.Y);
+        var projectedRoutePoints = viewModel.SuccessfulRoutes
+            .SelectMany(route => MapProjection
+                .ToContinuousMapPointsNear(
+                    route.Points.Select(point => point.Location),
+                    capturedWorldPoint.X)
+                .Select(point => viewport.WorldToScreen(point)))
+            .ToArray();
+        var distantScreenPoint = new ScreenPoint(
+            projectedRoutePoints.Max(point => point.X) + 10_000,
+            projectedRoutePoints.Max(point => point.Y) + 10_000);
 
         Assert.True(viewModel.CanInspectRouteAt(capturedWorldPoint, capturedScreenPoint));
         Assert.False(viewModel.CanInspectRouteAt(
             capturedWorldPoint,
-            new ScreenPoint(capturedScreenPoint.X + 100, capturedScreenPoint.Y + 100)));
+            distantScreenPoint));
 
         Assert.True(viewModel.InspectRouteAt(
             capturedWorldPoint,

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -697,37 +697,21 @@ public sealed class MainViewModelWorkflowTests
                 ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
         viewModel.UseEcmwf = true;
         await viewModel.CalculateRoutesAsync();
-        viewModel.Map.Navigator.SetSize(1280, 800);
         var ecmwf = viewModel.SuccessfulRoutes.Single(
             route => route.Model == ForecastModel.EcmwfIfs);
         var capturedWorldPoint = MapProjection.ToMapPoint(ecmwf.Points[1].Location);
-        var viewport = viewModel.Map.Navigator.Viewport;
-        var projected = viewport.WorldToScreen(capturedWorldPoint);
+        var projected = viewModel.Map.Navigator.Viewport.WorldToScreen(capturedWorldPoint);
         var capturedScreenPoint = new ScreenPoint(projected.X, projected.Y);
-        var projectedRoutePoints = viewModel.SuccessfulRoutes
-            .SelectMany(route => MapProjection
-                .ToContinuousMapPointsNear(
-                    route.Points.Select(point => point.Location),
-                    capturedWorldPoint.X)
-                .Select(point => viewport.WorldToScreen(point)))
-            .ToArray();
-        var distantScreenPoint = new ScreenPoint(
-            projectedRoutePoints.Max(point => point.X) + 10_000,
-            projectedRoutePoints.Max(point => point.Y) + 10_000);
 
+        var capturedSelection = Assert.IsType<RouteMapSelection>(
+            viewModel.FindRouteAt(capturedWorldPoint, capturedScreenPoint));
         Assert.True(viewModel.CanInspectRouteAt(capturedWorldPoint, capturedScreenPoint));
-        Assert.False(viewModel.CanInspectRouteAt(
-            capturedWorldPoint,
-            distantScreenPoint));
 
-        Assert.True(viewModel.InspectRouteAt(
-            capturedWorldPoint,
-            capturedScreenPoint,
-            focus: false));
+        viewModel.SelectRoutePoint(capturedSelection, focus: false);
 
         Assert.Same(ecmwf, viewModel.SelectedRoutePoint!.Route);
-        Assert.Equal(1, viewModel.SelectedRoutePoint.PointIndex);
-        Assert.Equal(ecmwf.Points[1].Timestamp, viewModel.SelectedTimelineUtc);
+        Assert.Equal(capturedSelection.PointIndex, viewModel.SelectedRoutePoint.PointIndex);
+        Assert.Equal(capturedSelection.TimelineTimestamp, viewModel.SelectedTimelineUtc);
         Assert.Equal(ForecastModel.EcmwfIfs, viewModel.ActiveWeatherModel);
         Assert.Contains("ECMWF", viewModel.StatusMessage);
     }

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Mapsui.Extensions;
 using Mapsui.UI.Avalonia;
 using Navtool.App.Models;
 using Navtool.App.Services;
@@ -288,6 +289,45 @@ public sealed class MainWindowLayoutTests
                 string.Empty);
 
             Assert.False(window.IsRadialMenuOpen);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void EveryRadialOpenUpdatesTheNextKeyboardAnchor()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            var anchor = new ScreenPoint(map.Bounds.Width * 0.25, map.Bounds.Height * 0.25);
+            window.OpenRadialMenu(
+                map.Map.Navigator.Viewport.ScreenToWorld(anchor.X, anchor.Y),
+                anchor);
+            var start = Assert.IsType<Button>(
+                window.FindControl<Button>("SetStartRadialButton"));
+            var expectedLeft = Canvas.GetLeft(start);
+            var expectedTop = Canvas.GetTop(start);
+            window.KeyPress(
+                Key.Escape,
+                RawInputModifiers.None,
+                PhysicalKey.Escape,
+                string.Empty);
+
+            window.KeyPress(
+                Key.Apps,
+                RawInputModifiers.None,
+                PhysicalKey.ContextMenu,
+                string.Empty);
+
+            Assert.True(window.IsRadialMenuOpen);
+            Assert.Equal(expectedLeft, Canvas.GetLeft(start));
+            Assert.Equal(expectedTop, Canvas.GetTop(start));
         }
         finally
         {

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -1,0 +1,316 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Mapsui.UI.Avalonia;
+using Navtool.App.Models;
+using Navtool.App.Services;
+using Navtool.App.ViewModels;
+using Navtool.App.Views;
+using Navtool.Infrastructure;
+
+namespace Navtool.App.Tests;
+
+public sealed class MainWindowLayoutTests
+{
+    [AvaloniaFact]
+    public void DrawersAreAlwaysInTheWindowNameScopeAndClosedByDefault()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+
+            Assert.False(window.IsPlanningDrawerOpen);
+            Assert.False(window.IsRouteDrawerOpen);
+            Assert.False(Assert.IsType<Border>(
+                window.FindControl<Border>("PlanningDrawerContent")).IsVisible);
+            Assert.False(Assert.IsType<Border>(
+                window.FindControl<Border>("RouteDrawerContent")).IsVisible);
+            Assert.NotNull(window.FindControl<ComboBox>("ThemeSelector"));
+            Assert.NotNull(window.FindControl<ToggleButton>("SetStartButton"));
+            Assert.NotNull(window.FindControl<ToggleButton>("SetDestinationButton"));
+            Assert.NotNull(window.FindControl<Button>("CalculateRoutesButton"));
+            Assert.NotNull(window.FindControl<NumericUpDown>("PassageDaysInput"));
+            Assert.NotNull(window.FindControl<NumericUpDown>("PassageHoursInput"));
+            Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
+            Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
+            Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [Fact]
+    public void SizingPolicyPreservesTheMapFloorAndUsesTheRequestedBreakpoint()
+    {
+        Assert.False(MainWindow.AllowsBothDrawers(1219.99));
+        Assert.True(MainWindow.AllowsBothDrawers(1220));
+        Assert.Equal(
+            560,
+            MainWindow.DrawerBreakpoint -
+            MainWindow.PlanningDrawerWidth -
+            MainWindow.RouteDrawerWidth);
+        Assert.True(
+            1040 - MainWindow.RouteDrawerWidth >= 560,
+            "The larger single drawer must leave the map at least 560px wide.");
+    }
+
+    [AvaloniaFact]
+    public void NarrowWindowsKeepOnlyTheMostRecentlyOpenedDrawer()
+    {
+        var window = CreateWindow();
+        window.Width = 1040;
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            window.SetRouteDrawerOpen(true);
+
+            Assert.False(window.IsPlanningDrawerOpen);
+            Assert.True(window.IsRouteDrawerOpen);
+            var shell = Assert.IsType<Grid>(window.FindControl<Grid>("ShellGrid"));
+            Assert.Equal(MainWindow.ClosedDrawerWidth, shell.ColumnDefinitions[0].Width.Value);
+            Assert.Equal(MainWindow.RouteDrawerWidth, shell.ColumnDefinitions[2].Width.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void WideWindowsCanKeepBothDrawersOpen()
+    {
+        var window = CreateWindow();
+        window.Width = 1220;
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            window.SetRouteDrawerOpen(true);
+
+            Assert.True(window.IsPlanningDrawerOpen);
+            Assert.True(window.IsRouteDrawerOpen);
+            var shell = Assert.IsType<Grid>(window.FindControl<Grid>("ShellGrid"));
+            Assert.Equal(MainWindow.PlanningDrawerWidth, shell.ColumnDefinitions[0].Width.Value);
+            Assert.Equal(MainWindow.RouteDrawerWidth, shell.ColumnDefinitions[2].Width.Value);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void CrossingBelowTheBreakpointKeepsTheMostRecentlyOpenedDrawer()
+    {
+        var window = CreateWindow();
+        window.Width = 1220;
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            window.SetRouteDrawerOpen(true);
+
+            window.Width = 1219;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.False(window.IsPlanningDrawerOpen);
+            Assert.True(window.IsRouteDrawerOpen);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void RouteLegendTimelineAndWeatherLiveInTheRightDrawer()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            window.SetRouteDrawerOpen(true);
+            Assert.IsType<Expander>(
+                window.FindControl<Expander>("RouteDetailsExpander")).IsExpanded = true;
+            Assert.IsType<Expander>(
+                window.FindControl<Expander>("WeatherDetailsExpander")).IsExpanded = true;
+            var rightDrawer = Assert.IsType<Border>(
+                window.FindControl<Border>("RouteDrawerContent"));
+            foreach (var control in new Control[]
+                     {
+                         Assert.IsType<Border>(
+                             window.FindControl<Border>("HistoricalIsochroneLegendSwatch")),
+                         Assert.IsType<Border>(
+                             window.FindControl<Border>("DestinationFrontLegendSwatch")),
+                         Assert.IsType<Slider>(
+                             window.FindControl<Slider>("TimelineSlider")),
+                         Assert.IsType<Expander>(
+                             window.FindControl<Expander>("WeatherDetailsExpander"))
+                     })
+            {
+                Assert.Contains(rightDrawer, control.GetLogicalAncestors());
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void RadialActionsUseTheSharedAccessibleTouchSizedLayout()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            var point = map.TranslatePoint(map.Bounds.Center, window);
+            Assert.NotNull(point);
+
+            window.MouseDown(point.Value, MouseButton.Right, RawInputModifiers.None);
+
+            Assert.True(window.IsRadialMenuOpen);
+            var layer = Assert.IsType<Canvas>(window.FindControl<Canvas>("RadialMenuLayer"));
+            var buttons = new[]
+            {
+                Assert.IsType<Button>(window.FindControl<Button>("SetStartRadialButton")),
+                Assert.IsType<Button>(window.FindControl<Button>("SetDestinationRadialButton")),
+                Assert.IsType<Button>(window.FindControl<Button>("InspectRadialButton"))
+            };
+            Assert.Equal(buttons, layer.Children.OfType<Button>());
+            Assert.All(buttons, button =>
+            {
+                Assert.True(button.Width >= 44);
+                Assert.True(button.Height >= 44);
+                Assert.NotNull(ToolTip.GetTip(button));
+            });
+            Assert.False(buttons[2].IsEnabled);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void RadialEndpointActionUsesTheCapturedMapPointAndCloses()
+    {
+        var viewModel = CreateViewModel();
+        var window = new MainWindow { DataContext = viewModel };
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            var point = map.TranslatePoint(map.Bounds.Center, window);
+            Assert.NotNull(point);
+            window.MouseDown(point.Value, MouseButton.Right, RawInputModifiers.None);
+            var start = Assert.IsType<Button>(
+                window.FindControl<Button>("SetStartRadialButton"));
+
+            start.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+            Assert.NotNull(viewModel.Start);
+            Assert.False(window.IsRadialMenuOpen);
+            Assert.Equal(MapInteractionMode.Browse, viewModel.InteractionMode);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenuKeyOpensAndEscapeClosesTheRadialMenu()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            map.Focus();
+            window.KeyPress(
+                Key.Apps,
+                RawInputModifiers.None,
+                PhysicalKey.ContextMenu,
+                string.Empty);
+            Assert.True(window.IsRadialMenuOpen);
+
+            window.KeyPress(
+                Key.Escape,
+                RawInputModifiers.None,
+                PhysicalKey.Escape,
+                string.Empty);
+            Assert.False(window.IsRadialMenuOpen);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ContextMenuKeyDoesNotOpenMapActionsFromDrawerControls()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            var calculate = Assert.IsType<Button>(
+                window.FindControl<Button>("CalculateRoutesButton"));
+            calculate.Focus();
+
+            window.KeyPress(
+                Key.Apps,
+                RawInputModifiers.None,
+                PhysicalKey.ContextMenu,
+                string.Empty);
+
+            Assert.False(window.IsRadialMenuOpen);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void MinimumWindowSizeMatchesTheProductionFloor()
+    {
+        var window = CreateWindow();
+        Assert.Equal(1040, window.MinWidth);
+        Assert.Equal(680, window.MinHeight);
+    }
+
+    private static MainWindow CreateWindow() =>
+        new() { DataContext = CreateViewModel() };
+
+    private static MainViewModel CreateViewModel() =>
+        new(
+            null,
+            null,
+            TimeProvider.System,
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+}

--- a/tests/Navtool.App.Tests/MapInputRoutingTests.cs
+++ b/tests/Navtool.App.Tests/MapInputRoutingTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Mapsui.Manipulations;
 using Mapsui.UI.Avalonia;
+using Navtool.App.Models;
 using Navtool.App.Services;
 using Navtool.App.ViewModels;
 using Navtool.App.Views;
@@ -57,5 +58,47 @@ public sealed class MapInputRoutingTests
         Assert.True(MainWindow.IsRadialGesture(GestureType.LongPress));
         Assert.False(MainWindow.IsRadialGesture(GestureType.SingleTap));
         Assert.False(MainWindow.IsRadialGesture(GestureType.DoubleTap));
+    }
+
+    [AvaloniaFact]
+    public void ClickAwayDismissalIsConsumedBeforeTheMapActionPath()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            TimeProvider.System,
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+        var window = new MainWindow { DataContext = viewModel };
+        var bubblePresses = 0;
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            var point = map.TranslatePoint(map.Bounds.Center, window);
+            Assert.NotNull(point);
+            window.MouseDown(point.Value, MouseButton.Right, RawInputModifiers.None);
+            window.MouseUp(point.Value, MouseButton.Right, RawInputModifiers.None);
+            Assert.True(window.IsRadialMenuOpen);
+            map.AddHandler(
+                InputElement.PointerPressedEvent,
+                (_, _) => bubblePresses++,
+                RoutingStrategies.Bubble);
+            viewModel.SetStartCommand.Execute(null);
+
+            var dismissPoint = point.Value + new Point(24, 24);
+            window.MouseDown(dismissPoint, MouseButton.Left, RawInputModifiers.None);
+            window.MouseUp(dismissPoint, MouseButton.Left, RawInputModifiers.None);
+
+            Assert.False(window.IsRadialMenuOpen);
+            Assert.Equal(0, bubblePresses);
+            Assert.Null(viewModel.Start);
+            Assert.Equal(MapInteractionMode.SetStart, viewModel.InteractionMode);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 }

--- a/tests/Navtool.App.Tests/MapInputRoutingTests.cs
+++ b/tests/Navtool.App.Tests/MapInputRoutingTests.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Mapsui.Manipulations;
+using Mapsui.UI.Avalonia;
+using Navtool.App.Services;
+using Navtool.App.ViewModels;
+using Navtool.App.Views;
+using Navtool.Infrastructure;
+
+namespace Navtool.App.Tests;
+
+public sealed class MapInputRoutingTests
+{
+    [AvaloniaFact]
+    public void RightClickIsHandledDuringTunnelBeforeMapManipulation()
+    {
+        var window = new MainWindow
+        {
+            DataContext = new MainViewModel(
+                null,
+                null,
+                TimeProvider.System,
+                TimeZoneInfo.Utc,
+                new OsmTileOptions(Enabled: false))
+        };
+        var bubblePresses = 0;
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            map.AddHandler(
+                InputElement.PointerPressedEvent,
+                (_, _) => bubblePresses++,
+                RoutingStrategies.Bubble);
+            var point = map.TranslatePoint(map.Bounds.Center, window);
+            Assert.NotNull(point);
+
+            window.MouseDown(point.Value, MouseButton.Right, RawInputModifiers.None);
+
+            Assert.True(window.IsRadialMenuOpen);
+            Assert.Equal(0, bubblePresses);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [Fact]
+    public void MapsuiLongPressIsTheOnlyTapGestureThatInvokesRadialInput()
+    {
+        Assert.True(MainWindow.IsRadialGesture(GestureType.LongPress));
+        Assert.False(MainWindow.IsRadialGesture(GestureType.SingleTap));
+        Assert.False(MainWindow.IsRadialGesture(GestureType.DoubleTap));
+    }
+}


### PR DESCRIPTION
## Summary
- replace the fixed sidebar/footer with closed-by-default resizing planning and route/weather edge drawers
- add shared right-click, touch long-press, and keyboard radial map actions using captured map and route targets
- preserve endpoint, routing, timeline, forecast, weather, theme, legend, warning, and safety workflows in the new shell
- add headless coverage for input tunneling, drawer sizing/name scope, radial workflows, keyboard scope, themes, and the 1040x680 floor

## Stack
Targets `frye-radial-action-foundation` (PR #34).

## Tests
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --no-restore` (67 passed)