### PR TITLE
Add multi-point route plan foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ It targets macOS, Windows, and Linux.
 
 ## Features
 
-- Select start and destination points on an OpenStreetMap-based map.
+- Build and save named, ordered itineraries with fixed start/finish waypoints,
+  reorderable intermediate waypoints, optional stopovers, and numbered map
+  markers connected by an antimeridian-safe planning guide.
 - Choose a local departure date/time, converted to UTC with DST validation.
 - Set the expected passage duration so only the required forecast times are
   acquired, up to the ten-day planning limit.
@@ -27,6 +29,8 @@ It targets macOS, Windows, and Linux.
   model.
 - Switch at runtime among Light, Dark, and the midnight-blue and brass
   **Kind of Blue** theme. Navtool remembers the selected theme across launches.
+- Persist route plans and their latest per-model leg outcomes as
+  schema-versioned JSON beneath the application data root.
 
 ## Prerequisites
 
@@ -167,6 +171,10 @@ also be installed or packaged according to the target platform.
 
 The selected display theme is stored in `preferences/theme.txt` beneath
 `NAVTOOL_APP_DATA_ROOT` (or Navtool's default local application-data directory).
+Route plans are stored atomically as JSON beneath `routes/` in the same root.
+Plan files contain waypoint, stopover, calculation-session, leg-outcome, sailed
+state, and route-point metadata, but never forecast binaries. Files from unknown
+future schemas or with inconsistent IDs/references are rejected visibly.
 
 NOAA data is downloaded from the operational NOMADS GFS filter. Navtool derives
 an antimeridian-safe buffered passage area, requests every available forecast
@@ -235,6 +243,12 @@ ECMWF Open Data remains an explicit experimental option. Official data supports
 field/step selection but not server-side geographic cropping, and indexed
 10u/10v retrieval has not yet been implemented in this application. No fallback
 or other model is presented as ECMWF data.
+
+Ordered waypoint editing and persistence are available now, while route
+calculation remains intentionally limited to a direct two-waypoint plan.
+Sequential calculation across intermediate waypoints and optimized multi-leg
+rendering are deferred; remove intermediate waypoints to calculate a direct
+route with the existing native engine.
 
 Saildocs is not used as an application API: it is an asynchronous email service
 for bandwidth-constrained users rather than a reliable regional download

--- a/src/Navtool.App/Models/MapInteractionState.cs
+++ b/src/Navtool.App/Models/MapInteractionState.cs
@@ -6,7 +6,8 @@ public enum MapInteractionMode
 {
     Browse,
     SetStart,
-    SetDestination
+    SetDestination,
+    SetWaypoint
 }
 
 public sealed class MapInteractionState
@@ -43,6 +44,9 @@ public sealed class MapInteractionState
                 break;
             case MapInteractionMode.SetDestination:
                 SetDestination(coordinate);
+                break;
+            case MapInteractionMode.SetWaypoint:
+                Mode = MapInteractionMode.Browse;
                 break;
             default:
                 return false;

--- a/src/Navtool.App/Services/AppComposition.cs
+++ b/src/Navtool.App/Services/AppComposition.cs
@@ -34,6 +34,10 @@ public static class AppComposition
 
         services.AddSingleton(_ => new AtomicFileCache(
             new AtomicFileCacheOptions(ResolveCacheRoot())));
+        services.AddSingleton<IRoutePlanSchemaMigrator, RoutePlanSchemaMigrator>();
+        services.AddSingleton<IRoutePlanRepository>(provider => new RoutePlanJsonRepository(
+            ResolveAppDataRoot(),
+            provider.GetRequiredService<IRoutePlanSchemaMigrator>()));
         services.AddSingleton<ILandDataProvider>(provider =>
         {
             var endpoint = ResolveLandDataEndpoint();

--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -142,7 +142,7 @@ public static class RadialMenuPlacement
         }
         else if (canUseVertical)
         {
-            var step = actionSize.Height + verticalGap.Value;
+            var step = actionSize.Height + verticalGap!.Value;
             offsets = [new ScreenPoint(0, -step), new ScreenPoint(0, 0), new ScreenPoint(0, step)];
             halfWidth = actionSize.Width / 2;
             halfHeight = step + (actionSize.Height / 2);
@@ -207,7 +207,7 @@ public static class RadialMenuPlacement
         ImmutableArray<RadialMenuActionPlacement> actions,
         RadialMenuLayout layout)
     {
-        var connector = anchor.DistanceTo(center) > ConnectorEpsilon
+        RadialMenuConnector? connector = anchor.DistanceTo(center) > ConnectorEpsilon
             ? new RadialMenuConnector(anchor, center)
             : null;
         return new RadialMenuPlacementResult(anchor, center, actions, layout, connector);

--- a/src/Navtool.App/Services/RouteHitTester.cs
+++ b/src/Navtool.App/Services/RouteHitTester.cs
@@ -69,12 +69,22 @@ public static class RouteHitTester
         ScreenPoint click,
         double tolerance)
     {
+        if (!IsFinite(click))
+        {
+            return null;
+        }
+
         RouteMapSelection? nearest = null;
 
         foreach (var route in routes)
         {
             for (var index = 0; index < route.Points.Length; index++)
             {
+                if (!IsFinite(route.Points[index]))
+                {
+                    continue;
+                }
+
                 var distance = click.DistanceTo(route.Points[index]);
                 if (distance <= tolerance && (nearest is null || distance < nearest.DistancePixels))
                 {
@@ -91,6 +101,11 @@ public static class RouteHitTester
         ScreenPoint click,
         double tolerance)
     {
+        if (!IsFinite(click))
+        {
+            return null;
+        }
+
         RouteMapSelection? nearest = null;
 
         foreach (var route in routes)
@@ -102,8 +117,15 @@ public static class RouteHitTester
 
             for (var index = 1; index < route.Points.Length; index++)
             {
+                if (!IsFinite(route.Points[index - 1]) || !IsFinite(route.Points[index]))
+                {
+                    continue;
+                }
+
                 var distance = DistanceToSegment(click, route.Points[index - 1], route.Points[index]);
-                if (distance > tolerance || (nearest is not null && distance >= nearest.DistancePixels))
+                if (!double.IsFinite(distance) ||
+                    distance > tolerance ||
+                    (nearest is not null && distance >= nearest.DistancePixels))
                 {
                     continue;
                 }
@@ -150,5 +172,9 @@ public static class RouteHitTester
             throw new ArgumentOutOfRangeException(parameterName);
         }
     }
+
+    private static bool IsFinite(ScreenPoint point) =>
+        double.IsFinite(point.X) && double.IsFinite(point.Y);
+
     private sealed record ProjectedRoute(RouteResult Route, ScreenPoint[] Points);
 }

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -16,6 +16,8 @@ public sealed record OsmTileOptions(
     bool Enabled = true,
     string UserAgent = "Navtool/1.0");
 
+public sealed record WaypointMapMarker(int Number, string Name, CoreCoordinate? Coordinate);
+
 public sealed class RouteMapLayers
 {
     public static readonly MapsuiColor NoaaColor = MapsuiColor.FromString("#0072B2");
@@ -46,6 +48,15 @@ public sealed class RouteMapLayers
     };
     private readonly MemoryLayer _windCells = new("Wind speed") { Style = null };
     private readonly MemoryLayer _windArrows = new("Wind direction") { Style = null };
+    private readonly MemoryLayer _waypointGuide = new("Waypoint guide")
+    {
+        Style = new VectorStyle
+        {
+            Line = new Pen(MapsuiColor.FromString("#607D8B"), 2),
+            Opacity = 0.65f
+        }
+    };
+    private readonly MemoryLayer _waypointMarkers = new("Waypoint markers") { Style = null };
 
     public RouteMapLayers(Map map)
     {
@@ -53,6 +64,7 @@ public sealed class RouteMapLayers
         Map = map;
         map.Layers.Add(_windCells);
         map.Layers.Add(_windArrows);
+        map.Layers.Add(_waypointGuide);
         map.Layers.Add(_noaaHistoricalFronts);
         map.Layers.Add(_ecmwfHistoricalFronts);
         map.Layers.Add(_noaaDestinationFront);
@@ -61,6 +73,7 @@ public sealed class RouteMapLayers
         map.Layers.Add(_ecmwfProvisionalRoute);
         map.Layers.Add(_noaaRoutes);
         map.Layers.Add(_ecmwfRoutes);
+        map.Layers.Add(_waypointMarkers);
     }
 
     public Map Map { get; }
@@ -68,6 +81,10 @@ public sealed class RouteMapLayers
     public IReadOnlyList<RouteResult> Routes { get; private set; } = Array.Empty<RouteResult>();
 
     public int WeatherCellCount { get; private set; }
+
+    public int WaypointMarkerCount => _waypointMarkers.Features.Count();
+
+    public int WaypointGuideSegmentCount => _waypointGuide.Features.Count();
 
     public int GetIsochroneFrontCount(ForecastModel model) =>
         GetHistoricalFrontFeatures(model).Count;
@@ -87,6 +104,20 @@ public sealed class RouteMapLayers
         _ecmwfRoutes.Features = CreateRouteFeatures(Routes.Where(route => route.Model == ForecastModel.EcmwfIfs));
         _noaaRoutes.FeaturesWereModified();
         _ecmwfRoutes.FeaturesWereModified();
+        Map.Refresh(ChangeType.Discrete);
+    }
+
+    public void SetWaypoints(IEnumerable<WaypointMapMarker> waypoints)
+    {
+        ArgumentNullException.ThrowIfNull(waypoints);
+        var ordered = waypoints.OrderBy(waypoint => waypoint.Number).ToArray();
+        _waypointMarkers.Features = ordered
+            .Where(waypoint => waypoint.Coordinate is not null)
+            .Select(CreateWaypointMarker)
+            .ToArray();
+        _waypointGuide.Features = CreateWaypointGuideFeatures(ordered);
+        _waypointMarkers.FeaturesWereModified();
+        _waypointGuide.FeaturesWereModified();
         Map.Refresh(ChangeType.Discrete);
     }
 
@@ -195,11 +226,69 @@ public sealed class RouteMapLayers
             }
         };
 
+    private static IFeature CreateWaypointMarker(WaypointMapMarker marker)
+    {
+        var point = MapProjection.ToMapPoint(marker.Coordinate!.Value);
+        var feature = new GeometryFeature(new Point(point.X, point.Y))
+        {
+            Data = marker
+        };
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = marker.Number.ToString(),
+            Font = new Font { Size = 12, Bold = true },
+            ForeColor = MapsuiColor.White,
+            BackColor = new Brush(MapsuiColor.FromString("#263238")),
+            BorderColor = MapsuiColor.White,
+            BorderThickness = 2,
+            CornerRounding = 14
+        });
+        return feature;
+    }
+
+    private static IFeature[] CreateWaypointGuideFeatures(
+        IReadOnlyList<WaypointMapMarker> waypoints)
+    {
+        var features = new List<IFeature>();
+        var contiguous = new List<CoreCoordinate>();
+        foreach (var waypoint in waypoints)
+        {
+            if (waypoint.Coordinate is null)
+            {
+                AddGuideSegment(contiguous, features);
+                contiguous.Clear();
+            }
+            else
+            {
+                contiguous.Add(waypoint.Coordinate.Value);
+            }
+        }
+
+        AddGuideSegment(contiguous, features);
+        return features.ToArray();
+    }
+
+    private static void AddGuideSegment(
+        IReadOnlyList<CoreCoordinate> coordinates,
+        ICollection<IFeature> features)
+    {
+        if (coordinates.Count < 2)
+        {
+            return;
+        }
+
+        var projected = MapProjection.ToContinuousMapPoints(coordinates)
+            .Select(point => new NtsCoordinate(point.X, point.Y))
+            .ToArray();
+        features.Add(new GeometryFeature(new LineString(projected)));
+    }
+
     private static MemoryLayer CreateHistoricalFrontLayer(string name) =>
         new(name)
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(ReachabilityColor, HistoricalFrontLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round
@@ -213,6 +302,7 @@ public sealed class RouteMapLayers
         {
             Style = new VectorStyle
             {
+                Fill = null,
                 Line = new Pen(ReachabilityColor, DestinationFrontLineWidth)
                 {
                     PenStrokeCap = PenStrokeCap.Round

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -1,0 +1,668 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Navtool.Core;
+
+namespace Navtool.App.ViewModels;
+
+public sealed partial class WaypointEditorItemViewModel : ViewModelBase
+{
+    private readonly ItineraryEditorViewModel _owner;
+
+    internal WaypointEditorItemViewModel(
+        ItineraryEditorViewModel owner,
+        RouteWaypointId id,
+        string name,
+        Coordinate? coordinate,
+        TimeSpan? stopover)
+    {
+        _owner = owner;
+        Id = id;
+        _name = name;
+        _coordinate = coordinate;
+        _hasStopover = stopover is not null;
+        _stopoverHours = stopover?.TotalHours ?? 1;
+    }
+
+    public RouteWaypointId Id { get; }
+
+    [ObservableProperty]
+    private string _name;
+
+    [ObservableProperty]
+    private Coordinate? _coordinate;
+
+    [ObservableProperty]
+    private bool _hasStopover;
+
+    [ObservableProperty]
+    private double _stopoverHours;
+
+    public int Position => _owner.Waypoints.IndexOf(this) + 1;
+
+    public string PositionLabel => Position.ToString();
+
+    public bool IsStart => Position == 1;
+
+    public bool IsFinish => Position == _owner.Waypoints.Count;
+
+    public bool IsIntermediate => !IsStart && !IsFinish;
+
+    public string Role => IsStart ? "START" : IsFinish ? "FINISH" : "WAYPOINT";
+
+    public string CoordinateDisplay => Coordinate is null
+        ? "Not set"
+        : $"{Math.Abs(Coordinate.Value.Latitude):0.000}° " +
+          $"{(Coordinate.Value.Latitude >= 0 ? "N" : "S")}, " +
+          $"{Math.Abs(Coordinate.Value.Longitude):0.000}° " +
+          $"{(Coordinate.Value.Longitude >= 0 ? "E" : "W")}";
+
+    [RelayCommand]
+    private void SetOnMap() => _owner.BeginMapPlacement(this);
+
+    [RelayCommand(CanExecute = nameof(IsIntermediate))]
+    private void Remove() => _owner.Remove(this);
+
+    [RelayCommand(CanExecute = nameof(CanMoveUp))]
+    private void MoveUp() => _owner.Move(this, Position - 2);
+
+    [RelayCommand(CanExecute = nameof(CanMoveDown))]
+    private void MoveDown() => _owner.Move(this, Position);
+
+    private bool CanMoveUp() => IsIntermediate && Position > 2;
+
+    private bool CanMoveDown() => IsIntermediate && Position < _owner.Waypoints.Count - 1;
+
+    partial void OnNameChanged(string value) => _owner.RenameWaypoint(this, value);
+
+    partial void OnCoordinateChanged(Coordinate? value)
+    {
+        OnPropertyChanged(nameof(CoordinateDisplay));
+        _owner.ChangeCoordinate(this, value);
+    }
+
+    partial void OnHasStopoverChanged(bool value) => _owner.ChangeStopover(this);
+
+    partial void OnStopoverHoursChanged(double value) => _owner.ChangeStopover(this);
+
+    internal TimeSpan? GetStopover() =>
+        IsIntermediate && HasStopover && double.IsFinite(StopoverHours) && StopoverHours > 0
+            ? TimeSpan.FromHours(StopoverHours)
+            : null;
+
+    internal void RefreshPosition()
+    {
+        OnPropertyChanged(nameof(Position));
+        OnPropertyChanged(nameof(PositionLabel));
+        OnPropertyChanged(nameof(IsStart));
+        OnPropertyChanged(nameof(IsFinish));
+        OnPropertyChanged(nameof(IsIntermediate));
+        OnPropertyChanged(nameof(Role));
+        RemoveCommand.NotifyCanExecuteChanged();
+        MoveUpCommand.NotifyCanExecuteChanged();
+        MoveDownCommand.NotifyCanExecuteChanged();
+    }
+}
+
+public sealed partial class ItineraryEditorViewModel : ViewModelBase
+{
+    private readonly IRoutePlanRepository? _repository;
+    private RoutePlan? _plan;
+    private bool _suppressChanges;
+
+    public ItineraryEditorViewModel(IRoutePlanRepository? repository = null)
+    {
+        _repository = repository;
+        NewDraft();
+    }
+
+    public ObservableCollection<WaypointEditorItemViewModel> Waypoints { get; } = [];
+
+    public ObservableCollection<RoutePlanSummary> SavedPlans { get; } = [];
+
+    [ObservableProperty]
+    private string _routeName = "Untitled route";
+
+    [ObservableProperty]
+    private string _saveAsName = "Untitled route copy";
+
+    [ObservableProperty]
+    private RoutePlanSummary? _selectedSavedPlan;
+
+    [ObservableProperty]
+    private bool _isDirty;
+
+    [ObservableProperty]
+    private bool _resultsInvalidated;
+
+    [ObservableProperty]
+    private string? _storageError;
+
+    [ObservableProperty]
+    private string? _validationMessage;
+
+    [ObservableProperty]
+    private WaypointEditorItemViewModel? _activeWaypoint;
+
+    public RoutePlanId PlanId { get; private set; }
+
+    public long CalculationRevision { get; private set; }
+
+    public long EditRevision { get; private set; }
+
+    public event EventHandler? ItineraryChanged;
+
+    public event EventHandler<WaypointEditorItemViewModel>? MapPlacementStarted;
+
+    public Coordinate? Start => Waypoints.FirstOrDefault()?.Coordinate;
+
+    public Coordinate? Finish => Waypoints.LastOrDefault()?.Coordinate;
+
+    public bool HasPendingWaypoint => Waypoints.Any(waypoint => waypoint.Coordinate is null);
+
+    public void SetEndpoints(Coordinate start, Coordinate finish)
+    {
+        Waypoints[0].Coordinate = start;
+        Waypoints[^1].Coordinate = finish;
+    }
+
+    public void BeginMapPlacement(WaypointEditorItemViewModel waypoint)
+    {
+        ArgumentNullException.ThrowIfNull(waypoint);
+        if (!Waypoints.Contains(waypoint))
+        {
+            throw new ArgumentException("The waypoint does not belong to this itinerary.", nameof(waypoint));
+        }
+
+        ActiveWaypoint = waypoint;
+        MapPlacementStarted?.Invoke(this, waypoint);
+    }
+
+    public void PlaceActiveWaypoint(Coordinate coordinate)
+    {
+        if (ActiveWaypoint is null)
+        {
+            throw new InvalidOperationException("No waypoint is awaiting map placement.");
+        }
+
+        var waypoint = ActiveWaypoint;
+        ActiveWaypoint = null;
+        waypoint.Coordinate = coordinate;
+    }
+
+    public void CancelMapPlacement() => ActiveWaypoint = null;
+
+    [RelayCommand]
+    private void New() => NewDraft();
+
+    [RelayCommand(CanExecute = nameof(CanAddWaypoint))]
+    private void AddWaypoint()
+    {
+        var item = new WaypointEditorItemViewModel(
+            this,
+            new RouteWaypointId(),
+            $"Waypoint {Waypoints.Count}",
+            null,
+            null);
+        Waypoints.Insert(Waypoints.Count - 1, item);
+        CalculationRevision++;
+        MarkChanged();
+        RefreshPositions();
+        AddWaypointCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool CanAddWaypoint() => !HasPendingWaypoint;
+
+    [RelayCommand]
+    private async Task RefreshSavedPlans()
+    {
+        if (_repository is null)
+        {
+            StorageError = "Route plan storage is unavailable.";
+            return;
+        }
+
+        try
+        {
+            StorageError = null;
+            var plans = await _repository.ListAsync();
+            SavedPlans.Clear();
+            foreach (var plan in plans)
+            {
+                SavedPlans.Add(plan);
+            }
+
+            SelectedSavedPlan = SavedPlans.FirstOrDefault(summary => summary.Id == PlanId) ??
+                                SavedPlans.FirstOrDefault();
+        }
+        catch (Exception exception)
+        {
+            StorageError = exception.Message;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanOpen))]
+    private async Task Open()
+    {
+        if (_repository is null || SelectedSavedPlan is null)
+        {
+            StorageError = "Select a saved route plan to open.";
+            return;
+        }
+
+        try
+        {
+            StorageError = null;
+            Load(await _repository.OpenAsync(SelectedSavedPlan.Id));
+        }
+        catch (Exception exception)
+        {
+            StorageError = exception.Message;
+        }
+    }
+
+    private bool CanOpen() => SelectedSavedPlan is not null;
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (_repository is null)
+        {
+            StorageError = "Route plan storage is unavailable.";
+            return;
+        }
+
+        if (!TryBuildPlan(out var plan, out var error))
+        {
+            StorageError = error;
+            return;
+        }
+
+        try
+        {
+            var revision = EditRevision;
+            StorageError = null;
+            await _repository.SaveAsync(plan!);
+            if (EditRevision == revision)
+            {
+                _plan = plan;
+                IsDirty = false;
+            }
+
+            await RefreshSavedPlans();
+        }
+        catch (Exception exception)
+        {
+            StorageError = exception.Message;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAs()
+    {
+        if (_repository is null)
+        {
+            StorageError = "Route plan storage is unavailable.";
+            return;
+        }
+
+        if (!TryBuildPlan(out var plan, out var error))
+        {
+            StorageError = error;
+            return;
+        }
+
+        try
+        {
+            var revision = EditRevision;
+            StorageError = null;
+            var copy = await _repository.SaveAsAsync(plan!, SaveAsName);
+            if (EditRevision == revision)
+            {
+                Load(copy);
+            }
+
+            await RefreshSavedPlans();
+        }
+        catch (Exception exception)
+        {
+            StorageError = exception.Message;
+        }
+    }
+
+    public bool TryBuildPlan(out RoutePlan? plan, out string? error)
+    {
+        plan = null;
+        error = null;
+        if (Waypoints.Count < 2 || Waypoints.Any(waypoint => waypoint.Coordinate is null))
+        {
+            error = "Set every waypoint on the map before saving.";
+            return false;
+        }
+
+        try
+        {
+            var waypoints = Waypoints.Select(waypoint => new RouteWaypoint(
+                waypoint.Id,
+                waypoint.Name,
+                waypoint.Coordinate!.Value,
+                waypoint.GetStopover())).ToArray();
+            if (_plan is not null &&
+                _plan.Id == PlanId &&
+                _plan.Waypoints.SequenceEqual(waypoints))
+            {
+                plan = _plan.Name == RouteName ? _plan : _plan.Rename(RouteName);
+            }
+            else
+            {
+                plan = _plan is null
+                    ? new RoutePlan(PlanId, RouteName, waypoints)
+                    : new RoutePlan(
+                        PlanId,
+                        RouteName,
+                        waypoints,
+                        _plan.Results,
+                        _plan.SailedLegIds);
+            }
+
+            ValidationMessage = null;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            error = exception.Message;
+            ValidationMessage = error;
+            return false;
+        }
+    }
+
+    public RouteResult? RecordSingleLegOutcome(
+        ForecastModel model,
+        RouteResult? route,
+        RouteLegOutcomeReason reason,
+        string? detail,
+        DateTimeOffset completedAt)
+    {
+        if (!TryBuildPlan(out var plan, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+
+        if (plan!.Legs.Length != 1)
+        {
+            throw new InvalidOperationException(
+                "Only two-waypoint route results can be recorded until sequential routing is implemented.");
+        }
+
+        var completed = completedAt.ToUniversalTime();
+        var session = new RouteCalculationSession(
+            plan.Id,
+            model,
+            completed).Complete(completed);
+        var state = route is null
+            ? RouteLegOutcomeState.Failed
+            : RouteLegOutcomeState.Succeeded;
+        _plan = plan.WithResult(new RoutePlanResult(
+            session,
+            [
+                new RouteLegResult(
+                    plan.Legs[0].Id,
+                    state,
+                    reason,
+                    route,
+                    detail)
+            ]));
+        ResultsInvalidated = _plan.HasInvalidatedResults;
+        IsDirty = true;
+        EditRevision++;
+        NotifyItineraryChanged();
+        return _plan.LatestResult(model)!.Legs[0].Route;
+    }
+
+    internal void Remove(WaypointEditorItemViewModel waypoint)
+    {
+        var index = Waypoints.IndexOf(waypoint);
+        if (index <= 0 || index >= Waypoints.Count - 1)
+        {
+            throw new InvalidOperationException("Start and finish waypoints cannot be removed.");
+        }
+
+        var belongsToPlan = _plan?.Waypoints.Any(existing => existing.Id == waypoint.Id) is true;
+        if (belongsToPlan && !TryUpdatePlan(plan => plan.RemoveWaypoint(waypoint.Id)))
+        {
+            return;
+        }
+
+        if (ReferenceEquals(ActiveWaypoint, waypoint))
+        {
+            ActiveWaypoint = null;
+        }
+
+        Waypoints.RemoveAt(index);
+        CalculationRevision++;
+        MarkChanged();
+        RefreshPositions();
+        AddWaypointCommand.NotifyCanExecuteChanged();
+    }
+
+    internal void Move(WaypointEditorItemViewModel waypoint, int newIndex)
+    {
+        var oldIndex = Waypoints.IndexOf(waypoint);
+        if (oldIndex <= 0 || oldIndex >= Waypoints.Count - 1 ||
+            newIndex <= 0 || newIndex >= Waypoints.Count - 1)
+        {
+            throw new InvalidOperationException("Only intermediate waypoints can be reordered.");
+        }
+
+        if (!TryUpdatePlan(plan => plan.MoveWaypoint(waypoint.Id, newIndex)))
+        {
+            return;
+        }
+
+        Waypoints.Move(oldIndex, newIndex);
+        CalculationRevision++;
+        MarkChanged();
+        RefreshPositions();
+    }
+
+    internal void RenameWaypoint(WaypointEditorItemViewModel waypoint, string name)
+    {
+        if (_suppressChanges)
+        {
+            return;
+        }
+
+        TryUpdatePlan(plan => plan.RenameWaypoint(waypoint.Id, name));
+        MarkChanged();
+    }
+
+    internal void ChangeCoordinate(WaypointEditorItemViewModel waypoint, Coordinate? coordinate)
+    {
+        if (_suppressChanges)
+        {
+            return;
+        }
+
+        if (coordinate is not null && _plan is not null)
+        {
+            if (_plan.Waypoints.Any(existing => existing.Id == waypoint.Id))
+            {
+                TryUpdatePlan(plan => plan.ChangeWaypointCoordinate(waypoint.Id, coordinate.Value));
+            }
+            else
+            {
+                var index = Waypoints.IndexOf(waypoint);
+                TryUpdatePlan(plan => plan.AddWaypoint(
+                    new RouteWaypoint(
+                        waypoint.Id,
+                        waypoint.Name,
+                        coordinate.Value,
+                        waypoint.GetStopover()),
+                    index));
+            }
+        }
+        else
+        {
+            ValidationMessage = null;
+        }
+
+        CalculationRevision++;
+        MarkChanged();
+        AddWaypointCommand.NotifyCanExecuteChanged();
+    }
+
+    internal void ChangeStopover(WaypointEditorItemViewModel waypoint)
+    {
+        if (_suppressChanges || !waypoint.IsIntermediate)
+        {
+            return;
+        }
+
+        if (_plan?.Waypoints.Any(existing => existing.Id == waypoint.Id) is true)
+        {
+            TryUpdatePlan(plan => plan.ChangeStopover(waypoint.Id, waypoint.GetStopover()));
+        }
+
+        CalculationRevision++;
+        MarkChanged();
+    }
+
+    private void NewDraft()
+    {
+        _suppressChanges = true;
+        try
+        {
+            PlanId = new RoutePlanId();
+            CalculationRevision++;
+            EditRevision++;
+            _plan = null;
+            RouteName = "Untitled route";
+            SaveAsName = "Untitled route copy";
+            Waypoints.Clear();
+            Waypoints.Add(new WaypointEditorItemViewModel(
+                this,
+                new RouteWaypointId(),
+                "Start",
+                null,
+                null));
+            Waypoints.Add(new WaypointEditorItemViewModel(
+                this,
+                new RouteWaypointId(),
+                "Finish",
+                null,
+                null));
+            IsDirty = false;
+            ResultsInvalidated = false;
+            StorageError = null;
+            ValidationMessage = null;
+            ActiveWaypoint = null;
+        }
+        finally
+        {
+            _suppressChanges = false;
+        }
+
+        RefreshPositions();
+        NotifyItineraryChanged();
+    }
+
+    private void Load(RoutePlan plan)
+    {
+        _suppressChanges = true;
+        try
+        {
+            _plan = plan;
+            PlanId = plan.Id;
+            CalculationRevision++;
+            EditRevision++;
+            RouteName = plan.Name;
+            SaveAsName = $"{plan.Name} copy";
+            Waypoints.Clear();
+            foreach (var waypoint in plan.Waypoints)
+            {
+                Waypoints.Add(new WaypointEditorItemViewModel(
+                    this,
+                    waypoint.Id,
+                    waypoint.Name,
+                    waypoint.Coordinate,
+                    waypoint.Stopover));
+            }
+
+            IsDirty = false;
+            ResultsInvalidated = plan.HasInvalidatedResults;
+            StorageError = null;
+            ValidationMessage = null;
+            ActiveWaypoint = null;
+        }
+        finally
+        {
+            _suppressChanges = false;
+        }
+
+        RefreshPositions();
+        NotifyItineraryChanged();
+    }
+
+    private bool TryUpdatePlan(Func<RoutePlan, RoutePlan> update)
+    {
+        if (_plan is null)
+        {
+            return true;
+        }
+
+        try
+        {
+            _plan = update(_plan);
+            ResultsInvalidated = _plan.HasInvalidatedResults;
+            ValidationMessage = null;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            ValidationMessage = exception.Message;
+            return false;
+        }
+    }
+
+    private void MarkChanged()
+    {
+        if (_suppressChanges)
+        {
+            return;
+        }
+
+        IsDirty = true;
+        EditRevision++;
+        NotifyItineraryChanged();
+    }
+
+    private void RefreshPositions()
+    {
+        foreach (var waypoint in Waypoints)
+        {
+            waypoint.RefreshPosition();
+        }
+    }
+
+    private void NotifyItineraryChanged()
+    {
+        OnPropertyChanged(nameof(Start));
+        OnPropertyChanged(nameof(Finish));
+        OnPropertyChanged(nameof(HasPendingWaypoint));
+        ItineraryChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    partial void OnRouteNameChanged(string value)
+    {
+        if (_suppressChanges)
+        {
+            return;
+        }
+
+        TryUpdatePlan(plan => plan.Rename(value));
+        MarkChanged();
+    }
+
+    partial void OnSelectedSavedPlanChanged(RoutePlanSummary? value) =>
+        OpenCommand.NotifyCanExecuteChanged();
+}

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -46,6 +46,9 @@ public partial class MainViewModel : ViewModelBase
     private CancellationTokenSource? _inspectionCancellation;
     private SharedRouteTimeline? _timeline;
     private long _calculationGeneration;
+    private RoutePlanId? _displayedRoutePlanId;
+    private RoutePlanId? _activeCalculationPlanId;
+    private long _activeCalculationRevision;
     private long _weatherGeneration;
     private bool _updatingTimelinePosition;
 
@@ -161,13 +164,33 @@ public partial class MainViewModel : ViewModelBase
         : this(
             workflow,
             weatherSampler,
+            localGribInspector,
+            nativeRoutingPreflight,
+            noaaProvider,
+            logger,
+            null)
+    {
+    }
+
+    public MainViewModel(
+        RoutingWorkflow workflow,
+        IWeatherSampler weatherSampler,
+        ILocalGribInspector localGribInspector,
+        INativeRoutingPreflight nativeRoutingPreflight,
+        NoaaGfsForecastProvider noaaProvider,
+        ILogger<MainViewModel> logger,
+        IRoutePlanRepository? routePlanRepository)
+        : this(
+            workflow,
+            weatherSampler,
             TimeProvider.System,
             TimeZoneInfo.Local,
             new OsmTileOptions(),
             logger,
             localGribInspector,
             nativeRoutingPreflight,
-            noaaProvider)
+            noaaProvider,
+            routePlanRepository)
     {
     }
 
@@ -180,7 +203,8 @@ public partial class MainViewModel : ViewModelBase
         ILogger<MainViewModel>? logger = null,
         ILocalGribInspector? localGribInspector = null,
         INativeRoutingPreflight? nativeRoutingPreflight = null,
-        NoaaGfsForecastProvider? noaaProvider = null)
+        NoaaGfsForecastProvider? noaaProvider = null,
+        IRoutePlanRepository? routePlanRepository = null)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(localTimeZone);
@@ -193,6 +217,9 @@ public partial class MainViewModel : ViewModelBase
         _timeProvider = timeProvider;
         _localTimeZone = localTimeZone;
         _logger = logger ?? NullLogger<MainViewModel>.Instance;
+        Itinerary = new ItineraryEditorViewModel(routePlanRepository);
+        Itinerary.ItineraryChanged += OnItineraryChanged;
+        Itinerary.MapPlacementStarted += OnMapPlacementStarted;
 
         Map = new Map
         {
@@ -206,6 +233,7 @@ public partial class MainViewModel : ViewModelBase
         Map.Layers.Add(osmLayer);
 
         _mapLayers = new RouteMapLayers(Map);
+        UpdateWaypointLayers();
         UtcOffsetDisplay = FormatUtcOffset(localTimeZone.GetUtcOffset(timeProvider.GetLocalNow()));
         Map.Navigator.CenterOnAndZoomTo(
             MapProjection.ToMapPoint(new Coordinate(35, -55)),
@@ -217,13 +245,15 @@ public partial class MainViewModel : ViewModelBase
 
     public Map Map { get; }
 
+    public ItineraryEditorViewModel Itinerary { get; }
+
     public string UtcOffsetDisplay { get; }
 
     public MapInteractionMode InteractionMode => _interaction.Mode;
 
-    public Coordinate? Start => _interaction.Start;
+    public Coordinate? Start => Itinerary.Start;
 
-    public Coordinate? Destination => _interaction.Destination;
+    public Coordinate? Destination => Itinerary.Finish;
 
     public string StartDisplay => FormatCoordinate(Start, "Not set");
 
@@ -237,6 +267,8 @@ public partial class MainViewModel : ViewModelBase
 
     public bool IsSettingDestination => InteractionMode == MapInteractionMode.SetDestination;
 
+    public bool IsSettingWaypoint => InteractionMode == MapInteractionMode.SetWaypoint;
+
     public string LocalGribDisplay => LocalForecast is null
         ? "No file selected"
         : $"{Path.GetFileName(LocalForecast.Artifact.Path)} · {ModelName(LocalForecast.Model)}\n" +
@@ -247,7 +279,8 @@ public partial class MainViewModel : ViewModelBase
     public string MapInstruction => InteractionMode switch
     {
         MapInteractionMode.SetStart => "Click the map to place the start",
-        MapInteractionMode.SetDestination => "Click the map to place the destination",
+        MapInteractionMode.SetDestination => "Click the map to place the finish",
+        MapInteractionMode.SetWaypoint => $"Click the map to place {Itinerary.ActiveWaypoint?.Name ?? "the waypoint"}",
         _ => "Pan and zoom, or select an endpoint tool"
     };
 
@@ -306,18 +339,23 @@ public partial class MainViewModel : ViewModelBase
     {
         _interaction.SetStart(start);
         _interaction.SetDestination(destination);
+        Itinerary.SetEndpoints(start, destination);
         NotifyInteractionChanged();
     }
 
     public void SetStartAt(Coordinate coordinate)
     {
         _interaction.SetStart(coordinate);
+        Itinerary.CancelMapPlacement();
+        Itinerary.Waypoints[0].Coordinate = coordinate;
         CompleteEndpointPlacement();
     }
 
     public void SetDestinationAt(Coordinate coordinate)
     {
         _interaction.SetDestination(coordinate);
+        Itinerary.CancelMapPlacement();
+        Itinerary.Waypoints[^1].Coordinate = coordinate;
         CompleteEndpointPlacement();
     }
 
@@ -337,6 +375,27 @@ public partial class MainViewModel : ViewModelBase
     public void HandleMapClick(MPoint worldPosition, ScreenPosition screenPosition)
     {
         var coordinate = MapProjection.ToCoordinate(worldPosition);
+        if (Itinerary.ActiveWaypoint is not null)
+        {
+            var waypoint = Itinerary.ActiveWaypoint;
+            Itinerary.PlaceActiveWaypoint(coordinate);
+            if (waypoint.IsStart)
+            {
+                _interaction.SetStart(coordinate);
+            }
+            else if (waypoint.IsFinish)
+            {
+                _interaction.SetDestination(coordinate);
+            }
+            else
+            {
+                _interaction.Activate(MapInteractionMode.Browse);
+            }
+
+            CompleteEndpointPlacement();
+            return;
+        }
+
         if (_interaction.HandleMapClick(coordinate))
         {
             CompleteEndpointPlacement();
@@ -459,6 +518,10 @@ public partial class MainViewModel : ViewModelBase
         }
 
         var generation = Interlocked.Increment(ref _calculationGeneration);
+        var calculationPlanId = Itinerary.PlanId;
+        var calculationRevision = Itinerary.CalculationRevision;
+        _activeCalculationPlanId = calculationPlanId;
+        _activeCalculationRevision = calculationRevision;
         var cancellation = new CancellationTokenSource();
         var previous = Interlocked.Exchange(ref _calculationCancellation, cancellation);
         previous?.Cancel();
@@ -513,6 +576,13 @@ public partial class MainViewModel : ViewModelBase
                 return;
             }
 
+            if (Itinerary.PlanId != calculationPlanId ||
+                Itinerary.CalculationRevision != calculationRevision)
+            {
+                StatusMessage = "Calculation result discarded because the itinerary changed.";
+                return;
+            }
+
             ApplyWorkflowResult(result);
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
@@ -537,6 +607,7 @@ public partial class MainViewModel : ViewModelBase
             if (IsCurrentCalculation(generation))
             {
                 IsCalculating = false;
+                _activeCalculationPlanId = null;
             }
         }
     }
@@ -632,15 +703,13 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void SetStart()
     {
-        _interaction.Activate(MapInteractionMode.SetStart);
-        NotifyInteractionChanged();
+        Itinerary.BeginMapPlacement(Itinerary.Waypoints[0]);
     }
 
     [RelayCommand]
     private void SetDestination()
     {
-        _interaction.Activate(MapInteractionMode.SetDestination);
-        NotifyInteractionChanged();
+        Itinerary.BeginMapPlacement(Itinerary.Waypoints[^1]);
     }
 
     [RelayCommand(CanExecute = nameof(CanCalculate))]
@@ -821,6 +890,13 @@ public partial class MainViewModel : ViewModelBase
             return false;
         }
 
+        if (Itinerary.Waypoints.Count != 2)
+        {
+            error = "Sequential multi-leg route calculation is not available yet. " +
+                    "Save the itinerary, or remove intermediate waypoints to calculate a direct route.";
+            return false;
+        }
+
         var selections = new List<ForecastSelection>();
         if (ForecastInputMode == ForecastInputMode.LocalFile)
         {
@@ -898,6 +974,7 @@ public partial class MainViewModel : ViewModelBase
         _acquisitions.Clear();
         var failures = new List<string>();
         var warnings = new List<string>();
+        var recordedRoutes = new List<RouteResult>();
         foreach (var outcome in result.Outcomes)
         {
             if (outcome.Acquisition is not null)
@@ -976,8 +1053,35 @@ public partial class MainViewModel : ViewModelBase
                 ? ForecastModel.EcmwfIfs
                 : null;
 
-        var routes = result.SuccessfulRoutes;
+        foreach (var outcome in result.Outcomes)
+        {
+            var reason = outcome.Route is not null
+                ? outcome.Route.IsForecastLimited
+                    ? RouteLegOutcomeReason.ForecastExhausted
+                    : RouteLegOutcomeReason.CalculationSucceeded
+                : outcome.Failure!.Stage switch
+                {
+                    ModelRouteFailureStage.ForecastAcquisition =>
+                        RouteLegOutcomeReason.ForecastAcquisitionFailed,
+                    ModelRouteFailureStage.RouteCalculation =>
+                        RouteLegOutcomeReason.RouteCalculationFailed,
+                    _ => RouteLegOutcomeReason.ResultValidationFailed
+                };
+            var recordedRoute = Itinerary.RecordSingleLegOutcome(
+                outcome.Model,
+                outcome.Route,
+                reason,
+                outcome.Failure?.Message,
+                _timeProvider.GetUtcNow());
+            if (recordedRoute is not null)
+            {
+                recordedRoutes.Add(recordedRoute);
+            }
+        }
+
+        var routes = recordedRoutes.ToImmutableArray();
         _mapLayers.SetRoutes(routes);
+        _displayedRoutePlanId = Itinerary.PlanId;
         _mapLayers.FitRoutes();
         OnPropertyChanged(nameof(SuccessfulRouteCount));
         BuildTimeline(routes);
@@ -1244,6 +1348,8 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(MapInstruction));
         OnPropertyChanged(nameof(IsSettingStart));
         OnPropertyChanged(nameof(IsSettingDestination));
+        OnPropertyChanged(nameof(IsSettingWaypoint));
+        UpdateWaypointLayers();
         UpdateForecastAreaSummary();
     }
 
@@ -1251,7 +1357,9 @@ public partial class MainViewModel : ViewModelBase
     {
         NotifyInteractionChanged();
         StatusMessage = Start is not null && Destination is not null
-            ? "Endpoints ready. Choose forecast models and calculate."
+            ? Itinerary.Waypoints.Count == 2
+                ? "Endpoints ready. Choose forecast models and calculate."
+                : "Itinerary updated. Multi-leg calculation will be added in a later slice."
             : "Endpoint placed. Set the remaining endpoint.";
     }
 
@@ -1409,4 +1517,74 @@ public partial class MainViewModel : ViewModelBase
 
         return minutes > 0 ? $"{minutes}m" : $"{overrun.Seconds}s";
     }
+
+    private void OnMapPlacementStarted(
+        object? sender,
+        WaypointEditorItemViewModel waypoint)
+    {
+        _interaction.Activate(waypoint.IsStart
+            ? MapInteractionMode.SetStart
+            : waypoint.IsFinish
+                ? MapInteractionMode.SetDestination
+                : MapInteractionMode.SetWaypoint);
+        NotifyInteractionChanged();
+    }
+
+    private void OnItineraryChanged(object? sender, EventArgs e)
+    {
+        if (IsCalculating &&
+            (_activeCalculationPlanId != Itinerary.PlanId ||
+             _activeCalculationRevision != Itinerary.CalculationRevision))
+        {
+            Interlocked.Increment(ref _calculationGeneration);
+            var cancellation = Interlocked.Exchange(ref _calculationCancellation, null);
+            cancellation?.Cancel();
+            cancellation?.Dispose();
+            _mapLayers.ClearCalculationOverlays();
+            IsCalculating = false;
+            _activeCalculationPlanId = null;
+            StatusMessage = "Calculation cancelled because the itinerary changed.";
+        }
+
+        if (Itinerary.ActiveWaypoint is null)
+        {
+            _interaction.Activate(MapInteractionMode.Browse);
+        }
+
+        if (Itinerary.Start is { } start)
+        {
+            _interaction.SetStart(start);
+        }
+
+        if (Itinerary.Finish is { } finish)
+        {
+            _interaction.SetDestination(finish);
+        }
+
+        if (_mapLayers.Routes.Count > 0 &&
+            (_displayedRoutePlanId != Itinerary.PlanId ||
+             Itinerary.ResultsInvalidated ||
+             Start is null ||
+             Destination is null ||
+             _mapLayers.Routes.Any(route =>
+                 !route.Request.Origin.IsSameLocation(Start.Value) ||
+                 !route.Request.Destination.IsSameLocation(Destination.Value))))
+        {
+            _mapLayers.SetRoutes([]);
+            _displayedRoutePlanId = null;
+            BuildTimeline([]);
+            _acquisitions.Clear();
+            HasNoaaWeather = false;
+            HasEcmwfWeather = false;
+            ActiveWeatherModel = null;
+            OnPropertyChanged(nameof(SuccessfulRouteCount));
+            LandAvoidanceWarning = null;
+        }
+
+        NotifyInteractionChanged();
+    }
+
+    private void UpdateWaypointLayers() =>
+        _mapLayers.SetWaypoints(Itinerary.Waypoints.Select(waypoint =>
+            new WaypointMapMarker(waypoint.Position, waypoint.Name, waypoint.Coordinate)));
 }

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -1,6 +1,7 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:Navtool.App.ViewModels"
+        xmlns:core="using:Navtool.Core"
         xmlns:mapsui="using:Mapsui.UI.Avalonia"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -87,49 +88,118 @@
                                        FontWeight="SemiBold"
                                        Foreground="{DynamicResource TextPrimaryColor}" />
                             <TextBlock Classes="muted"
-                                       Text="Choose endpoints, departure, and forecast models." />
+                                       Text="Build an ordered itinerary, then choose departure and forecasts." />
                         </StackPanel>
 
                         <Border Classes="card">
                             <StackPanel Spacing="10">
                                 <TextBlock Classes="section-title"
-                                           Text="1  ROUTE ENDPOINTS" />
-                                <ToggleButton x:Name="SetStartButton"
-                                              Classes="map-tool"
-                                              IsChecked="{Binding IsSettingStart, Mode=OneWay}"
-                                              Command="{Binding SetStartCommand}">
-                                    <Grid ColumnDefinitions="14,10,*">
-                                        <Ellipse Width="12"
-                                                 Height="12"
-                                                 Fill="#009E73"
-                                                 Stroke="{DynamicResource MarkerOutlineColor}"
-                                                 StrokeThickness="2" />
-                                        <StackPanel Grid.Column="2">
-                                            <TextBlock Text="Set start"
-                                                       FontWeight="SemiBold" />
-                                            <TextBlock Text="{Binding StartDisplay}"
-                                                       Classes="muted" />
-                                        </StackPanel>
-                                    </Grid>
-                                </ToggleButton>
-                                <ToggleButton x:Name="SetDestinationButton"
-                                              Classes="map-tool"
-                                              IsChecked="{Binding IsSettingDestination, Mode=OneWay}"
-                                              Command="{Binding SetDestinationCommand}">
-                                    <Grid ColumnDefinitions="14,10,*">
-                                        <Ellipse Width="12"
-                                                 Height="12"
-                                                 Fill="#CC3311"
-                                                 Stroke="{DynamicResource MarkerOutlineColor}"
-                                                 StrokeThickness="2" />
-                                        <StackPanel Grid.Column="2">
-                                            <TextBlock Text="Set destination"
-                                                       FontWeight="SemiBold" />
-                                            <TextBlock Text="{Binding DestinationDisplay}"
-                                                       Classes="muted" />
-                                        </StackPanel>
-                                    </Grid>
-                                </ToggleButton>
+                                           Text="1  ITINERARY" />
+                                <TextBox Text="{Binding Itinerary.RouteName}"
+                                         Watermark="Route name" />
+                                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="6">
+                                    <Button Content="New"
+                                            Command="{Binding Itinerary.NewCommand}" />
+                                    <ComboBox Grid.Column="1"
+                                              ItemsSource="{Binding Itinerary.SavedPlans}"
+                                              SelectedItem="{Binding Itinerary.SelectedSavedPlan}">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate x:DataType="core:RoutePlanSummary">
+                                                <TextBlock Text="{Binding Name}" />
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+                                    <Button Grid.Column="2"
+                                            Content="Open"
+                                            Command="{Binding Itinerary.OpenCommand}" />
+                                </Grid>
+                                <Button Content="Refresh saved routes"
+                                        Command="{Binding Itinerary.RefreshSavedPlansCommand}" />
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="6">
+                                    <ToggleButton x:Name="SetStartButton"
+                                                  Classes="map-tool"
+                                                  Content="Set start"
+                                                  IsChecked="{Binding IsSettingStart, Mode=OneWay}"
+                                                  Command="{Binding SetStartCommand}" />
+                                    <ToggleButton x:Name="SetDestinationButton"
+                                                  Grid.Column="1"
+                                                  Classes="map-tool"
+                                                  Content="Set finish"
+                                                  IsChecked="{Binding IsSettingDestination, Mode=OneWay}"
+                                                  Command="{Binding SetDestinationCommand}" />
+                                </Grid>
+                                <ItemsControl ItemsSource="{Binding Itinerary.Waypoints}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:WaypointEditorItemViewModel">
+                                            <Border Classes="subtle" Margin="0,0,0,6">
+                                                <StackPanel Spacing="6">
+                                                    <Grid ColumnDefinitions="28,*,Auto" ColumnSpacing="6">
+                                                        <Border Width="24"
+                                                                Height="24"
+                                                                CornerRadius="12"
+                                                                Background="#263238">
+                                                            <TextBlock Text="{Binding PositionLabel}"
+                                                                       Foreground="White"
+                                                                       FontWeight="Bold"
+                                                                       HorizontalAlignment="Center"
+                                                                       VerticalAlignment="Center" />
+                                                        </Border>
+                                                        <StackPanel Grid.Column="1">
+                                                            <TextBox Text="{Binding Name}" />
+                                                            <TextBlock Text="{Binding CoordinateDisplay}"
+                                                                       Classes="muted" />
+                                                        </StackPanel>
+                                                        <Button Grid.Column="2"
+                                                                Content="Map"
+                                                                Command="{Binding SetOnMapCommand}" />
+                                                    </Grid>
+                                                    <Grid IsVisible="{Binding IsIntermediate}"
+                                                          ColumnDefinitions="Auto,*,Auto,Auto"
+                                                          ColumnSpacing="5">
+                                                        <CheckBox Content="Stopover"
+                                                                  IsChecked="{Binding HasStopover}" />
+                                                        <NumericUpDown Grid.Column="1"
+                                                                       Minimum="0.25"
+                                                                       Maximum="240"
+                                                                       Increment="0.25"
+                                                                       Value="{Binding StopoverHours}"
+                                                                       IsEnabled="{Binding HasStopover}" />
+                                                        <Button Grid.Column="2"
+                                                                Content="↑"
+                                                                Command="{Binding MoveUpCommand}" />
+                                                        <Button Grid.Column="3"
+                                                                Content="↓"
+                                                                Command="{Binding MoveDownCommand}" />
+                                                    </Grid>
+                                                    <Button IsVisible="{Binding IsIntermediate}"
+                                                            Content="Remove waypoint"
+                                                            Command="{Binding RemoveCommand}" />
+                                                </StackPanel>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                                <Button Content="Add waypoint"
+                                        Command="{Binding Itinerary.AddWaypointCommand}" />
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                                    <TextBox Text="{Binding Itinerary.SaveAsName}"
+                                             Watermark="Save-as name" />
+                                    <Button Grid.Column="1"
+                                            Content="Save as"
+                                            Command="{Binding Itinerary.SaveAsCommand}" />
+                                </Grid>
+                                <Button Content="Save"
+                                        Command="{Binding Itinerary.SaveCommand}" />
+                                <TextBlock Text="{Binding Itinerary.StorageError}"
+                                           Classes="error"
+                                           TextWrapping="Wrap" />
+                                <TextBlock Text="{Binding Itinerary.ValidationMessage}"
+                                           Classes="error"
+                                           TextWrapping="Wrap" />
+                                <TextBlock Classes="muted"
+                                           Text="{Binding Itinerary.IsDirty, StringFormat=Unsaved changes: {0}}" />
+                                <TextBlock Classes="muted"
+                                           Text="{Binding Itinerary.ResultsInvalidated, StringFormat=Results invalidated: {0}}" />
                             </StackPanel>
                         </Border>
 

--- a/src/Navtool.Core/RoutePlans.cs
+++ b/src/Navtool.Core/RoutePlans.cs
@@ -1,0 +1,715 @@
+using System.Collections.Immutable;
+using System.Security.Cryptography;
+
+namespace Navtool.Core;
+
+public readonly record struct RoutePlanId(Guid Value)
+{
+    public RoutePlanId() : this(Guid.NewGuid())
+    {
+    }
+
+    public override string ToString() => Value.ToString("N");
+}
+
+public readonly record struct RouteWaypointId(Guid Value)
+{
+    public RouteWaypointId() : this(Guid.NewGuid())
+    {
+    }
+
+    public override string ToString() => Value.ToString("N");
+}
+
+public readonly record struct RouteCalculationSessionId(Guid Value)
+{
+    public RouteCalculationSessionId() : this(Guid.NewGuid())
+    {
+    }
+
+    public override string ToString() => Value.ToString("N");
+}
+
+public readonly record struct RouteLegId(Guid Value)
+{
+    public static RouteLegId FromEndpoints(RouteWaypointId from, RouteWaypointId to)
+    {
+        Span<byte> input = stackalloc byte[32];
+        from.Value.TryWriteBytes(input[..16]);
+        to.Value.TryWriteBytes(input[16..]);
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(input, hash);
+        return new RouteLegId(new Guid(hash[..16]));
+    }
+
+    public override string ToString() => Value.ToString("N");
+}
+
+public sealed record RouteWaypoint
+{
+    public RouteWaypoint(
+        RouteWaypointId id,
+        string name,
+        Coordinate coordinate,
+        TimeSpan? stopover = null)
+    {
+        if (id.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A waypoint ID cannot be empty.", nameof(id));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        if (stopover <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(stopover), "A stopover must be greater than zero.");
+        }
+
+        Id = id;
+        Name = name.Trim();
+        Coordinate = coordinate;
+        Stopover = stopover;
+    }
+
+    public RouteWaypoint(string name, Coordinate coordinate, TimeSpan? stopover = null)
+        : this(new RouteWaypointId(), name, coordinate, stopover)
+    {
+    }
+
+    public RouteWaypointId Id { get; }
+
+    public string Name { get; }
+
+    public Coordinate Coordinate { get; }
+
+    public TimeSpan? Stopover { get; }
+
+    public RouteWaypoint Rename(string name) => new(Id, name, Coordinate, Stopover);
+
+    public RouteWaypoint MoveTo(Coordinate coordinate) => new(Id, Name, coordinate, Stopover);
+
+    public RouteWaypoint WithStopover(TimeSpan? stopover) => new(Id, Name, Coordinate, stopover);
+}
+
+public sealed record RouteLeg(
+    RouteLegId Id,
+    int Index,
+    RouteWaypointId FromWaypointId,
+    RouteWaypointId ToWaypointId)
+{
+    public static RouteLeg Create(int index, RouteWaypoint from, RouteWaypoint to) =>
+        new(RouteLegId.FromEndpoints(from.Id, to.Id), index, from.Id, to.Id);
+}
+
+public sealed record RouteCalculationSession
+{
+    public RouteCalculationSession(
+        RouteCalculationSessionId id,
+        RoutePlanId planId,
+        ForecastModel model,
+        DateTimeOffset startedAt,
+        DateTimeOffset? completedAt = null)
+    {
+        if (id.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A calculation session ID cannot be empty.", nameof(id));
+        }
+
+        if (planId.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A route plan ID cannot be empty.", nameof(planId));
+        }
+
+        _ = model.Provider();
+        var utcStartedAt = startedAt.ToUniversalTime();
+        var utcCompletedAt = completedAt?.ToUniversalTime();
+        if (utcCompletedAt < utcStartedAt)
+        {
+            throw new ArgumentOutOfRangeException(nameof(completedAt), "Completion cannot precede the start.");
+        }
+
+        Id = id;
+        PlanId = planId;
+        Model = model;
+        StartedAt = utcStartedAt;
+        CompletedAt = utcCompletedAt;
+    }
+
+    public RouteCalculationSession(
+        RoutePlanId planId,
+        ForecastModel model,
+        DateTimeOffset startedAt)
+        : this(new RouteCalculationSessionId(), planId, model, startedAt)
+    {
+    }
+
+    public RouteCalculationSessionId Id { get; }
+
+    public RoutePlanId PlanId { get; }
+
+    public ForecastModel Model { get; }
+
+    public DateTimeOffset StartedAt { get; }
+
+    public DateTimeOffset? CompletedAt { get; }
+
+    public RouteCalculationSession Complete(DateTimeOffset completedAt) =>
+        new(Id, PlanId, Model, StartedAt, completedAt);
+}
+
+public enum RouteLegOutcomeState
+{
+    Pending,
+    Succeeded,
+    Failed,
+    Invalidated
+}
+
+public enum RouteLegOutcomeReason
+{
+    None,
+    CalculationSucceeded,
+    ForecastExhausted,
+    ForecastAcquisitionFailed,
+    RouteCalculationFailed,
+    ResultValidationFailed,
+    WaypointCoordinateChanged,
+    WaypointsReordered,
+    StopoverChanged,
+    WaypointAdded,
+    WaypointRemoved
+}
+
+public sealed record RouteLegResult
+{
+    public RouteLegResult(
+        RouteLegId legId,
+        RouteLegOutcomeState state,
+        RouteLegOutcomeReason reason,
+        RouteResult? route = null,
+        string? detail = null,
+        RouteLegOutcomeReason? deferredInvalidationReason = null)
+    {
+        if (legId.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A route leg ID cannot be empty.", nameof(legId));
+        }
+
+        if (!Enum.IsDefined(state))
+        {
+            throw new ArgumentOutOfRangeException(nameof(state));
+        }
+
+        if (!Enum.IsDefined(reason))
+        {
+            throw new ArgumentOutOfRangeException(nameof(reason));
+        }
+
+        if (state == RouteLegOutcomeState.Succeeded && route is null)
+        {
+            throw new ArgumentException("A successful leg outcome requires a route.", nameof(route));
+        }
+
+        if (state != RouteLegOutcomeState.Succeeded && route is not null)
+        {
+            throw new ArgumentException("Only successful leg outcomes may contain a route.", nameof(route));
+        }
+
+        if ((state == RouteLegOutcomeState.Pending && reason != RouteLegOutcomeReason.None) ||
+            (state != RouteLegOutcomeState.Pending && reason == RouteLegOutcomeReason.None))
+        {
+            throw new ArgumentException("The outcome state and reason are inconsistent.", nameof(reason));
+        }
+
+        if (deferredInvalidationReason is not null &&
+            (deferredInvalidationReason == RouteLegOutcomeReason.None ||
+             !Enum.IsDefined(deferredInvalidationReason.Value)))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(deferredInvalidationReason),
+                "A deferred invalidation requires a defined non-empty reason.");
+        }
+
+        LegId = legId;
+        State = state;
+        Reason = reason;
+        Route = route;
+        Detail = string.IsNullOrWhiteSpace(detail) ? null : detail.Trim();
+        DeferredInvalidationReason = deferredInvalidationReason;
+    }
+
+    public RouteLegId LegId { get; }
+
+    public RouteLegOutcomeState State { get; }
+
+    public RouteLegOutcomeReason Reason { get; }
+
+    public RouteResult? Route { get; }
+
+    public string? Detail { get; }
+
+    public RouteLegOutcomeReason? DeferredInvalidationReason { get; }
+
+    public RouteLegResult Invalidate(RouteLegOutcomeReason reason) =>
+        new(LegId, RouteLegOutcomeState.Invalidated, reason);
+
+    public RouteLegResult DeferInvalidation(RouteLegOutcomeReason reason) =>
+        State == RouteLegOutcomeState.Invalidated
+            ? this
+            : new(LegId, State, Reason, Route, Detail, reason);
+}
+
+public sealed record RoutePlanResult
+{
+    public RoutePlanResult(
+        RouteCalculationSession session,
+        IEnumerable<RouteLegResult> legs)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(legs);
+        var immutableLegs = legs.ToImmutableArray();
+        if (immutableLegs.Select(leg => leg.LegId).Distinct().Count() != immutableLegs.Length)
+        {
+            throw new ArgumentException("A route plan result cannot contain duplicate leg IDs.", nameof(legs));
+        }
+
+        if (immutableLegs.Any(leg => leg.Route is not null && leg.Route.Model != session.Model))
+        {
+            throw new ArgumentException("Every route leg result must use the calculation session model.", nameof(legs));
+        }
+
+        Session = session;
+        Legs = immutableLegs;
+    }
+
+    public RouteCalculationSession Session { get; }
+
+    public ForecastModel Model => Session.Model;
+
+    public ImmutableArray<RouteLegResult> Legs { get; }
+
+    public bool IsInvalidated => Legs.Any(leg =>
+        leg.State == RouteLegOutcomeState.Invalidated ||
+        leg.DeferredInvalidationReason is not null);
+}
+
+public sealed record RoutePlan
+{
+    public RoutePlan(
+        RoutePlanId id,
+        string name,
+        IEnumerable<RouteWaypoint> waypoints,
+        IEnumerable<RoutePlanResult>? results = null,
+        IEnumerable<RouteLegId>? sailedLegIds = null)
+    {
+        if (id.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A route plan ID cannot be empty.", nameof(id));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(waypoints);
+        var immutableWaypoints = waypoints.ToImmutableArray();
+        ValidateWaypoints(immutableWaypoints);
+        var legs = CreateLegs(immutableWaypoints);
+        var immutableResults = (results ?? []).ToImmutableArray();
+        var immutableSailed = (sailedLegIds ?? []).ToImmutableHashSet();
+        ValidateReferences(id, immutableWaypoints, legs, immutableResults, immutableSailed);
+
+        Id = id;
+        Name = name.Trim();
+        Waypoints = immutableWaypoints;
+        Legs = legs;
+        Results = immutableResults;
+        SailedLegIds = immutableSailed;
+    }
+
+    public RoutePlan(string name, IEnumerable<RouteWaypoint> waypoints)
+        : this(new RoutePlanId(), name, waypoints)
+    {
+    }
+
+    public RoutePlanId Id { get; }
+
+    public string Name { get; }
+
+    public ImmutableArray<RouteWaypoint> Waypoints { get; }
+
+    public ImmutableArray<RouteLeg> Legs { get; }
+
+    public ImmutableArray<RoutePlanResult> Results { get; }
+
+    public ImmutableHashSet<RouteLegId> SailedLegIds { get; }
+
+    public bool HasInvalidatedResults => Results.Any(result => result.IsInvalidated);
+
+    public RoutePlanResult? LatestResult(ForecastModel model) =>
+        Results.SingleOrDefault(result => result.Model == model);
+
+    public RoutePlan Rename(string name) =>
+        new(Id, name, Waypoints, Results, SailedLegIds);
+
+    public RoutePlan RenameWaypoint(RouteWaypointId waypointId, string name)
+    {
+        var index = FindWaypointIndex(waypointId);
+        return ReplaceWaypoint(index, Waypoints[index].Rename(name), null, RouteLegOutcomeReason.None);
+    }
+
+    public RoutePlan ChangeWaypointCoordinate(RouteWaypointId waypointId, Coordinate coordinate)
+    {
+        var index = FindWaypointIndex(waypointId);
+        if (Waypoints[index].Coordinate.IsSameLocation(coordinate))
+        {
+            return this;
+        }
+
+        return ReplaceWaypoint(
+            index,
+            Waypoints[index].MoveTo(coordinate),
+            Math.Max(0, index - 1),
+            RouteLegOutcomeReason.WaypointCoordinateChanged);
+    }
+
+    public RoutePlan ChangeStopover(RouteWaypointId waypointId, TimeSpan? stopover)
+    {
+        var index = FindWaypointIndex(waypointId);
+        EnsureIntermediate(index, "Only intermediate waypoints may have stopovers.");
+        if (Waypoints[index].Stopover == stopover)
+        {
+            return this;
+        }
+
+        return ReplaceWaypoint(
+            index,
+            Waypoints[index].WithStopover(stopover),
+            index,
+            RouteLegOutcomeReason.StopoverChanged);
+    }
+
+    public RoutePlan AddWaypoint(RouteWaypoint waypoint, int index)
+    {
+        ArgumentNullException.ThrowIfNull(waypoint);
+        if (index <= 0 || index >= Waypoints.Length)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), "A waypoint can only be added between start and finish.");
+        }
+
+        if (Waypoints.Any(existing => existing.Id == waypoint.Id))
+        {
+            throw new ArgumentException("Waypoint IDs must be unique.", nameof(waypoint));
+        }
+
+        var updated = Waypoints.Insert(index, waypoint);
+        return Rebuild(updated, Math.Max(0, index - 1), RouteLegOutcomeReason.WaypointAdded);
+    }
+
+    public RoutePlan RemoveWaypoint(RouteWaypointId waypointId)
+    {
+        var index = FindWaypointIndex(waypointId);
+        EnsureIntermediate(index, "Start and finish waypoints cannot be removed.");
+        return Rebuild(
+            Waypoints.RemoveAt(index),
+            Math.Max(0, index - 1),
+            RouteLegOutcomeReason.WaypointRemoved);
+    }
+
+    public RoutePlan MoveWaypoint(RouteWaypointId waypointId, int newIndex)
+    {
+        var oldIndex = FindWaypointIndex(waypointId);
+        EnsureIntermediate(oldIndex, "Start and finish waypoints cannot be reordered.");
+        if (newIndex <= 0 || newIndex >= Waypoints.Length - 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(newIndex), "Intermediate waypoints must remain between start and finish.");
+        }
+
+        if (newIndex == oldIndex)
+        {
+            return this;
+        }
+
+        var waypoint = Waypoints[oldIndex];
+        var updated = Waypoints.RemoveAt(oldIndex).Insert(newIndex, waypoint);
+        return Rebuild(
+            updated,
+            Math.Max(0, Math.Min(oldIndex, newIndex) - 1),
+            RouteLegOutcomeReason.WaypointsReordered);
+    }
+
+    public RoutePlan WithResult(RoutePlanResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        if (result.Session.PlanId != Id)
+        {
+            throw new ArgumentException("The calculation session belongs to a different route plan.", nameof(result));
+        }
+
+        ValidateResultLegs(result, Legs);
+        var existingForModel = LatestResult(result.Model);
+        if (existingForModel is not null && SailedLegIds.Count > 0)
+        {
+            var existingByLeg = existingForModel.Legs.ToDictionary(leg => leg.LegId);
+            result = new RoutePlanResult(
+                result.Session,
+                result.Legs.Select(outcome =>
+                    SailedLegIds.Contains(outcome.LegId) &&
+                    existingByLeg.TryGetValue(outcome.LegId, out var sailed)
+                        ? sailed
+                        : outcome));
+        }
+
+        var retained = Results.Where(existing => existing.Model != result.Model);
+        return new RoutePlan(Id, Name, Waypoints, retained.Append(result), SailedLegIds);
+    }
+
+    public RoutePlan MarkSailed(RouteLegId legId)
+    {
+        EnsureLegExists(legId);
+        return new RoutePlan(Id, Name, Waypoints, Results, SailedLegIds.Add(legId));
+    }
+
+    public RoutePlan UnmarkSailed(RouteLegId legId)
+    {
+        EnsureLegExists(legId);
+        var leg = Legs.Single(item => item.Id == legId);
+        var from = Waypoints.Single(item => item.Id == leg.FromWaypointId);
+        var to = Waypoints.Single(item => item.Id == leg.ToWaypointId);
+        var updatedResults = Results.Select(result => new RoutePlanResult(
+            result.Session,
+            result.Legs.Select(outcome =>
+            {
+                if (outcome.LegId != legId)
+                {
+                    return outcome;
+                }
+
+                if (outcome.DeferredInvalidationReason is { } deferredReason)
+                {
+                    return outcome.Invalidate(deferredReason);
+                }
+
+                return outcome.Route is not null &&
+                       (!outcome.Route.Request.Origin.IsSameLocation(from.Coordinate) ||
+                        !outcome.Route.Request.Destination.IsSameLocation(to.Coordinate))
+                    ? outcome.Invalidate(RouteLegOutcomeReason.WaypointCoordinateChanged)
+                    : outcome;
+            })));
+        return new RoutePlan(
+            Id,
+            Name,
+            Waypoints,
+            updatedResults,
+            SailedLegIds.Remove(legId));
+    }
+
+    private RoutePlan ReplaceWaypoint(
+        int index,
+        RouteWaypoint waypoint,
+        int? invalidFromLeg,
+        RouteLegOutcomeReason reason)
+    {
+        var updated = Waypoints.SetItem(index, waypoint);
+        return invalidFromLeg is null
+            ? new RoutePlan(Id, Name, updated, Results, SailedLegIds)
+            : Rebuild(updated, invalidFromLeg.Value, reason);
+    }
+
+    private RoutePlan Rebuild(
+        ImmutableArray<RouteWaypoint> waypoints,
+        int invalidFromLeg,
+        RouteLegOutcomeReason reason)
+    {
+        ValidateWaypoints(waypoints);
+        var newLegs = CreateLegs(waypoints);
+        var newLegIds = newLegs.Select(leg => leg.Id).ToImmutableHashSet();
+        var removedSailed = SailedLegIds.Except(newLegIds).ToArray();
+        if (removedSailed.Length > 0)
+        {
+            throw new InvalidOperationException("Unmark sailed legs before changing their waypoint boundaries.");
+        }
+
+        var updatedResults = Results
+            .Select(result => RebuildResult(result, newLegs, invalidFromLeg, reason))
+            .ToArray();
+        return new RoutePlan(Id, Name, waypoints, updatedResults, SailedLegIds);
+    }
+
+    private RoutePlanResult RebuildResult(
+        RoutePlanResult result,
+        ImmutableArray<RouteLeg> newLegs,
+        int invalidFromLeg,
+        RouteLegOutcomeReason reason)
+    {
+        var existing = result.Legs.ToDictionary(leg => leg.LegId);
+        var rebuilt = newLegs.Select(leg =>
+        {
+            if (SailedLegIds.Contains(leg.Id) && existing.TryGetValue(leg.Id, out var sailed))
+            {
+                return leg.Index >= invalidFromLeg
+                    ? sailed.DeferInvalidation(reason)
+                    : sailed;
+            }
+
+            if (leg.Index < invalidFromLeg && existing.TryGetValue(leg.Id, out var unchanged))
+            {
+                return unchanged;
+            }
+
+            return new RouteLegResult(
+                leg.Id,
+                RouteLegOutcomeState.Invalidated,
+                reason);
+        });
+        return new RoutePlanResult(result.Session, rebuilt);
+    }
+
+    private int FindWaypointIndex(RouteWaypointId waypointId)
+    {
+        for (var index = 0; index < Waypoints.Length; index++)
+        {
+            if (Waypoints[index].Id == waypointId)
+            {
+                return index;
+            }
+        }
+
+        throw new KeyNotFoundException($"Waypoint '{waypointId}' was not found.");
+    }
+
+    private void EnsureIntermediate(int index, string message)
+    {
+        if (index == 0 || index == Waypoints.Length - 1)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+    private void EnsureLegExists(RouteLegId legId)
+    {
+        if (!Legs.Any(leg => leg.Id == legId))
+        {
+            throw new KeyNotFoundException($"Route leg '{legId}' was not found.");
+        }
+    }
+
+    private static ImmutableArray<RouteLeg> CreateLegs(ImmutableArray<RouteWaypoint> waypoints)
+    {
+        var builder = ImmutableArray.CreateBuilder<RouteLeg>(waypoints.Length - 1);
+        for (var index = 0; index < waypoints.Length - 1; index++)
+        {
+            builder.Add(RouteLeg.Create(index, waypoints[index], waypoints[index + 1]));
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    private static void ValidateWaypoints(ImmutableArray<RouteWaypoint> waypoints)
+    {
+        if (waypoints.Length < 2)
+        {
+            throw new ArgumentException("A route plan requires at least a start and finish.", nameof(waypoints));
+        }
+
+        if (waypoints.Any(waypoint => waypoint is null))
+        {
+            throw new ArgumentException("Route waypoints cannot be null.", nameof(waypoints));
+        }
+
+        if (waypoints.Select(waypoint => waypoint.Id).Distinct().Count() != waypoints.Length)
+        {
+            throw new ArgumentException("Waypoint IDs must be unique.", nameof(waypoints));
+        }
+
+        if (waypoints[0].Stopover is not null || waypoints[^1].Stopover is not null)
+        {
+            throw new ArgumentException("Start and finish waypoints cannot have stopovers.", nameof(waypoints));
+        }
+
+        for (var index = 1; index < waypoints.Length; index++)
+        {
+            if (waypoints[index - 1].Coordinate.IsSameLocation(waypoints[index].Coordinate))
+            {
+                throw new ArgumentException("Adjacent waypoint coordinates must differ.", nameof(waypoints));
+            }
+        }
+    }
+
+    private static void ValidateReferences(
+        RoutePlanId planId,
+        ImmutableArray<RouteWaypoint> waypoints,
+        ImmutableArray<RouteLeg> legs,
+        ImmutableArray<RoutePlanResult> results,
+        ImmutableHashSet<RouteLegId> sailedLegIds)
+    {
+        if (results.Select(result => result.Model).Distinct().Count() != results.Length)
+        {
+            throw new ArgumentException("Only the latest result for each forecast model may be stored.", nameof(results));
+        }
+
+        foreach (var result in results)
+        {
+            if (result.Session.PlanId != planId)
+            {
+                throw new ArgumentException("A calculation session references a different route plan.", nameof(results));
+            }
+
+            ValidateResultLegs(result, legs);
+            foreach (var legResult in result.Legs.Where(item => item.Route is not null))
+            {
+                if (sailedLegIds.Contains(legResult.LegId))
+                {
+                    continue;
+                }
+
+                var leg = legs.Single(item => item.Id == legResult.LegId);
+                var from = waypoints.Single(item => item.Id == leg.FromWaypointId);
+                var to = waypoints.Single(item => item.Id == leg.ToWaypointId);
+                if (!legResult.Route!.Request.Origin.IsSameLocation(from.Coordinate) ||
+                    !legResult.Route.Request.Destination.IsSameLocation(to.Coordinate))
+                {
+                    throw new ArgumentException("A route result does not match its referenced leg endpoints.", nameof(results));
+                }
+            }
+        }
+
+        var legIds = legs.Select(leg => leg.Id).ToImmutableHashSet();
+        if (!sailedLegIds.IsSubsetOf(legIds))
+        {
+            throw new ArgumentException("A sailed-leg reference does not exist in the route plan.", nameof(sailedLegIds));
+        }
+    }
+
+    private static void ValidateResultLegs(RoutePlanResult result, ImmutableArray<RouteLeg> legs)
+    {
+        var expected = legs.Select(leg => leg.Id).ToImmutableHashSet();
+        var actual = result.Legs.Select(leg => leg.LegId).ToImmutableHashSet();
+        if (!expected.SetEquals(actual))
+        {
+            throw new ArgumentException("A route plan result must contain exactly one outcome for every current leg.");
+        }
+    }
+}
+
+public sealed record RoutePlanSummary(RoutePlanId Id, string Name, int WaypointCount);
+
+public sealed class RoutePlanRepositoryException : Exception
+{
+    public RoutePlanRepositoryException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}
+
+public interface IRoutePlanRepository
+{
+    ValueTask<ImmutableArray<RoutePlanSummary>> ListAsync(CancellationToken cancellationToken = default);
+
+    ValueTask<RoutePlan> OpenAsync(RoutePlanId id, CancellationToken cancellationToken = default);
+
+    ValueTask SaveAsync(RoutePlan plan, CancellationToken cancellationToken = default);
+
+    ValueTask<RoutePlan> SaveAsAsync(
+        RoutePlan plan,
+        string name,
+        CancellationToken cancellationToken = default);
+
+    ValueTask DeleteAsync(RoutePlanId id, CancellationToken cancellationToken = default);
+}

--- a/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
+++ b/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
@@ -1,0 +1,575 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Navtool.Core;
+
+namespace Navtool.Infrastructure;
+
+public interface IRoutePlanSchemaMigrator
+{
+    JsonDocument MigrateToCurrent(JsonDocument document, int fromVersion, int currentVersion);
+}
+
+public sealed class RoutePlanSchemaMigrator : IRoutePlanSchemaMigrator
+{
+    public JsonDocument MigrateToCurrent(JsonDocument document, int fromVersion, int currentVersion) =>
+        throw new InvalidDataException(
+            $"Route plan schema version {fromVersion} is not supported by this application version.");
+}
+
+public sealed class RoutePlanJsonRepository : IRoutePlanRepository
+{
+    public const int CurrentSchemaVersion = 1;
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        RespectRequiredConstructorParameters = true,
+        Converters = { new JsonStringEnumConverter(allowIntegerValues: false) }
+    };
+
+    private readonly string _rootDirectory;
+    private readonly IRoutePlanSchemaMigrator _migrator;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    public RoutePlanJsonRepository(
+        string appDataRoot,
+        IRoutePlanSchemaMigrator? migrator = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(appDataRoot);
+        _rootDirectory = Path.Combine(Path.GetFullPath(appDataRoot), "routes");
+        _migrator = migrator ?? new RoutePlanSchemaMigrator();
+        Directory.CreateDirectory(_rootDirectory);
+    }
+
+    public string RootDirectory => _rootDirectory;
+
+    public async ValueTask<ImmutableArray<RoutePlanSummary>> ListAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var plans = new List<RoutePlanSummary>();
+            foreach (var path in Directory.EnumerateFiles(_rootDirectory, "*.route.json")
+                         .Order(StringComparer.Ordinal))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var plan = await ReadAsync(path, cancellationToken).ConfigureAwait(false);
+                var fileName = Path.GetFileName(path);
+                var idText = fileName[..^".route.json".Length];
+                if (!Guid.TryParseExact(idText, "N", out var fileId) ||
+                    plan.Id != new RoutePlanId(fileId))
+                {
+                    throw new InvalidDataException(
+                        $"Route plan file '{path}' does not match its stored plan ID '{plan.Id}'.");
+                }
+
+                plans.Add(new RoutePlanSummary(plan.Id, plan.Name, plan.Waypoints.Length));
+            }
+
+            return plans
+                .OrderBy(plan => plan.Name, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(plan => plan.Id.Value)
+                .ToImmutableArray();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is not RoutePlanRepositoryException)
+        {
+            throw new RoutePlanRepositoryException(
+                $"Listing saved route plans in '{_rootDirectory}' failed: {exception.Message}",
+                exception);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask<RoutePlan> OpenAsync(
+        RoutePlanId id,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var path = GetPath(id);
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Route plan '{id}' was not found.", path);
+            }
+
+            var plan = await ReadAsync(path, cancellationToken).ConfigureAwait(false);
+            if (plan.Id != id)
+            {
+                throw new InvalidDataException(
+                    $"Route plan file '{path}' contains plan ID '{plan.Id}' instead of '{id}'.");
+            }
+
+            return plan;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is not RoutePlanRepositoryException)
+        {
+            throw new RoutePlanRepositoryException(
+                $"Opening route plan '{id}' failed: {exception.Message}",
+                exception);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask SaveAsync(
+        RoutePlan plan,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await WriteAsync(plan, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is not RoutePlanRepositoryException)
+        {
+            throw new RoutePlanRepositoryException(
+                $"Saving route plan '{plan.Name}' failed: {exception.Message}",
+                exception);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async ValueTask<RoutePlan> SaveAsAsync(
+        RoutePlan plan,
+        string name,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        var newPlanId = new RoutePlanId();
+        var copiedResults = plan.Results.Select(result =>
+        {
+            var session = new RouteCalculationSession(
+                new RouteCalculationSessionId(),
+                newPlanId,
+                result.Model,
+                result.Session.StartedAt,
+                result.Session.CompletedAt);
+            return new RoutePlanResult(session, result.Legs);
+        });
+        var copy = new RoutePlan(
+            newPlanId,
+            name,
+            plan.Waypoints,
+            copiedResults,
+            plan.SailedLegIds);
+        await SaveAsync(copy, cancellationToken).ConfigureAwait(false);
+        return copy;
+    }
+
+    public async ValueTask DeleteAsync(
+        RoutePlanId id,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateId(id);
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var path = GetPath(id);
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Route plan '{id}' was not found.", path);
+            }
+
+            File.Delete(path);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is not RoutePlanRepositoryException)
+        {
+            throw new RoutePlanRepositoryException(
+                $"Deleting route plan '{id}' failed: {exception.Message}",
+                exception);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async ValueTask<RoutePlan> ReadAsync(string path, CancellationToken cancellationToken)
+    {
+        await using var stream = new FileStream(
+            path,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            32 * 1024,
+            FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var original = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        if (!original.RootElement.TryGetProperty("schemaVersion", out var versionElement) ||
+            !versionElement.TryGetInt32(out var version) ||
+            version <= 0)
+        {
+            throw new InvalidDataException($"Route plan file '{path}' has no valid schemaVersion.");
+        }
+
+        if (version > CurrentSchemaVersion)
+        {
+            throw new InvalidDataException(
+                $"Route plan file '{path}' uses future schema version {version}; " +
+                $"this app supports through version {CurrentSchemaVersion}.");
+        }
+
+        using var migrated = version == CurrentSchemaVersion
+            ? JsonDocument.Parse(original.RootElement.GetRawText())
+            : _migrator.MigrateToCurrent(original, version, CurrentSchemaVersion);
+        var envelope = migrated.Deserialize<RoutePlanEnvelope>(JsonOptions) ??
+                       throw new InvalidDataException($"Route plan file '{path}' is empty.");
+        if (envelope.SchemaVersion != CurrentSchemaVersion || envelope.Plan is null)
+        {
+            throw new InvalidDataException($"Route plan file '{path}' has an invalid document envelope.");
+        }
+
+        return FromDto(envelope.Plan);
+    }
+
+    private async ValueTask WriteAsync(RoutePlan plan, CancellationToken cancellationToken)
+    {
+        var path = GetPath(plan.Id);
+        var temporaryPath = Path.Combine(
+            _rootDirectory,
+            $".{plan.Id}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            var envelope = new RoutePlanEnvelope(CurrentSchemaVersion, ToDto(plan));
+            await using (var stream = new FileStream(
+                             temporaryPath,
+                             FileMode.CreateNew,
+                             FileAccess.Write,
+                             FileShare.None,
+                             32 * 1024,
+                             FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await JsonSerializer.SerializeAsync(
+                        stream,
+                        envelope,
+                        JsonOptions,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                stream.Flush(true);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(temporaryPath, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                File.Delete(temporaryPath);
+            }
+        }
+    }
+
+    private string GetPath(RoutePlanId id) => Path.Combine(_rootDirectory, $"{id}.route.json");
+
+    private static void ValidateId(RoutePlanId id)
+    {
+        if (id.Value == Guid.Empty)
+        {
+            throw new ArgumentException("A route plan ID cannot be empty.", nameof(id));
+        }
+    }
+
+    private static RoutePlanDto ToDto(RoutePlan plan) =>
+        new(
+            plan.Id.Value,
+            plan.Name,
+            plan.Waypoints.Select(waypoint => new RouteWaypointDto(
+                waypoint.Id.Value,
+                waypoint.Name,
+                waypoint.Coordinate.Latitude,
+                waypoint.Coordinate.Longitude,
+                waypoint.Stopover?.Ticks)).ToArray(),
+            plan.Results.Select(ToDto).ToArray(),
+            plan.SailedLegIds.Select(id => id.Value).ToArray());
+
+    private static RoutePlanResultDto ToDto(RoutePlanResult result) =>
+        new(
+            new RouteCalculationSessionDto(
+                result.Session.Id.Value,
+                result.Session.PlanId.Value,
+                result.Model,
+                result.Session.StartedAt,
+                result.Session.CompletedAt),
+            result.Legs.Select(leg => new RouteLegResultDto(
+                leg.LegId.Value,
+                leg.State,
+                leg.Reason,
+                leg.Route is null ? null : ToDto(leg.Route),
+                leg.Detail,
+                leg.DeferredInvalidationReason)).ToArray());
+
+    private static RouteResultDto ToDto(RouteResult route) =>
+        new(
+            new RouteRequestDto(
+                route.Request.RouteId,
+                route.Request.Origin.Latitude,
+                route.Request.Origin.Longitude,
+                route.Request.Destination.Latitude,
+                route.Request.Destination.Longitude,
+                route.Request.DepartureTime,
+                route.Request.LatestArrivalTime),
+            route.Model,
+            route.Points.Select(point => new RoutePointDto(
+                point.Location.Latitude,
+                point.Location.Longitude,
+                point.Timestamp,
+                point.HeadingDegrees,
+                point.BoatSpeedKnots,
+                point.TrueWindSpeedKnots,
+                point.TrueWindDirectionDegrees,
+                point.CumulativeDistanceNauticalMiles)).ToArray(),
+            new RouteDiagnosticsDto(
+                route.Diagnostics.ExpandedNodes,
+                route.Diagnostics.GeneratedCandidates,
+                route.Diagnostics.RetainedCandidates,
+                route.Diagnostics.TimeSteps,
+                route.Diagnostics.CalculationDuration?.Ticks),
+            route.Completion,
+            new RouteLandAvoidanceDto(
+                route.LandAvoidance.Status,
+                route.LandAvoidance.Warning,
+                route.LandAvoidance.Attribution));
+
+    private static RoutePlan FromDto(RoutePlanDto dto)
+    {
+        if (dto.Id == Guid.Empty)
+        {
+            throw new InvalidDataException("A stored route plan ID cannot be empty.");
+        }
+
+        if (dto.Waypoints is null || dto.Results is null || dto.SailedLegIds is null)
+        {
+            throw new InvalidDataException("A stored route plan is missing required collections.");
+        }
+
+        if (dto.Waypoints.Any(waypoint => waypoint.Id == Guid.Empty) ||
+            dto.Waypoints.Select(waypoint => waypoint.Id).Distinct().Count() != dto.Waypoints.Length)
+        {
+            throw new InvalidDataException("A stored route plan contains empty or duplicate waypoint IDs.");
+        }
+
+        var waypoints = dto.Waypoints.Select(waypoint => new RouteWaypoint(
+            new RouteWaypointId(waypoint.Id),
+            waypoint.Name,
+            new Coordinate(waypoint.Latitude, waypoint.Longitude),
+            waypoint.StopoverTicks is null
+                ? null
+                : TimeSpan.FromTicks(waypoint.StopoverTicks.Value))).ToArray();
+        var legs = waypoints.Zip(waypoints.Skip(1), (from, to) => RouteLegId.FromEndpoints(from.Id, to.Id))
+            .ToImmutableHashSet();
+        var results = dto.Results.Select(result => FromDto(result, dto.Id, legs)).ToArray();
+        var sailedIds = dto.SailedLegIds.Select(id => new RouteLegId(id)).ToArray();
+        if (dto.SailedLegIds.Any(id => id == Guid.Empty) ||
+            dto.SailedLegIds.Distinct().Count() != dto.SailedLegIds.Length)
+        {
+            throw new InvalidDataException("A stored route plan contains empty or duplicate sailed-leg IDs.");
+        }
+
+        return new RoutePlan(
+            new RoutePlanId(dto.Id),
+            dto.Name,
+            waypoints,
+            results,
+            sailedIds);
+    }
+
+    private static RoutePlanResult FromDto(
+        RoutePlanResultDto dto,
+        Guid planId,
+        ImmutableHashSet<RouteLegId> validLegIds)
+    {
+        if (dto.Session is null || dto.Legs is null)
+        {
+            throw new InvalidDataException("A stored route plan result is incomplete.");
+        }
+
+        if (dto.Session.PlanId != planId)
+        {
+            throw new InvalidDataException("A calculation session references a different route plan.");
+        }
+
+        if (dto.Legs.Any(leg => leg.LegId == Guid.Empty) ||
+            dto.Legs.Select(leg => leg.LegId).Distinct().Count() != dto.Legs.Length)
+        {
+            throw new InvalidDataException("A route plan result contains empty or duplicate leg IDs.");
+        }
+
+        var legs = dto.Legs.Select(leg =>
+        {
+            var legId = new RouteLegId(leg.LegId);
+            if (!validLegIds.Contains(legId))
+            {
+                throw new InvalidDataException($"A route plan result references unknown leg '{legId}'.");
+            }
+
+            return new RouteLegResult(
+                legId,
+                leg.State,
+                leg.Reason,
+                leg.Route is null ? null : FromDto(leg.Route),
+                leg.Detail,
+                leg.DeferredInvalidationReason);
+        });
+        return new RoutePlanResult(
+            new RouteCalculationSession(
+                new RouteCalculationSessionId(dto.Session.Id),
+                new RoutePlanId(dto.Session.PlanId),
+                dto.Session.Model,
+                dto.Session.StartedAt,
+                dto.Session.CompletedAt),
+            legs);
+    }
+
+    private static RouteResult FromDto(RouteResultDto dto)
+    {
+        if (dto.Request is null || dto.Points is null || dto.Diagnostics is null ||
+            dto.LandAvoidance is null)
+        {
+            throw new InvalidDataException("A stored route result is incomplete.");
+        }
+
+        var request = new RouteRequest(
+            dto.Request.RouteId,
+            new Coordinate(dto.Request.OriginLatitude, dto.Request.OriginLongitude),
+            new Coordinate(dto.Request.DestinationLatitude, dto.Request.DestinationLongitude),
+            dto.Request.DepartureTime,
+            dto.Request.LatestArrivalTime);
+        if (!Enum.IsDefined(dto.Model) ||
+            !Enum.IsDefined(dto.Completion) ||
+            !Enum.IsDefined(dto.LandAvoidance.Status))
+        {
+            throw new InvalidDataException("A stored route result contains an unknown enum value.");
+        }
+
+        return new RouteResult(
+            request,
+            dto.Model,
+            dto.Points.Select(point => new RoutePoint(
+                new Coordinate(point.Latitude, point.Longitude),
+                point.Timestamp,
+                point.HeadingDegrees,
+                point.BoatSpeedKnots,
+                point.TrueWindSpeedKnots,
+                point.TrueWindDirectionDegrees,
+                point.CumulativeDistanceNauticalMiles)),
+            new RouteDiagnostics(
+                dto.Diagnostics.ExpandedNodes,
+                dto.Diagnostics.GeneratedCandidates,
+                dto.Diagnostics.RetainedCandidates,
+                dto.Diagnostics.TimeSteps,
+                dto.Diagnostics.CalculationDurationTicks is null
+                    ? null
+                    : TimeSpan.FromTicks(dto.Diagnostics.CalculationDurationTicks.Value)),
+            dto.Completion,
+            new RouteLandAvoidance(
+                dto.LandAvoidance.Status,
+                dto.LandAvoidance.Warning,
+                dto.LandAvoidance.Attribution));
+    }
+
+    private sealed record RoutePlanEnvelope(int SchemaVersion, RoutePlanDto? Plan);
+
+    private sealed record RoutePlanDto(
+        Guid Id,
+        string Name,
+        RouteWaypointDto[] Waypoints,
+        RoutePlanResultDto[] Results,
+        Guid[] SailedLegIds);
+
+    private sealed record RouteWaypointDto(
+        Guid Id,
+        string Name,
+        double Latitude,
+        double Longitude,
+        long? StopoverTicks);
+
+    private sealed record RoutePlanResultDto(
+        RouteCalculationSessionDto Session,
+        RouteLegResultDto[] Legs);
+
+    private sealed record RouteCalculationSessionDto(
+        Guid Id,
+        Guid PlanId,
+        ForecastModel Model,
+        DateTimeOffset StartedAt,
+        DateTimeOffset? CompletedAt);
+
+    private sealed record RouteLegResultDto(
+        Guid LegId,
+        RouteLegOutcomeState State,
+        RouteLegOutcomeReason Reason,
+        RouteResultDto? Route,
+        string? Detail,
+        RouteLegOutcomeReason? DeferredInvalidationReason);
+
+    private sealed record RouteResultDto(
+        RouteRequestDto Request,
+        ForecastModel Model,
+        RoutePointDto[] Points,
+        RouteDiagnosticsDto Diagnostics,
+        RouteCompletion Completion,
+        RouteLandAvoidanceDto LandAvoidance);
+
+    private sealed record RouteRequestDto(
+        string RouteId,
+        double OriginLatitude,
+        double OriginLongitude,
+        double DestinationLatitude,
+        double DestinationLongitude,
+        DateTimeOffset DepartureTime,
+        DateTimeOffset LatestArrivalTime);
+
+    private sealed record RoutePointDto(
+        double Latitude,
+        double Longitude,
+        DateTimeOffset Timestamp,
+        double HeadingDegrees,
+        double BoatSpeedKnots,
+        double TrueWindSpeedKnots,
+        double TrueWindDirectionDegrees,
+        double CumulativeDistanceNauticalMiles);
+
+    private sealed record RouteDiagnosticsDto(
+        long ExpandedNodes,
+        long GeneratedCandidates,
+        long RetainedCandidates,
+        int TimeSteps,
+        long? CalculationDurationTicks);
+
+    private sealed record RouteLandAvoidanceDto(
+        LandAvoidanceStatus Status,
+        string? Warning,
+        string? Attribution);
+}

--- a/tests/Navtool.App.Tests/AppCompositionTests.cs
+++ b/tests/Navtool.App.Tests/AppCompositionTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Navtool.App.Services;
+using Navtool.App.ViewModels;
+using Navtool.Core;
 using Navtool.Infrastructure;
 
 namespace Navtool.App.Tests;
@@ -24,6 +26,34 @@ public sealed class AppCompositionTests
             Assert.IsType<OsmLandDataProvider>(
                 services.GetRequiredService<ILandDataProvider>());
         });
+    }
+
+    [Fact]
+    public void Registers_route_plan_repository_under_app_data_routes()
+    {
+        var previous = Environment.GetEnvironmentVariable(
+            AppComposition.AppDataRootEnvironmentVariable);
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-composition-{Guid.NewGuid():N}");
+        try
+        {
+            Environment.SetEnvironmentVariable(AppComposition.AppDataRootEnvironmentVariable, root);
+            using var services = AppComposition.CreateServices();
+
+            var repository = Assert.IsType<RoutePlanJsonRepository>(
+                services.GetRequiredService<IRoutePlanRepository>());
+            Assert.Equal(Path.Combine(root, "routes"), repository.RootDirectory);
+            Assert.NotNull(services.GetRequiredService<MainViewModel>().Itinerary);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                AppComposition.AppDataRootEnvironmentVariable,
+                previous);
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
     }
 
     private static void WithLandEndpoint(

--- a/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
+++ b/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.Immutable;
+using Navtool.App.ViewModels;
+using Navtool.Core;
+
+namespace Navtool.App.Tests;
+
+public sealed class ItineraryEditorViewModelTests
+{
+    [Fact]
+    public void Add_place_rename_move_remove_and_stopover_preserve_fixed_boundaries()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 3));
+
+        editor.AddWaypointCommand.Execute(null);
+        var intermediate = editor.Waypoints[1];
+        intermediate.Name = "Lunch";
+        intermediate.HasStopover = true;
+        intermediate.StopoverHours = 2;
+        intermediate.SetOnMapCommand.Execute(null);
+        editor.PlaceActiveWaypoint(new Coordinate(0, 1));
+
+        Assert.Equal("Start", editor.Waypoints[0].Name);
+        Assert.Equal("Finish", editor.Waypoints[^1].Name);
+        Assert.Equal(new Coordinate(0, 1), intermediate.Coordinate);
+        Assert.True(editor.TryBuildPlan(out var plan, out var error), error);
+        Assert.Equal(TimeSpan.FromHours(2), plan!.Waypoints[1].Stopover);
+
+        editor.AddWaypointCommand.Execute(null);
+        var second = editor.Waypoints[2];
+        second.SetOnMapCommand.Execute(null);
+        editor.PlaceActiveWaypoint(new Coordinate(0, 2));
+        second.MoveUpCommand.Execute(null);
+        Assert.Same(second, editor.Waypoints[1]);
+
+        second.RemoveCommand.Execute(null);
+        Assert.Equal(3, editor.Waypoints.Count);
+        Assert.False(editor.Waypoints[0].RemoveCommand.CanExecute(null));
+        Assert.False(editor.Waypoints[^1].RemoveCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task Repository_commands_surface_errors_and_track_dirty_state()
+    {
+        var repository = new MemoryRepository { Failure = new IOException("disk unavailable") };
+        var editor = new ItineraryEditorViewModel(repository);
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+
+        await editor.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(editor.IsDirty);
+        Assert.Contains("disk unavailable", editor.StorageError);
+    }
+
+    [Fact]
+    public async Task Opened_result_is_invalidated_at_field_specific_boundary()
+    {
+        var plan = CreatePlanWithPendingResult();
+        var repository = new MemoryRepository(plan);
+        var editor = new ItineraryEditorViewModel(repository);
+        await editor.RefreshSavedPlansCommand.ExecuteAsync(null);
+        await editor.OpenCommand.ExecuteAsync(null);
+
+        editor.Waypoints[1].HasStopover = true;
+
+        Assert.True(editor.ResultsInvalidated);
+        Assert.True(editor.IsDirty);
+    }
+
+    [Fact]
+    public async Task Rejected_sailed_boundary_edit_does_not_mutate_or_erase_history()
+    {
+        var plan = CreatePlanWithPendingResult();
+        plan = plan.MarkSailed(plan.Legs[0].Id);
+        var repository = new MemoryRepository(plan);
+        var editor = new ItineraryEditorViewModel(repository);
+        await editor.RefreshSavedPlansCommand.ExecuteAsync(null);
+        await editor.OpenCommand.ExecuteAsync(null);
+        var waypoint = editor.Waypoints[1];
+
+        waypoint.RemoveCommand.Execute(null);
+        await editor.SaveCommand.ExecuteAsync(null);
+
+        Assert.Equal(3, editor.Waypoints.Count);
+        Assert.Single(repository.Plan!.Results);
+        Assert.Single(repository.Plan.SailedLegIds);
+    }
+
+    [Fact]
+    public void Failed_outcome_replaces_latest_unsailed_model_result()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+
+        editor.RecordSingleLegOutcome(
+            ForecastModel.NoaaGfs,
+            null,
+            RouteLegOutcomeReason.RouteCalculationFailed,
+            "router failed",
+            DateTimeOffset.UtcNow);
+
+        Assert.True(editor.TryBuildPlan(out var plan, out var error), error);
+        var outcome = Assert.Single(Assert.Single(plan!.Results).Legs);
+        Assert.Equal(RouteLegOutcomeState.Failed, outcome.State);
+        Assert.Equal("router failed", outcome.Detail);
+    }
+
+    [Fact]
+    public void Pending_waypoint_can_be_removed_before_map_placement()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 2));
+        editor.AddWaypointCommand.Execute(null);
+        editor.Waypoints[1].SetOnMapCommand.Execute(null);
+
+        editor.Waypoints[1].RemoveCommand.Execute(null);
+
+        Assert.Equal(2, editor.Waypoints.Count);
+        Assert.False(editor.HasPendingWaypoint);
+        Assert.Null(editor.ActiveWaypoint);
+    }
+
+    [Fact]
+    public async Task Save_completion_does_not_mark_concurrent_edits_clean()
+    {
+        var repository = new MemoryRepository
+        {
+            SaveGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var editor = new ItineraryEditorViewModel(repository);
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+
+        var save = editor.SaveCommand.ExecuteAsync(null);
+        await repository.SaveStarted.Task;
+        editor.RouteName = "Edited while saving";
+        repository.SaveGate.SetResult();
+        await save;
+
+        Assert.True(editor.IsDirty);
+        Assert.Equal("Edited while saving", editor.RouteName);
+    }
+
+    private static RoutePlan CreatePlanWithPendingResult()
+    {
+        var plan = new RoutePlan(
+            "Stored",
+            [
+                new RouteWaypoint("Start", new Coordinate(0, 0)),
+                new RouteWaypoint("Middle", new Coordinate(0, 1)),
+                new RouteWaypoint("Finish", new Coordinate(0, 2))
+            ]);
+        var session = new RouteCalculationSession(
+            plan.Id,
+            ForecastModel.NoaaGfs,
+            DateTimeOffset.UtcNow);
+        return plan.WithResult(new RoutePlanResult(
+            session,
+            plan.Legs.Select(leg =>
+                new RouteLegResult(
+                    leg.Id,
+                    RouteLegOutcomeState.Pending,
+                    RouteLegOutcomeReason.None))));
+    }
+
+    private sealed class MemoryRepository : IRoutePlanRepository
+    {
+        private RoutePlan? _plan;
+
+        public MemoryRepository(RoutePlan? plan = null)
+        {
+            _plan = plan;
+        }
+
+        public Exception? Failure { get; init; }
+
+        public RoutePlan? Plan => _plan;
+
+        public TaskCompletionSource? SaveGate { get; init; }
+
+        public TaskCompletionSource SaveStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask<ImmutableArray<RoutePlanSummary>> ListAsync(
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfFailed();
+            return ValueTask.FromResult(_plan is null
+                ? ImmutableArray<RoutePlanSummary>.Empty
+                : [new RoutePlanSummary(_plan.Id, _plan.Name, _plan.Waypoints.Length)]);
+        }
+
+        public ValueTask<RoutePlan> OpenAsync(
+            RoutePlanId id,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfFailed();
+            return ValueTask.FromResult(_plan!);
+        }
+
+        public async ValueTask SaveAsync(RoutePlan plan, CancellationToken cancellationToken = default)
+        {
+            ThrowIfFailed();
+            SaveStarted.TrySetResult();
+            if (SaveGate is not null)
+            {
+                await SaveGate.Task.WaitAsync(cancellationToken);
+            }
+
+            _plan = plan;
+        }
+
+        public ValueTask<RoutePlan> SaveAsAsync(
+            RoutePlan plan,
+            string name,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfFailed();
+            _plan = new RoutePlan(name, plan.Waypoints);
+            return ValueTask.FromResult(_plan);
+        }
+
+        public ValueTask DeleteAsync(
+            RoutePlanId id,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfFailed();
+            _plan = null;
+            return ValueTask.CompletedTask;
+        }
+
+        private void ThrowIfFailed()
+        {
+            if (Failure is not null)
+            {
+                throw Failure;
+            }
+        }
+    }
+}

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Mapsui.Extensions;
 using Mapsui.Layers;
 using Navtool.App.Models;
 using Navtool.App.Services;
@@ -167,7 +168,7 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task Invalid_recalculation_preserves_warning_for_routes_still_displayed()
+    public async Task Endpoint_change_clears_route_and_its_warning_before_invalid_recalculation()
     {
         var warning = new RouteLandAvoidance(
             LandAvoidanceStatus.RouterUnsupported,
@@ -189,8 +190,8 @@ public sealed class MainViewModelWorkflowTests
 
         await viewModel.CalculateRoutesAsync();
 
-        Assert.Equal(1, viewModel.SuccessfulRouteCount);
-        Assert.Equal(warning.Warning, viewModel.LandAvoidanceWarning);
+        Assert.Equal(0, viewModel.SuccessfulRouteCount);
+        Assert.Null(viewModel.LandAvoidanceWarning);
     }
 
     [Fact]
@@ -250,6 +251,33 @@ public sealed class MainViewModelWorkflowTests
 
         Assert.Null(noaa.LastRequest);
         Assert.Contains("cannot exceed 10 days", viewModel.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Intermediate_waypoint_is_editable_but_sequential_calculation_is_deferred()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        var waypoint = viewModel.Itinerary.Waypoints[1];
+        waypoint.SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Null(noaa.LastRequest);
+        Assert.Equal(36, waypoint.Coordinate!.Value.Latitude, 10);
+        Assert.Equal(-58, waypoint.Coordinate.Value.Longitude, 10);
+        Assert.Contains("Sequential multi-leg", viewModel.ErrorMessage);
     }
 
     [Fact]
@@ -481,6 +509,7 @@ public sealed class MainViewModelWorkflowTests
             new RoutingWorkflow(providers, engine),
             new DelegateWeatherSampler((_, _, _, _, _, _) =>
                 ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.Map.Navigator.SetSize(1280, 800);
         viewModel.UseEcmwf = true;
 
         await viewModel.CalculateRoutesAsync();
@@ -628,6 +657,38 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Itinerary_change_discards_late_result_and_clears_displayed_route()
+    {
+        var started = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource<ForecastAcquisition>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            async (_, _) =>
+            {
+                started.SetResult();
+                return await release.Task;
+            });
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { provider }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        var calculation = viewModel.CalculateRoutesAsync();
+        await started.Task;
+        viewModel.SetDestinationAt(new Coordinate(40, -50));
+        release.SetResult(CreateAcquisition(provider.LastRequest!));
+        await calculation;
+
+        Assert.Equal(0, viewModel.SuccessfulRouteCount);
+        Assert.False(viewModel.HasTimeline);
+        Assert.False(viewModel.IsCalculating);
+    }
+
+    [Fact]
     public async Task TimelineCommandsAndRouteSelectionShareUtcState()
     {
         var providers = new[]
@@ -699,13 +760,20 @@ public sealed class MainViewModelWorkflowTests
         var ecmwf = viewModel.SuccessfulRoutes.Single(
             route => route.Model == ForecastModel.EcmwfIfs);
         var capturedWorldPoint = MapProjection.ToMapPoint(ecmwf.Points[1].Location);
+        viewModel.Map.Navigator.SetViewport(new Mapsui.Viewport(
+            capturedWorldPoint.X,
+            capturedWorldPoint.Y,
+            10_000,
+            0,
+            1280,
+            800));
         var projected = viewModel.Map.Navigator.Viewport.WorldToScreen(capturedWorldPoint);
         var capturedScreenPoint = new ScreenPoint(projected.X, projected.Y);
 
         Assert.True(viewModel.CanInspectRouteAt(capturedWorldPoint, capturedScreenPoint));
         Assert.False(viewModel.CanInspectRouteAt(
             capturedWorldPoint,
-            new ScreenPoint(capturedScreenPoint.X + 100, capturedScreenPoint.Y + 100)));
+            new ScreenPoint(-1_000, -1_000)));
 
         Assert.True(viewModel.InspectRouteAt(
             capturedWorldPoint,

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -109,6 +109,7 @@ public sealed class MapRenderingTests
             [
                 "Wind speed",
                 "Wind direction",
+                "Waypoint guide",
                 "NOAA GFS isochrone fronts",
                 "ECMWF IFS isochrone fronts",
                 "NOAA GFS latest isochrone front",
@@ -116,9 +117,45 @@ public sealed class MapRenderingTests
                 "NOAA GFS provisional route",
                 "ECMWF IFS provisional route",
                 "NOAA GFS routes",
-                "ECMWF IFS routes"
+                "ECMWF IFS routes",
+                "Waypoint markers"
             ],
             layers.Skip(1).Select(layer => layer.Name));
+    }
+
+    [Fact]
+    public void Waypoint_markers_are_numbered_and_guide_is_antimeridian_safe()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        layers.SetWaypoints(
+        [
+            new WaypointMapMarker(1, "Start", new Coordinate(10, 179)),
+            new WaypointMapMarker(2, "Stop", new Coordinate(11, -179.5)),
+            new WaypointMapMarker(3, "Finish", new Coordinate(12, -178))
+        ]);
+
+        Assert.Equal(3, layers.WaypointMarkerCount);
+        Assert.Equal(1, layers.WaypointGuideSegmentCount);
+        var markerLayer = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "Waypoint markers"));
+        Assert.Equal(
+            [1, 2, 3],
+            markerLayer.Features.Select(feature =>
+                Assert.IsType<WaypointMapMarker>(feature.Data).Number));
+        Assert.Equal(
+            ["1", "2", "3"],
+            markerLayer.Features.Select(feature =>
+                Assert.IsType<LabelStyle>(Assert.Single(feature.Styles)).GetLabelText(feature)));
+
+        var guide = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "Waypoint guide"));
+        var line = Assert.IsType<LineString>(
+            Assert.IsType<GeometryFeature>(Assert.Single(guide.Features)).Geometry);
+        for (var index = 1; index < line.Coordinates.Length; index++)
+        {
+            Assert.True(Math.Abs(line.Coordinates[index].X - line.Coordinates[index - 1].X) < 500_000);
+        }
     }
 
     [Fact]

--- a/tests/Navtool.Core.Tests/RoutePlanTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanTests.cs
@@ -1,0 +1,182 @@
+using Navtool.Core;
+
+namespace Navtool.Core.Tests;
+
+public sealed class RoutePlanTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Validates_fixed_boundaries_minimum_and_adjacent_coordinates()
+    {
+        Assert.Throws<ArgumentException>(() => new RoutePlan(
+            "Too short",
+            [Waypoint("Start", 0)]));
+        Assert.Throws<ArgumentException>(() => new RoutePlan(
+            "Duplicate coordinate",
+            [Waypoint("Start", 0), Waypoint("Finish", 0)]));
+        Assert.Throws<ArgumentException>(() => new RoutePlan(
+            "Start stopover",
+            [Waypoint("Start", 0, TimeSpan.FromHours(1)), Waypoint("Finish", 2)]));
+
+        var plan = CreatePlan();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            plan.RemoveWaypoint(plan.Waypoints[0].Id));
+        Assert.Throws<InvalidOperationException>(() =>
+            plan.MoveWaypoint(plan.Waypoints[^1].Id, 1));
+        Assert.Throws<InvalidOperationException>(() =>
+            plan.ChangeStopover(plan.Waypoints[0].Id, TimeSpan.FromHours(1)));
+    }
+
+    [Fact]
+    public void Coordinate_change_invalidates_inbound_and_later_legs()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+
+        var changed = plan.ChangeWaypointCoordinate(
+            plan.Waypoints[1].Id,
+            new Coordinate(1, 1.5));
+
+        Assert.All(changed.Results[0].Legs, leg =>
+        {
+            Assert.Equal(RouteLegOutcomeState.Invalidated, leg.State);
+            Assert.Equal(RouteLegOutcomeReason.WaypointCoordinateChanged, leg.Reason);
+        });
+    }
+
+    [Fact]
+    public void Rename_does_not_invalidate_and_stopover_invalidates_outbound_only()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+        var renamed = plan.RenameWaypoint(plan.Waypoints[1].Id, "Lunch");
+        var changed = renamed.ChangeStopover(plan.Waypoints[1].Id, TimeSpan.FromHours(2));
+
+        Assert.All(renamed.Results[0].Legs, leg =>
+            Assert.Equal(RouteLegOutcomeState.Succeeded, leg.State));
+        Assert.Equal(RouteLegOutcomeState.Succeeded, changed.Results[0].Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, changed.Results[0].Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.StopoverChanged, changed.Results[0].Legs[1].Reason);
+    }
+
+    [Fact]
+    public void Reorder_invalidates_from_earliest_changed_leg()
+    {
+        var plan = WithSuccessfulResult(new RoutePlan(
+            "Four",
+            [Waypoint("Start", 0), Waypoint("A", 1), Waypoint("B", 2), Waypoint("Finish", 3)]));
+
+        var changed = plan.MoveWaypoint(plan.Waypoints[2].Id, 1);
+
+        Assert.All(changed.Results[0].Legs, leg =>
+        {
+            Assert.Equal(RouteLegOutcomeState.Invalidated, leg.State);
+            Assert.Equal(RouteLegOutcomeReason.WaypointsReordered, leg.Reason);
+        });
+    }
+
+    [Fact]
+    public void Sailed_result_is_retained_until_unmarked()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+        var sailedLeg = plan.Legs[0].Id;
+        plan = plan.MarkSailed(sailedLeg);
+
+        var changed = plan.ChangeWaypointCoordinate(
+            plan.Waypoints[1].Id,
+            new Coordinate(1, 1.5));
+
+        Assert.Equal(RouteLegOutcomeState.Succeeded, changed.Results[0].Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, changed.Results[0].Legs[1].State);
+
+        var unmarked = changed.UnmarkSailed(sailedLeg);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, unmarked.Results[0].Legs[0].State);
+    }
+
+    [Fact]
+    public void Sailed_result_survives_recalculation_and_defers_stopover_invalidation()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+        var sailedLeg = plan.Legs[1].Id;
+        plan = plan.MarkSailed(sailedLeg);
+        var originalSailed = plan.Results[0].Legs[1];
+        var replacementSession = new RouteCalculationSession(
+            plan.Id,
+            ForecastModel.NoaaGfs,
+            Now.AddHours(2));
+        var replacement = new RoutePlanResult(
+            replacementSession,
+            plan.Legs.Select(leg =>
+                new RouteLegResult(
+                    leg.Id,
+                    RouteLegOutcomeState.Failed,
+                    RouteLegOutcomeReason.RouteCalculationFailed)));
+
+        var recalculated = plan.WithResult(replacement);
+        var changed = recalculated.ChangeStopover(
+            plan.Waypoints[1].Id,
+            TimeSpan.FromHours(3));
+
+        Assert.Same(originalSailed.Route, recalculated.Results[0].Legs[1].Route);
+        Assert.Equal(RouteLegOutcomeReason.StopoverChanged,
+            changed.Results[0].Legs[1].DeferredInvalidationReason);
+        var unmarked = changed.UnmarkSailed(sailedLeg);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, unmarked.Results[0].Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.StopoverChanged, unmarked.Results[0].Legs[1].Reason);
+    }
+
+    [Fact]
+    public void Results_reject_wrong_plan_leg_and_endpoint_references()
+    {
+        var plan = CreatePlan();
+        var wrongSession = new RouteCalculationSession(
+            new RoutePlanId(),
+            ForecastModel.NoaaGfs,
+            Now);
+        var outcomes = plan.Legs.Select(leg =>
+            new RouteLegResult(leg.Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None));
+
+        Assert.Throws<ArgumentException>(() =>
+            plan.WithResult(new RoutePlanResult(wrongSession, outcomes)));
+        Assert.Throws<ArgumentException>(() => plan.WithResult(new RoutePlanResult(
+            new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, Now),
+            [new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None)])));
+    }
+
+    private static RoutePlan CreatePlan() =>
+        new("Passage", [Waypoint("Start", 0), Waypoint("Mid", 1), Waypoint("Finish", 2)]);
+
+    private static RouteWaypoint Waypoint(string name, double longitude, TimeSpan? stopover = null) =>
+        new(name, new Coordinate(0, longitude), stopover);
+
+    private static RoutePlan WithSuccessfulResult(RoutePlan plan)
+    {
+        var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, Now).Complete(Now.AddMinutes(1));
+        var outcomes = plan.Legs.Select(leg =>
+        {
+            var from = plan.Waypoints[leg.Index];
+            var to = plan.Waypoints[leg.Index + 1];
+            var request = new RouteRequest(
+                $"leg-{leg.Index}",
+                from.Coordinate,
+                to.Coordinate,
+                Now,
+                Now.AddHours(2));
+            var route = new RouteResult(
+                request,
+                ForecastModel.NoaaGfs,
+                [
+                    new RoutePoint(from.Coordinate, Now, 90, 5, 10, 180, 0),
+                    new RoutePoint(to.Coordinate, Now.AddHours(1), 90, 5, 10, 180, 60)
+                ],
+                new RouteDiagnostics(1, 2, 1, 1));
+            return new RouteLegResult(
+                leg.Id,
+                RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded,
+                route);
+        });
+        return plan.WithResult(new RoutePlanResult(session, outcomes));
+    }
+}

--- a/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
@@ -1,0 +1,208 @@
+using System.Text.Json;
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+public sealed class RoutePlanJsonRepositoryTests
+{
+    [Fact]
+    public async Task Round_trip_list_save_as_and_delete_preserve_plan_data()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = WithResult(CreatePlan());
+
+        await repository.SaveAsync(plan);
+        var loaded = await repository.OpenAsync(plan.Id);
+        var copy = await repository.SaveAsAsync(loaded, "Return passage");
+        var summaries = await repository.ListAsync();
+
+        Assert.Equal(plan.Id, loaded.Id);
+        Assert.Equal(plan.Waypoints.Length, loaded.Waypoints.Length);
+        for (var index = 0; index < plan.Waypoints.Length; index++)
+        {
+            Assert.Equal(plan.Waypoints[index].Id, loaded.Waypoints[index].Id);
+            Assert.Equal(plan.Waypoints[index].Name, loaded.Waypoints[index].Name);
+            Assert.Equal(plan.Waypoints[index].Coordinate, loaded.Waypoints[index].Coordinate);
+            Assert.Equal(plan.Waypoints[index].Stopover, loaded.Waypoints[index].Stopover);
+        }
+
+        Assert.Equal(plan.SailedLegIds, loaded.SailedLegIds);
+        Assert.Single(loaded.Results);
+        var expectedRoute = plan.Results[0].Legs[0].Route!;
+        var loadedRoute = loaded.Results[0].Legs[0].Route!;
+        Assert.Equal(expectedRoute.Request.RouteId, loadedRoute.Request.RouteId);
+        Assert.Equal(expectedRoute.Request.Origin, loadedRoute.Request.Origin);
+        Assert.Equal(expectedRoute.Request.Destination, loadedRoute.Request.Destination);
+        Assert.Equal(expectedRoute.Points.Length, loadedRoute.Points.Length);
+        Assert.Equal(
+            expectedRoute.Points.Select(point => point.Location),
+            loadedRoute.Points.Select(point => point.Location));
+        Assert.Equal(expectedRoute.Diagnostics.CalculationDuration, loadedRoute.Diagnostics.CalculationDuration);
+        Assert.NotEqual(plan.Id, copy.Id);
+        Assert.Equal("Return passage", copy.Name);
+        Assert.Equal(2, summaries.Length);
+        Assert.Empty(Directory.EnumerateFiles(repository.RootDirectory, "*.tmp"));
+
+        await repository.DeleteAsync(plan.Id);
+        Assert.Single(await repository.ListAsync());
+        await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(plan.Id));
+    }
+
+    [Fact]
+    public async Task Future_and_malformed_schemas_fail_visibly()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var futureId = new RoutePlanId();
+        var malformedId = new RoutePlanId();
+        await File.WriteAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{futureId}.route.json"),
+            """{"schemaVersion":999,"plan":{}}""");
+        await File.WriteAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{malformedId}.route.json"),
+            """{"schemaVersion":1,"plan":{"id":"00000000-0000-0000-0000-000000000000"}}""");
+
+        var future = await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(futureId));
+        Assert.Contains("future schema version", future.Message);
+
+        var malformed = await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(malformedId));
+        Assert.Contains("failed", malformed.Message);
+        await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.ListAsync());
+    }
+
+    [Fact]
+    public async Task Missing_required_fields_and_numeric_enums_are_rejected()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var missingId = new RoutePlanId();
+        var numericId = new RoutePlanId();
+        await File.WriteAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{missingId}.route.json"),
+            """{"schemaVersion":1,"plan":{"id":"11111111-1111-1111-1111-111111111111"}}""");
+        await File.WriteAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{numericId}.route.json"),
+            """
+            {"schemaVersion":1,"plan":{"id":"22222222-2222-2222-2222-222222222222","name":"bad",
+            "waypoints":[],"results":[{"session":{"id":"33333333-3333-3333-3333-333333333333",
+            "planId":"22222222-2222-2222-2222-222222222222","model":0,
+            "startedAt":"2026-08-01T00:00:00Z","completedAt":null},"legs":[]}],"sailedLegIds":[]}}
+            """);
+
+        await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(missingId));
+        await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(numericId));
+    }
+
+    [Fact]
+    public async Task Duplicate_and_unknown_references_are_rejected_on_load()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = CreatePlan();
+        await repository.SaveAsync(plan);
+        var path = Path.Combine(repository.RootDirectory, $"{plan.Id}.route.json");
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path));
+        var json = document.RootElement.GetRawText()
+            .Replace(
+                plan.Waypoints[1].Id.Value.ToString(),
+                plan.Waypoints[0].Id.Value.ToString(),
+                StringComparison.OrdinalIgnoreCase);
+        await File.WriteAllTextAsync(path, json);
+
+        var exception = await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(plan.Id));
+        Assert.Contains("duplicate waypoint", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Open_rejects_document_id_that_disagrees_with_requested_file()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = CreatePlan();
+        await repository.SaveAsync(plan);
+        var otherId = new RoutePlanId();
+        var originalPath = Path.Combine(repository.RootDirectory, $"{plan.Id}.route.json");
+        var mismatchedPath = Path.Combine(repository.RootDirectory, $"{otherId}.route.json");
+        File.Move(originalPath, mismatchedPath);
+
+        var exception = await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(otherId));
+
+        Assert.Contains("instead of", exception.Message);
+        await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.ListAsync());
+    }
+
+    [Fact]
+    public async Task Cancelled_overwrite_keeps_previous_complete_document()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = CreatePlan();
+        await repository.SaveAsync(plan);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await repository.SaveAsync(plan.Rename("Should not persist"), cancellation.Token));
+
+        var loaded = await repository.OpenAsync(plan.Id);
+        Assert.Equal(plan.Name, loaded.Name);
+        Assert.Empty(Directory.EnumerateFiles(repository.RootDirectory, "*.tmp"));
+    }
+
+    private static RoutePlan CreatePlan()
+    {
+        var plan = new RoutePlan(
+            "Atlantic",
+            [
+                new RouteWaypoint("Start", new Coordinate(35, -65)),
+                new RouteWaypoint("Stop", new Coordinate(37, -60), TimeSpan.FromHours(4)),
+                new RouteWaypoint("Finish", new Coordinate(40, -52))
+            ]);
+        return plan.MarkSailed(plan.Legs[0].Id);
+    }
+
+    private static RoutePlan WithResult(RoutePlan plan)
+    {
+        var now = new DateTimeOffset(2026, 8, 1, 18, 0, 0, TimeSpan.Zero);
+        var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, now)
+            .Complete(now.AddSeconds(2));
+        var outcomes = plan.Legs.Select(leg =>
+        {
+            var from = plan.Waypoints[leg.Index];
+            var to = plan.Waypoints[leg.Index + 1];
+            var request = new RouteRequest(
+                $"persisted-{leg.Index}",
+                from.Coordinate,
+                to.Coordinate,
+                now,
+                now.AddHours(4));
+            var route = new RouteResult(
+                request,
+                ForecastModel.NoaaGfs,
+                [
+                    new RoutePoint(from.Coordinate, now, 90, 6, 15, 180, 0),
+                    new RoutePoint(to.Coordinate, now.AddHours(1), 90, 6, 15, 180, 50)
+                ],
+                new RouteDiagnostics(1, 2, 1, 1, TimeSpan.FromSeconds(2)),
+                RouteCompletion.DestinationReached,
+                new RouteLandAvoidance(LandAvoidanceStatus.Applied, Attribution: "Test"));
+            return new RouteLegResult(
+                leg.Id,
+                RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded,
+                route);
+        });
+        return plan.WithResult(new RoutePlanResult(session, outcomes));
+    }
+}


### PR DESCRIPTION
## Summary
- add immutable route-plan, waypoint, derived-leg, calculation-session, per-model result, sailed-state, and field-specific invalidation domain types
- add strict schema-v1 JSON route-plan persistence under `NAVTOOL_APP_DATA_ROOT/routes/` with atomic writes, migration seam, reference validation, and DI registration
- add a testable itinerary editor with ordered waypoint commands, route plan save/open workflows, dirty/invalidation state, and safe async lifecycle handling
- add numbered waypoint markers and an antimeridian-safe unoptimized guide while preserving the existing direct two-point route workflow
- document route-plan storage and the deliberate multi-leg calculation/rendering deferral

## Validation
- `dotnet test Navtool.sln --no-restore --nologo --verbosity:minimal`
- 46 Core tests, 65 App tests, and 79 Infrastructure tests passed

## Deliberate deferrals
- sequential calculation across intermediate waypoints
- optimized multi-leg route rendering
- native ABI or `router-lib` changes

Intermediate waypoints can be edited and persisted now; calculation remains explicitly limited to a two-waypoint plan.