### PR TITLE
Add sequential multi-leg routing

### DIFF
--- a/src/Navtool.App/Services/AppComposition.cs
+++ b/src/Navtool.App/Services/AppComposition.cs
@@ -76,6 +76,9 @@ public static class AppComposition
                 provider.GetRequiredService<EcmwfOpenDataForecastProvider>()
             },
             provider.GetRequiredService<IRouteEngine>()));
+        services.AddSingleton(provider => new RoutePlanRoutingWorkflow(
+            provider.GetRequiredService<RoutingWorkflow>(),
+            provider.GetRequiredService<IRoutePlanRepository>()));
         services.AddSingleton<MainViewModel>();
         return services.BuildServiceProvider();
     }

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -425,6 +425,26 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         return _plan.LatestResult(model)!.Legs[0].Route;
     }
 
+    public void AcceptCalculationResult(RoutePlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        if (!TryBuildPlan(out var current, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+
+        if (plan.Id != PlanId || !plan.Waypoints.SequenceEqual(current!.Waypoints))
+        {
+            throw new InvalidOperationException(
+                "The calculation result does not match the current itinerary.");
+        }
+
+        _plan = plan;
+        ResultsInvalidated = plan.HasInvalidatedResults;
+        IsDirty = false;
+        StorageError = null;
+    }
+
     internal void Remove(WaypointEditorItemViewModel waypoint)
     {
         var index = Waypoints.IndexOf(waypoint);

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -39,6 +39,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly MapInteractionState _interaction = new();
     private readonly RouteMapLayers _mapLayers;
     private readonly RoutingWorkflow? _workflow;
+    private readonly RoutePlanRoutingWorkflow? _routePlanWorkflow;
     private readonly IWeatherSampler? _weatherSampler;
     private readonly ILocalGribInspector? _localGribInspector;
     private readonly INativeRoutingPreflight? _nativeRoutingPreflight;
@@ -203,6 +204,30 @@ public partial class MainViewModel : ViewModelBase
     }
 
     public MainViewModel(
+        RoutingWorkflow workflow,
+        IWeatherSampler weatherSampler,
+        ILocalGribInspector localGribInspector,
+        INativeRoutingPreflight nativeRoutingPreflight,
+        NoaaGfsForecastProvider noaaProvider,
+        ILogger<MainViewModel> logger,
+        IRoutePlanRepository routePlanRepository,
+        RoutePlanRoutingWorkflow routePlanWorkflow)
+        : this(
+            workflow,
+            weatherSampler,
+            TimeProvider.System,
+            TimeZoneInfo.Local,
+            new OsmTileOptions(),
+            logger,
+            localGribInspector,
+            nativeRoutingPreflight,
+            noaaProvider,
+            routePlanRepository,
+            routePlanWorkflow)
+    {
+    }
+
+    public MainViewModel(
         RoutingWorkflow? workflow,
         IWeatherSampler? weatherSampler,
         TimeProvider timeProvider,
@@ -212,12 +237,16 @@ public partial class MainViewModel : ViewModelBase
         ILocalGribInspector? localGribInspector = null,
         INativeRoutingPreflight? nativeRoutingPreflight = null,
         NoaaGfsForecastProvider? noaaProvider = null,
-        IRoutePlanRepository? routePlanRepository = null)
+        IRoutePlanRepository? routePlanRepository = null,
+        RoutePlanRoutingWorkflow? routePlanWorkflow = null)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(localTimeZone);
         ArgumentNullException.ThrowIfNull(tileOptions);
         _workflow = workflow;
+        _routePlanWorkflow = routePlanWorkflow ?? (workflow is null || routePlanRepository is null
+            ? null
+            : new RoutePlanRoutingWorkflow(workflow, routePlanRepository, timeProvider));
         _weatherSampler = weatherSampler;
         _localGribInspector = localGribInspector;
         _nativeRoutingPreflight = nativeRoutingPreflight;
@@ -517,6 +546,28 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        RoutePlanRoutingRequest? planRequest = null;
+        if (Itinerary.Waypoints.Count > 2)
+        {
+            if (_routePlanWorkflow is null)
+            {
+                ErrorMessage = "Route plan storage is required for multi-leg calculation.";
+                return;
+            }
+
+            if (!Itinerary.TryBuildPlan(out var plan, out validationError))
+            {
+                ErrorMessage = validationError;
+                return;
+            }
+
+            planRequest = new RoutePlanRoutingRequest(
+                plan!,
+                request!.Route.DepartureTime,
+                request.Route.LatestArrivalTime,
+                request.Selections);
+        }
+
         try
         {
             _nativeRoutingPreflight?.EnsureAvailable();
@@ -585,11 +636,57 @@ public partial class MainViewModel : ViewModelBase
                 _mapLayers.ClearCalculationOverlay(value.Model);
             }
         });
+        var planProgress = new Progress<RoutePlanRoutingProgress>(value =>
+        {
+            if (!IsCurrentCalculation(generation) || !IsCalculating)
+            {
+                return;
+            }
+
+            ProgressFraction = value.OverallFraction;
+            SetModelStatus(
+                value.Model,
+                $"{(IsExperimentalDownload(request, value.Model) ? "Experimental · " : string.Empty)}" +
+                $"leg {value.LegIndex + 1} {PlanProgressStageName(value.Status)} " +
+                $"{value.UnitFraction:P0}" +
+                $"{(string.IsNullOrWhiteSpace(value.Message) ? string.Empty : $" · {value.Message}")}");
+            if (value.Snapshot is not null)
+            {
+                _mapLayers.AddCalculationSnapshot(value.Model, value.Snapshot);
+            }
+            else if (value.Status is RoutePlanRoutingUnitStatus.Failed or
+                     RoutePlanRoutingUnitStatus.Cancelled)
+            {
+                _mapLayers.ClearCalculationOverlay(value.Model);
+            }
+        });
 
         try
         {
-            var result = await _workflow.ExecuteAsync(request, progress, cancellation.Token);
-            if (!IsCurrentCalculation(generation))
+            if (planRequest is not null)
+            {
+                var planResult = await _routePlanWorkflow!.ExecuteAsync(
+                    planRequest,
+                    planProgress,
+                    cancellation.Token);
+                if (!IsCurrentCalculation(generation) || !planResult.IsCurrent)
+                {
+                    return;
+                }
+
+                if (Itinerary.PlanId != calculationPlanId ||
+                    Itinerary.CalculationRevision != calculationRevision)
+                {
+                    StatusMessage = "Calculation result discarded because the itinerary changed.";
+                    return;
+                }
+
+                ApplyPlanWorkflowResult(planResult);
+                return;
+            }
+
+            var result = await _workflow.ExecuteAsync(request!, progress, cancellation.Token);
+            if (!IsCurrentCalculation(generation) || cancellation.IsCancellationRequested)
             {
                 return;
             }
@@ -748,7 +845,10 @@ public partial class MainViewModel : ViewModelBase
     private void Cancel()
     {
         var wasCalculating = IsCalculating;
-        Interlocked.Increment(ref _calculationGeneration);
+        if (IsInspectingLocalGrib)
+        {
+            Interlocked.Increment(ref _calculationGeneration);
+        }
         var cancellation = Interlocked.Exchange(ref _calculationCancellation, null);
         cancellation?.Cancel();
         cancellation?.Dispose();
@@ -853,6 +953,78 @@ public partial class MainViewModel : ViewModelBase
         RequestWeatherRefreshFromViewport();
     }
 
+    private void ApplyPlanWorkflowResult(RoutePlanRoutingResult result)
+    {
+        Itinerary.AcceptCalculationResult(result.Plan);
+        _acquisitions.Clear();
+        var failures = new List<string>();
+        var warnings = new List<string>();
+        foreach (var outcome in result.Models)
+        {
+            if (!outcome.Acquisitions.IsEmpty)
+            {
+                _acquisitions[outcome.Model] = outcome.Acquisitions[^1];
+            }
+
+            var legStatuses = outcome.Legs.Select((leg, index) =>
+                $"leg {index + 1} {LegStatusName(leg)}");
+            var modelStatus =
+                $"{(IsExperimentalDownload(result.Request.Selections, outcome.Model) ? "Experimental · " : string.Empty)}" +
+                string.Join(" · ", legStatuses);
+            SetModelStatus(outcome.Model, modelStatus);
+
+            foreach (var leg in outcome.Legs)
+            {
+                if (leg.State == RouteLegOutcomeState.Failed)
+                {
+                    failures.Add(
+                        $"{ModelName(outcome.Model)} failed: {leg.Detail ?? LegStatusName(leg)}");
+                }
+                else if (leg.Reason == RouteLegOutcomeReason.ForecastExhausted ||
+                         leg.State == RouteLegOutcomeState.OutsideForecastWindow)
+                {
+                    warnings.Add(
+                        $"{ModelName(outcome.Model)} {LegStatusName(leg)}" +
+                        $"{(string.IsNullOrWhiteSpace(leg.Detail) ? "." : $": {leg.Detail}")}");
+                }
+            }
+        }
+
+        HasNoaaWeather = _acquisitions.ContainsKey(ForecastModel.NoaaGfs);
+        HasEcmwfWeather = _acquisitions.ContainsKey(ForecastModel.EcmwfIfs);
+        ActiveWeatherModel = HasNoaaWeather
+            ? ForecastModel.NoaaGfs
+            : HasEcmwfWeather
+                ? ForecastModel.EcmwfIfs
+                : null;
+
+        var routes = result.Models
+            .SelectMany(outcome => outcome.Legs)
+            .Where(leg => leg.Route is not null)
+            .Select(leg => leg.Route!)
+            .ToImmutableArray();
+        _mapLayers.SetRoutes(routes);
+        _displayedRoutePlanId = Itinerary.PlanId;
+        _mapLayers.FitRoutes();
+        OnPropertyChanged(nameof(SuccessfulRouteCount));
+        BuildTimeline(routes);
+        ProgressFraction = 1;
+        ErrorMessage = failures.Count == 0 ? null : string.Join(Environment.NewLine, failures);
+        WarningMessage = warnings.Count == 0 ? null : string.Join(Environment.NewLine, warnings);
+        UpdateLandAvoidanceWarning(routes);
+        StatusMessage = result.Status switch
+        {
+            RoutePlanRoutingStatus.Succeeded => "All itinerary legs are complete.",
+            RoutePlanRoutingStatus.PartialSuccess =>
+                "The itinerary has partial results; review the model and leg statuses.",
+            RoutePlanRoutingStatus.Cancelled =>
+                "Calculation cancelled; completed legs were saved.",
+            _ => "No model completed the itinerary."
+        };
+        OnPropertyChanged(nameof(SelectedRouteDetails));
+        RequestWeatherRefreshFromViewport();
+    }
+
     partial void OnHasNoaaWeatherChanged(bool value) =>
         ActivateNoaaWeatherCommand.NotifyCanExecuteChanged();
 
@@ -905,13 +1077,6 @@ public partial class MainViewModel : ViewModelBase
         if (Start is null || Destination is null)
         {
             error = "Set both endpoints before calculating.";
-            return false;
-        }
-
-        if (Itinerary.Waypoints.Count != 2)
-        {
-            error = "Sequential multi-leg route calculation is not available yet. " +
-                    "Save the itinerary, or remove intermediate waypoints to calculate a direct route.";
             return false;
         }
 
@@ -1383,7 +1548,7 @@ public partial class MainViewModel : ViewModelBase
         StatusMessage = Start is not null && Destination is not null
             ? Itinerary.Waypoints.Count == 2
                 ? "Endpoints ready. Choose forecast models and calculate."
-                : "Itinerary updated. Multi-leg calculation will be added in a later slice."
+                : "Itinerary ready. Choose forecast models and calculate."
             : "Endpoint placed. Set the remaining endpoint.";
     }
 
@@ -1487,10 +1652,41 @@ public partial class MainViewModel : ViewModelBase
     private static bool IsExperimentalDownload(
         RoutingWorkflowRequest request,
         ForecastModel model) =>
+        IsExperimentalDownload(request.Selections, model);
+
+    private static bool IsExperimentalDownload(
+        IEnumerable<ForecastSelection> selections,
+        ForecastModel model) =>
         model == ForecastModel.EcmwfIfs &&
-        request.Selections.Any(selection =>
+        selections.Any(selection =>
             selection.Model == model &&
             selection.Kind == ForecastSelectionKind.OfficialDownload);
+
+    private static string PlanProgressStageName(RoutePlanRoutingUnitStatus status) => status switch
+    {
+        RoutePlanRoutingUnitStatus.AcquiringForecast => "acquiring",
+        RoutePlanRoutingUnitStatus.CalculatingRoute => "routing",
+        RoutePlanRoutingUnitStatus.Succeeded => "complete",
+        RoutePlanRoutingUnitStatus.ForecastLimited => "forecast-limited",
+        RoutePlanRoutingUnitStatus.Failed => "failed",
+        RoutePlanRoutingUnitStatus.Cancelled => "cancelled",
+        RoutePlanRoutingUnitStatus.Blocked => "blocked",
+        RoutePlanRoutingUnitStatus.OutsideForecastWindow => "outside forecast window",
+        _ => status.ToString()
+    };
+
+    private static string LegStatusName(RouteLegResult leg) => leg.State switch
+    {
+        RouteLegOutcomeState.Succeeded
+            when leg.Reason == RouteLegOutcomeReason.ForecastExhausted => "forecast-limited",
+        RouteLegOutcomeState.Succeeded => "complete",
+        RouteLegOutcomeState.Failed => "failed",
+        RouteLegOutcomeState.Cancelled => "cancelled",
+        RouteLegOutcomeState.Blocked => "blocked by prior failure",
+        RouteLegOutcomeState.OutsideForecastWindow => "outside forecast window",
+        RouteLegOutcomeState.Invalidated => "invalidated",
+        _ => "not calculated"
+    };
 
     private static string ProgressStageName(RoutingProgressStage stage) => stage switch
     {

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -265,7 +265,7 @@ public sealed class RoutePlanRoutingWorkflow
                             acceptedRoute);
                         if (!await PublishAsync(
                                 modelState,
-                                completeSession: limited || legIndex == request.Plan.Legs.Length - 1)
+                                completeSession: legIndex == request.Plan.Legs.Length - 1)
                             .ConfigureAwait(false))
                         {
                             return;
@@ -365,7 +365,7 @@ public sealed class RoutePlanRoutingWorkflow
                     legs,
                     state.Acquisitions.ToImmutableArray());
             })
-            .OrderBy(outcome => Array.IndexOf(request.Models.ToArray(), outcome.Model))
+            .OrderBy(outcome => request.Models.IndexOf(outcome.Model))
             .ToImmutableArray();
         return new RoutePlanRoutingResult(
             request,
@@ -532,10 +532,11 @@ public sealed class RoutePlanRoutingWorkflow
             string? message = null,
             RouteCalculationSnapshot? snapshot = null)
         {
+            RoutePlanRoutingProgress report;
             lock (_gate)
             {
                 _fractions[(model, legIndex)] = fraction;
-                _progress?.Report(new RoutePlanRoutingProgress(
+                report = new RoutePlanRoutingProgress(
                     model.Provider(),
                     model,
                     legIndex,
@@ -544,8 +545,10 @@ public sealed class RoutePlanRoutingWorkflow
                     fraction,
                     _fractions.Values.Average(),
                     message,
-                    snapshot));
+                    snapshot);
             }
+
+            _progress?.Report(report);
         }
     }
 

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -1,0 +1,556 @@
+using System.Collections.Immutable;
+
+namespace Navtool.Core;
+
+public sealed record RoutePlanRoutingRequest
+{
+    public static readonly TimeSpan MaximumForecastWindow = TimeSpan.FromDays(10);
+
+    public RoutePlanRoutingRequest(
+        RoutePlan plan,
+        DateTimeOffset departureTime,
+        DateTimeOffset forecastCutoff,
+        IEnumerable<ForecastSelection> selections)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(selections);
+        var immutableSelections = selections.ToImmutableArray();
+        if (immutableSelections.Length is < 1 or > 2 ||
+            immutableSelections.Select(selection => selection.Model).Distinct().Count() !=
+            immutableSelections.Length)
+        {
+            throw new ArgumentException(
+                "Select one or two distinct forecast models.",
+                nameof(selections));
+        }
+
+        var departureUtc = departureTime.ToUniversalTime();
+        var cutoffUtc = forecastCutoff.ToUniversalTime();
+        if (cutoffUtc <= departureUtc)
+        {
+            throw new ArgumentException(
+                "The forecast cutoff must be after the departure.",
+                nameof(forecastCutoff));
+        }
+
+        if (cutoffUtc - departureUtc > MaximumForecastWindow)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(forecastCutoff),
+                "The forecast window cannot exceed ten days.");
+        }
+
+        Plan = plan;
+        DepartureTime = departureUtc;
+        ForecastCutoff = cutoffUtc;
+        Selections = immutableSelections;
+        Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
+    }
+
+    public RoutePlan Plan { get; }
+
+    public DateTimeOffset DepartureTime { get; }
+
+    public DateTimeOffset ForecastCutoff { get; }
+
+    public ImmutableArray<ForecastSelection> Selections { get; }
+
+    public ImmutableArray<ForecastModel> Models { get; }
+}
+
+public enum RoutePlanRoutingUnitStatus
+{
+    AcquiringForecast,
+    CalculatingRoute,
+    Succeeded,
+    ForecastLimited,
+    Failed,
+    Cancelled,
+    Blocked,
+    OutsideForecastWindow
+}
+
+public sealed record RoutePlanRoutingProgress(
+    ForecastProvider Provider,
+    ForecastModel Model,
+    int LegIndex,
+    RouteLegId LegId,
+    RoutePlanRoutingUnitStatus Status,
+    double UnitFraction,
+    double OverallFraction,
+    string? Message = null,
+    RouteCalculationSnapshot? Snapshot = null);
+
+public enum RoutePlanModelStatus
+{
+    Succeeded,
+    PartialSuccess,
+    ForecastLimited,
+    Failed,
+    Cancelled,
+    OutsideForecastWindow
+}
+
+public sealed record RoutePlanModelOutcome(
+    ForecastModel Model,
+    RoutePlanModelStatus Status,
+    ImmutableArray<RouteLegResult> Legs,
+    ImmutableArray<ForecastAcquisition> Acquisitions);
+
+public enum RoutePlanRoutingStatus
+{
+    Succeeded,
+    PartialSuccess,
+    Failed,
+    Cancelled
+}
+
+public sealed record RoutePlanRoutingResult(
+    RoutePlanRoutingRequest Request,
+    RoutePlan Plan,
+    ImmutableArray<RoutePlanModelOutcome> Models,
+    RoutePlanRoutingStatus Status,
+    bool IsCurrent);
+
+public sealed class RoutePlanRoutingWorkflow
+{
+    private readonly RoutingWorkflow _singleLegWorkflow;
+    private readonly IRoutePlanRepository _repository;
+    private readonly TimeProvider _timeProvider;
+    private readonly SemaphoreSlim _publicationGate = new(1, 1);
+    private readonly Dictionary<RoutePlanId, Guid> _activeOperations = [];
+
+    public RoutePlanRoutingWorkflow(
+        RoutingWorkflow singleLegWorkflow,
+        IRoutePlanRepository repository,
+        TimeProvider? timeProvider = null)
+    {
+        ArgumentNullException.ThrowIfNull(singleLegWorkflow);
+        ArgumentNullException.ThrowIfNull(repository);
+        _singleLegWorkflow = singleLegWorkflow;
+        _repository = repository;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<RoutePlanRoutingResult> ExecuteAsync(
+        RoutePlanRoutingRequest request,
+        IProgress<RoutePlanRoutingProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var operationId = Guid.NewGuid();
+        var currentPlan = request.Plan;
+        await _publicationGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            _activeOperations[request.Plan.Id] = operationId;
+        }
+        finally
+        {
+            _publicationGate.Release();
+        }
+
+        var progressState = new ProgressState(request, progress);
+        var modelStates = request.Selections.ToDictionary(
+            selection => selection.Model,
+            selection => new ModelExecutionState(
+                selection,
+                new RouteCalculationSession(
+                    request.Plan.Id,
+                    selection.Model,
+                    _timeProvider.GetUtcNow()),
+                request.Plan.Legs.Select(leg => new RouteLegResult(
+                    leg.Id,
+                    RouteLegOutcomeState.Pending,
+                    RouteLegOutcomeReason.None)).ToArray()));
+
+        async Task<bool> PublishAsync(ModelExecutionState modelState, bool completeSession)
+        {
+            await _publicationGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+            try
+            {
+                if (!_activeOperations.TryGetValue(request.Plan.Id, out var currentOperation) ||
+                    currentOperation != operationId)
+                {
+                    return false;
+                }
+
+                var session = completeSession
+                    ? modelState.Session.Complete(_timeProvider.GetUtcNow())
+                    : modelState.Session;
+                var updatedPlan = currentPlan.WithResult(
+                    new RoutePlanResult(session, modelState.Legs));
+                await _repository.SaveAsync(updatedPlan, CancellationToken.None).ConfigureAwait(false);
+                currentPlan = updatedPlan;
+                return true;
+            }
+            finally
+            {
+                _publicationGate.Release();
+            }
+        }
+
+        async Task RunModelAsync(ModelExecutionState modelState)
+        {
+            var departure = request.DepartureTime;
+            try
+            {
+                for (var legIndex = 0; legIndex < request.Plan.Legs.Length; legIndex++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (departure >= request.ForecastCutoff)
+                    {
+                        await MarkRemainingAsync(
+                            modelState,
+                            legIndex,
+                            RouteLegOutcomeState.OutsideForecastWindow,
+                            RouteLegOutcomeReason.OutsideForecastWindow,
+                            RoutePlanRoutingUnitStatus.OutsideForecastWindow,
+                            "Departure is at or after the forecast cutoff.",
+                            PublishAsync,
+                            progressState).ConfigureAwait(false);
+                        return;
+                    }
+
+                    var leg = request.Plan.Legs[legIndex];
+                    var from = request.Plan.Waypoints[legIndex];
+                    var to = request.Plan.Waypoints[legIndex + 1];
+                    var route = new RouteRequest(
+                        $"{request.Plan.Id}-leg-{legIndex}-{modelState.Session.Id}",
+                        from.Coordinate,
+                        to.Coordinate,
+                        departure,
+                        request.ForecastCutoff);
+                    var workflowRequest = new RoutingWorkflowRequest(
+                        route,
+                        [modelState.Selection],
+                        ForecastCorridor.Create(route.Origin, route.Destination));
+                    var legProgress = new InlineProgress<RoutingProgress>(value =>
+                        progressState.Report(
+                            value.Model,
+                            legIndex,
+                            value.Stage switch
+                            {
+                                RoutingProgressStage.AcquiringForecast =>
+                                    RoutePlanRoutingUnitStatus.AcquiringForecast,
+                                RoutingProgressStage.CalculatingRoute =>
+                                    RoutePlanRoutingUnitStatus.CalculatingRoute,
+                                RoutingProgressStage.Completed =>
+                                    RoutePlanRoutingUnitStatus.Succeeded,
+                                _ => RoutePlanRoutingUnitStatus.Failed
+                            },
+                            value.Fraction,
+                            value.Message,
+                            value.Snapshot));
+                    var workflowResult = await _singleLegWorkflow.ExecuteAsync(
+                        workflowRequest,
+                        legProgress,
+                        cancellationToken).ConfigureAwait(false);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var outcome = workflowResult.Outcomes[0];
+                    if (outcome.Acquisition is not null)
+                    {
+                        modelState.Acquisitions.Add(outcome.Acquisition);
+                    }
+
+                    if (outcome.Route is { } acceptedRoute)
+                    {
+                        var limited = acceptedRoute.IsForecastLimited;
+                        modelState.Legs[legIndex] = new RouteLegResult(
+                            leg.Id,
+                            RouteLegOutcomeState.Succeeded,
+                            limited
+                                ? RouteLegOutcomeReason.ForecastExhausted
+                                : RouteLegOutcomeReason.CalculationSucceeded,
+                            acceptedRoute);
+                        if (!await PublishAsync(
+                                modelState,
+                                completeSession: limited || legIndex == request.Plan.Legs.Length - 1)
+                            .ConfigureAwait(false))
+                        {
+                            return;
+                        }
+
+                        progressState.Report(
+                            modelState.Selection.Model,
+                            legIndex,
+                            limited
+                                ? RoutePlanRoutingUnitStatus.ForecastLimited
+                                : RoutePlanRoutingUnitStatus.Succeeded,
+                            1,
+                            limited ? "Forecast coverage ended before the destination." : null);
+                        if (limited)
+                        {
+                            await MarkRemainingAsync(
+                                modelState,
+                                legIndex + 1,
+                                RouteLegOutcomeState.Blocked,
+                                RouteLegOutcomeReason.BlockedByPriorFailure,
+                                RoutePlanRoutingUnitStatus.Blocked,
+                                "Blocked because the prior leg exhausted forecast coverage.",
+                                PublishAsync,
+                                progressState).ConfigureAwait(false);
+                            return;
+                        }
+
+                        departure = acceptedRoute.ArrivalTime + (to.Stopover ?? TimeSpan.Zero);
+                        continue;
+                    }
+
+                    var failure = outcome.Failure!;
+                    modelState.Legs[legIndex] = new RouteLegResult(
+                        leg.Id,
+                        RouteLegOutcomeState.Failed,
+                        FailureReason(failure.Stage),
+                        detail: failure.Message);
+                    if (!await PublishAsync(
+                            modelState,
+                            completeSession: legIndex == request.Plan.Legs.Length - 1)
+                        .ConfigureAwait(false))
+                    {
+                        return;
+                    }
+
+                    progressState.Report(
+                        modelState.Selection.Model,
+                        legIndex,
+                        RoutePlanRoutingUnitStatus.Failed,
+                        1,
+                        failure.Message);
+                    await MarkRemainingAsync(
+                        modelState,
+                        legIndex + 1,
+                        RouteLegOutcomeState.Blocked,
+                        RouteLegOutcomeReason.BlockedByPriorFailure,
+                        RoutePlanRoutingUnitStatus.Blocked,
+                        "Blocked because the prior leg failed.",
+                        PublishAsync,
+                        progressState).ConfigureAwait(false);
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                await MarkCancelledAsync(modelState, PublishAsync, progressState).ConfigureAwait(false);
+            }
+        }
+
+        var tasks = modelStates.Values.Select(RunModelAsync).ToArray();
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        var isCurrent = false;
+        await _publicationGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
+            if (_activeOperations.TryGetValue(request.Plan.Id, out var currentOperation) &&
+                currentOperation == operationId)
+            {
+                _activeOperations.Remove(request.Plan.Id);
+                isCurrent = true;
+            }
+        }
+        finally
+        {
+            _publicationGate.Release();
+        }
+
+        var outcomes = modelStates.Values
+            .Select(state =>
+            {
+                var result = currentPlan.LatestResult(state.Selection.Model);
+                var legs = result?.Legs ?? state.Legs.ToImmutableArray();
+                return new RoutePlanModelOutcome(
+                    state.Selection.Model,
+                    DetermineModelStatus(legs),
+                    legs,
+                    state.Acquisitions.ToImmutableArray());
+            })
+            .OrderBy(outcome => Array.IndexOf(request.Models.ToArray(), outcome.Model))
+            .ToImmutableArray();
+        return new RoutePlanRoutingResult(
+            request,
+            currentPlan,
+            outcomes,
+            DetermineOverallStatus(outcomes),
+            isCurrent);
+    }
+
+    private static async Task MarkRemainingAsync(
+        ModelExecutionState modelState,
+        int firstLegIndex,
+        RouteLegOutcomeState state,
+        RouteLegOutcomeReason reason,
+        RoutePlanRoutingUnitStatus status,
+        string detail,
+        Func<ModelExecutionState, bool, Task<bool>> publish,
+        ProgressState progress)
+    {
+        for (var index = firstLegIndex; index < modelState.Legs.Length; index++)
+        {
+            modelState.Legs[index] = new RouteLegResult(
+                modelState.Legs[index].LegId,
+                state,
+                reason,
+                detail: detail);
+            if (!await publish(modelState, index == modelState.Legs.Length - 1).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            progress.Report(modelState.Selection.Model, index, status, 1, detail);
+        }
+    }
+
+    private static async Task MarkCancelledAsync(
+        ModelExecutionState modelState,
+        Func<ModelExecutionState, bool, Task<bool>> publish,
+        ProgressState progress)
+    {
+        var pending = Enumerable.Range(0, modelState.Legs.Length)
+            .Where(index => modelState.Legs[index].State == RouteLegOutcomeState.Pending)
+            .ToArray();
+        for (var pendingIndex = 0; pendingIndex < pending.Length; pendingIndex++)
+        {
+            var legIndex = pending[pendingIndex];
+            modelState.Legs[legIndex] = new RouteLegResult(
+                modelState.Legs[legIndex].LegId,
+                RouteLegOutcomeState.Cancelled,
+                RouteLegOutcomeReason.CalculationCancelled,
+                detail: "Not calculated because the calculation was cancelled.");
+            if (!await publish(modelState, pendingIndex == pending.Length - 1).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            progress.Report(
+                modelState.Selection.Model,
+                legIndex,
+                RoutePlanRoutingUnitStatus.Cancelled,
+                1,
+                "Calculation cancelled.");
+        }
+    }
+
+    private static RouteLegOutcomeReason FailureReason(ModelRouteFailureStage stage) => stage switch
+    {
+        ModelRouteFailureStage.ForecastAcquisition =>
+            RouteLegOutcomeReason.ForecastAcquisitionFailed,
+        ModelRouteFailureStage.RouteCalculation =>
+            RouteLegOutcomeReason.RouteCalculationFailed,
+        _ => RouteLegOutcomeReason.ResultValidationFailed
+    };
+
+    private static RoutePlanModelStatus DetermineModelStatus(ImmutableArray<RouteLegResult> legs)
+    {
+        var hasAccepted = legs.Any(leg => leg.Route is not null);
+        if (legs.Any(leg => leg.State == RouteLegOutcomeState.Cancelled))
+        {
+            return RoutePlanModelStatus.Cancelled;
+        }
+
+        if (legs.Any(leg => leg.Reason == RouteLegOutcomeReason.ForecastExhausted))
+        {
+            return RoutePlanModelStatus.ForecastLimited;
+        }
+
+        if (legs.Any(leg => leg.State == RouteLegOutcomeState.Failed))
+        {
+            return hasAccepted ? RoutePlanModelStatus.PartialSuccess : RoutePlanModelStatus.Failed;
+        }
+
+        if (legs.Any(leg => leg.State == RouteLegOutcomeState.OutsideForecastWindow))
+        {
+            return hasAccepted
+                ? RoutePlanModelStatus.PartialSuccess
+                : RoutePlanModelStatus.OutsideForecastWindow;
+        }
+
+        return RoutePlanModelStatus.Succeeded;
+    }
+
+    private static RoutePlanRoutingStatus DetermineOverallStatus(
+        ImmutableArray<RoutePlanModelOutcome> outcomes)
+    {
+        if (outcomes.Any(outcome => outcome.Status == RoutePlanModelStatus.Cancelled))
+        {
+            return RoutePlanRoutingStatus.Cancelled;
+        }
+
+        if (outcomes.All(outcome => outcome.Status == RoutePlanModelStatus.Succeeded))
+        {
+            return RoutePlanRoutingStatus.Succeeded;
+        }
+
+        if (outcomes.Any(outcome => outcome.Legs.Any(leg => leg.Route is not null)))
+        {
+            return RoutePlanRoutingStatus.PartialSuccess;
+        }
+
+        return RoutePlanRoutingStatus.Failed;
+    }
+
+    private sealed class ModelExecutionState(
+        ForecastSelection selection,
+        RouteCalculationSession session,
+        RouteLegResult[] legs)
+    {
+        public ForecastSelection Selection { get; } = selection;
+
+        public RouteCalculationSession Session { get; } = session;
+
+        public RouteLegResult[] Legs { get; } = legs;
+
+        public List<ForecastAcquisition> Acquisitions { get; } = [];
+    }
+
+    private sealed class ProgressState
+    {
+        private readonly RoutePlanRoutingRequest _request;
+        private readonly IProgress<RoutePlanRoutingProgress>? _progress;
+        private readonly Dictionary<(ForecastModel Model, int LegIndex), double> _fractions;
+        private readonly object _gate = new();
+
+        public ProgressState(
+            RoutePlanRoutingRequest request,
+            IProgress<RoutePlanRoutingProgress>? progress)
+        {
+            _request = request;
+            _progress = progress;
+            _fractions = request.Models
+                .SelectMany(model => Enumerable.Range(0, request.Plan.Legs.Length)
+                    .Select(index => new KeyValuePair<(ForecastModel, int), double>(
+                        (model, index),
+                        0)))
+                .ToDictionary();
+        }
+
+        public void Report(
+            ForecastModel model,
+            int legIndex,
+            RoutePlanRoutingUnitStatus status,
+            double fraction,
+            string? message = null,
+            RouteCalculationSnapshot? snapshot = null)
+        {
+            lock (_gate)
+            {
+                _fractions[(model, legIndex)] = fraction;
+                _progress?.Report(new RoutePlanRoutingProgress(
+                    model.Provider(),
+                    model,
+                    legIndex,
+                    _request.Plan.Legs[legIndex].Id,
+                    status,
+                    fraction,
+                    _fractions.Values.Average(),
+                    message,
+                    snapshot));
+            }
+        }
+    }
+
+    private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+    {
+        public void Report(T value) => report(value);
+    }
+}

--- a/src/Navtool.Core/RoutePlans.cs
+++ b/src/Navtool.Core/RoutePlans.cs
@@ -161,6 +161,9 @@ public enum RouteLegOutcomeState
     Pending,
     Succeeded,
     Failed,
+    Cancelled,
+    Blocked,
+    OutsideForecastWindow,
     Invalidated
 }
 
@@ -172,6 +175,9 @@ public enum RouteLegOutcomeReason
     ForecastAcquisitionFailed,
     RouteCalculationFailed,
     ResultValidationFailed,
+    CalculationCancelled,
+    BlockedByPriorFailure,
+    OutsideForecastWindow,
     WaypointCoordinateChanged,
     WaypointsReordered,
     StopoverChanged,

--- a/tests/Navtool.App.Tests/AppCompositionTests.cs
+++ b/tests/Navtool.App.Tests/AppCompositionTests.cs
@@ -42,6 +42,7 @@ public sealed class AppCompositionTests
             var repository = Assert.IsType<RoutePlanJsonRepository>(
                 services.GetRequiredService<IRoutePlanRepository>());
             Assert.Equal(Path.Combine(root, "routes"), repository.RootDirectory);
+            Assert.NotNull(services.GetRequiredService<RoutePlanRoutingWorkflow>());
             Assert.NotNull(services.GetRequiredService<MainViewModel>().Itinerary);
         }
         finally

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -274,7 +274,7 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task Intermediate_waypoint_is_editable_but_sequential_calculation_is_deferred()
+    public async Task Initial_departure_beyond_five_day_lead_does_not_acquire_forecast()
     {
         var noaa = new DelegateForecastProvider(
             ForecastModel.NoaaGfs,
@@ -285,8 +285,35 @@ public sealed class MainViewModelWorkflowTests
             new RoutingWorkflow(new[] { noaa }, engine),
             new DelegateWeatherSampler((_, _, _, _, _, _) =>
                 ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        var departure = Now.AddDays(5).AddMinutes(1);
+        viewModel.DepartureDate = departure;
+        viewModel.DepartureTime = departure.TimeOfDay;
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Empty(noaa.Requests);
+        Assert.Contains("forecast horizon", viewModel.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Intermediate_waypoint_routes_sequentially_and_persists_results()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-multi-leg-{Guid.NewGuid():N}");
+        var repository = new RoutePlanJsonRepository(root);
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
         viewModel.Itinerary.AddWaypointCommand.Execute(null);
         var waypoint = viewModel.Itinerary.Waypoints[1];
+        waypoint.HasStopover = true;
+        waypoint.StopoverHours = 2;
         waypoint.SetOnMapCommand.Execute(null);
         viewModel.HandleMapClick(
             MapProjection.ToMapPoint(new Coordinate(36, -58)),
@@ -294,10 +321,24 @@ public sealed class MainViewModelWorkflowTests
 
         await viewModel.CalculateRoutesAsync();
 
-        Assert.Null(noaa.LastRequest);
+        Assert.Equal(2, noaa.Requests.Count);
+        Assert.Equal(noaa.Requests[0].Through, noaa.Requests[1].Through);
+        Assert.Equal(
+            noaa.Requests[0].From.AddHours(8),
+            noaa.Requests[1].From);
         Assert.Equal(36, waypoint.Coordinate!.Value.Latitude, 10);
         Assert.Equal(-58, waypoint.Coordinate.Value.Longitude, 10);
-        Assert.Contains("Sequential multi-leg", viewModel.ErrorMessage);
+        Assert.Equal(2, viewModel.SuccessfulRouteCount);
+        Assert.Contains("leg 1 complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("leg 2 complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("All itinerary legs are complete.", viewModel.StatusMessage);
+
+        var loaded = await repository.OpenAsync(viewModel.Itinerary.PlanId);
+        Assert.Equal(2, loaded.LatestResult(ForecastModel.NoaaGfs)!.Legs.Length);
+        var json = await File.ReadAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{loaded.Id}.route.json"));
+        Assert.DoesNotContain("fake-forecast.grib2", json, StringComparison.OrdinalIgnoreCase);
+        Directory.Delete(root, recursive: true);
     }
 
     [Fact]
@@ -881,7 +922,8 @@ public sealed class MainViewModelWorkflowTests
         RoutingWorkflow workflow,
         IWeatherSampler sampler,
         ILocalGribInspector? localGribInspector = null,
-        INativeRoutingPreflight? nativeRoutingPreflight = null)
+        INativeRoutingPreflight? nativeRoutingPreflight = null,
+        IRoutePlanRepository? routePlanRepository = null)
     {
         var viewModel = new MainViewModel(
             workflow,
@@ -890,7 +932,8 @@ public sealed class MainViewModelWorkflowTests
             TimeZoneInfo.Utc,
             new OsmTileOptions(Enabled: false),
             localGribInspector: localGribInspector,
-            nativeRoutingPreflight: nativeRoutingPreflight);
+            nativeRoutingPreflight: nativeRoutingPreflight,
+            routePlanRepository: routePlanRepository);
         viewModel.SetEndpoints(
             new Coordinate(34, -64),
             new Coordinate(39, -52));
@@ -1003,6 +1046,8 @@ public sealed class MainViewModelWorkflowTests
 
         public ForecastRequest? LastRequest { get; private set; }
 
+        public List<ForecastRequest> Requests { get; } = [];
+
         public int CallCount { get; private set; }
 
         public async ValueTask<ForecastAcquisition> AcquireAsync(
@@ -1012,6 +1057,7 @@ public sealed class MainViewModelWorkflowTests
         {
             CallCount++;
             LastRequest = request;
+            Requests.Add(request);
             progress?.Report(new ForecastProgress(
                 Provider,
                 Model,

--- a/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
@@ -137,14 +137,18 @@ public sealed class RoutePlanRoutingWorkflowTests
             ForecastModel.NoaaGfs,
             (request, _, _) => ValueTask.FromResult(Acquisition(request)));
         var plan = ThreeLegPlan();
-        var workflow = CreateWorkflow(
-            provider,
-            new DelegateRouteEngine((request, forecast, _) =>
-                ValueTask.FromResult(Route(
-                    request,
-                    forecast.Request.Model,
-                    TimeSpan.FromHours(4),
-                    RouteCompletion.ForecastExhausted))));
+        var repository = new RecordingRepository();
+        var workflow = new RoutePlanRoutingWorkflow(
+            new RoutingWorkflow(
+                [provider],
+                new DelegateRouteEngine((request, forecast, _) =>
+                    ValueTask.FromResult(Route(
+                        request,
+                        forecast.Request.Model,
+                        TimeSpan.FromHours(4),
+                        RouteCompletion.ForecastExhausted)))),
+            repository,
+            new FixedTimeProvider(Now));
 
         var result = await workflow.ExecuteAsync(
             Request(plan, Now.AddHours(1), Now.AddDays(8)));
@@ -158,6 +162,10 @@ public sealed class RoutePlanRoutingWorkflowTests
             Assert.Equal(RouteLegOutcomeState.Blocked, leg.State);
             Assert.Equal(RouteLegOutcomeReason.BlockedByPriorFailure, leg.Reason);
         });
+        Assert.Equal(
+            [false, false, true],
+            repository.SavedPlans.Select(saved =>
+                saved.LatestResult(ForecastModel.NoaaGfs)!.Session.CompletedAt is not null));
     }
 
     [Fact]
@@ -427,6 +435,8 @@ public sealed class RoutePlanRoutingWorkflowTests
 
         public int SaveCount { get; private set; }
 
+        public List<RoutePlan> SavedPlans { get; } = [];
+
         public ValueTask<ImmutableArray<RoutePlanSummary>> ListAsync(
             CancellationToken cancellationToken = default) =>
             ValueTask.FromResult(ImmutableArray<RoutePlanSummary>.Empty);
@@ -452,6 +462,7 @@ public sealed class RoutePlanRoutingWorkflowTests
             {
                 _plan = plan;
                 SaveCount++;
+                SavedPlans.Add(plan);
             }
 
             return ValueTask.CompletedTask;

--- a/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
@@ -1,0 +1,481 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace Navtool.Core.Tests;
+
+public sealed class RoutePlanRoutingWorkflowTests
+{
+    private static readonly DateTimeOffset Now =
+        new(2026, 8, 1, 18, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task Models_chain_independently_with_stopovers_one_cutoff_and_leg_corridors()
+    {
+        var bothModelsStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirstLegs = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstLegCalls = 0;
+        async ValueTask<ForecastAcquisition> Acquire(
+            ForecastRequest request,
+            IProgress<ForecastProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref firstLegCalls) <= 2)
+            {
+                if (Volatile.Read(ref firstLegCalls) == 2)
+                {
+                    bothModelsStarted.SetResult();
+                }
+
+                await releaseFirstLegs.Task.WaitAsync(cancellationToken);
+            }
+
+            progress?.Report(new(
+                request.Provider,
+                request.Model,
+                ForecastProgressStage.Downloading,
+                0.5));
+            return Acquisition(request, ForecastAcquisitionSource.Cache);
+        }
+
+        var noaa = new RecordingProvider(ForecastModel.NoaaGfs, Acquire);
+        var ecmwf = new RecordingProvider(ForecastModel.EcmwfIfs, Acquire);
+        var plan = Plan(
+            new RouteWaypoint("Start", new Coordinate(30, -70)),
+            new RouteWaypoint("Stop", new Coordinate(35, -60), TimeSpan.FromHours(2)),
+            new RouteWaypoint("Finish", new Coordinate(40, -50)));
+        var departure = Now.AddHours(1);
+        var cutoff = departure.AddDays(10);
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            var isFirstLeg = request.Origin == plan.Waypoints[0].Coordinate;
+            var duration = isFirstLeg
+                ? forecast.Request.Model == ForecastModel.NoaaGfs
+                    ? TimeSpan.FromDays(6) + TimeSpan.FromMilliseconds(900)
+                    : TimeSpan.FromDays(3) + TimeSpan.FromMilliseconds(400)
+                : TimeSpan.FromHours(4);
+            return ValueTask.FromResult(Route(request, forecast.Request.Model, duration));
+        });
+        var repository = new RecordingRepository();
+        var workflow = new RoutePlanRoutingWorkflow(
+            new RoutingWorkflow([noaa, ecmwf], engine),
+            repository,
+            new FixedTimeProvider(Now));
+        var reports = new ConcurrentQueue<RoutePlanRoutingProgress>();
+        var request = new RoutePlanRoutingRequest(
+            plan,
+            departure,
+            cutoff,
+            [ForecastSelection.OfficialDownload(ForecastModel.NoaaGfs),
+             ForecastSelection.OfficialDownload(ForecastModel.EcmwfIfs)]);
+
+        var execution = workflow.ExecuteAsync(
+            request,
+            new InlineProgress<RoutePlanRoutingProgress>(reports.Enqueue));
+        await bothModelsStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        releaseFirstLegs.SetResult();
+        var result = await execution;
+
+        Assert.Equal(RoutePlanRoutingStatus.Succeeded, result.Status);
+        Assert.All(result.Models, model => Assert.Equal(RoutePlanModelStatus.Succeeded, model.Status));
+        Assert.Equal(2, noaa.Requests.Count);
+        Assert.Equal(2, ecmwf.Requests.Count);
+        Assert.All(noaa.Requests.Concat(ecmwf.Requests), item =>
+            Assert.Equal(cutoff, item.Through));
+        Assert.Equal(
+            departure.AddDays(6).AddHours(2),
+            noaa.Requests[1].From);
+        Assert.True(noaa.Requests[1].From > Now.AddDays(5));
+        Assert.Equal(
+            ForecastCorridor.Create(plan.Waypoints[0].Coordinate, plan.Waypoints[1].Coordinate),
+            noaa.Requests[0].Bounds);
+        Assert.Equal(
+            ForecastCorridor.Create(plan.Waypoints[1].Coordinate, plan.Waypoints[2].Coordinate),
+            noaa.Requests[1].Bounds);
+        Assert.True(repository.SaveCount >= 4);
+        Assert.Equal(1, reports.Last().OverallFraction);
+        AssertProgressAverages(reports, request.Models.Length * plan.Legs.Length);
+        Assert.All(result.Models.SelectMany(model => model.Acquisitions), acquisition =>
+            Assert.Equal(ForecastAcquisitionSource.Cache, acquisition.Source));
+    }
+
+    [Fact]
+    public async Task Result_derived_departure_at_cutoff_marks_remaining_legs_outside_window()
+    {
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = Plan(
+            new RouteWaypoint("Start", new Coordinate(30, -70)),
+            new RouteWaypoint("Stop", new Coordinate(35, -60)),
+            new RouteWaypoint("Finish", new Coordinate(40, -50)));
+        var departure = Now.AddHours(1);
+        var cutoff = departure.AddDays(2);
+        var workflow = CreateWorkflow(
+            provider,
+            new DelegateRouteEngine((request, forecast, _) =>
+                ValueTask.FromResult(Route(
+                    request,
+                    forecast.Request.Model,
+                    cutoff - request.DepartureTime))));
+
+        var result = await workflow.ExecuteAsync(Request(plan, departure, cutoff));
+
+        Assert.Single(provider.Requests);
+        var model = Assert.Single(result.Models);
+        Assert.Equal(RoutePlanModelStatus.PartialSuccess, model.Status);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.OutsideForecastWindow, model.Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.OutsideForecastWindow, model.Legs[1].Reason);
+    }
+
+    [Fact]
+    public async Task Forecast_exhaustion_accepts_partial_route_and_never_schedules_later_leg()
+    {
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        var workflow = CreateWorkflow(
+            provider,
+            new DelegateRouteEngine((request, forecast, _) =>
+                ValueTask.FromResult(Route(
+                    request,
+                    forecast.Request.Model,
+                    TimeSpan.FromHours(4),
+                    RouteCompletion.ForecastExhausted))));
+
+        var result = await workflow.ExecuteAsync(
+            Request(plan, Now.AddHours(1), Now.AddDays(8)));
+
+        Assert.Single(provider.Requests);
+        var model = Assert.Single(result.Models);
+        Assert.Equal(RoutePlanModelStatus.ForecastLimited, model.Status);
+        Assert.Equal(RouteLegOutcomeReason.ForecastExhausted, model.Legs[0].Reason);
+        Assert.All(model.Legs.Skip(1), leg =>
+        {
+            Assert.Equal(RouteLegOutcomeState.Blocked, leg.State);
+            Assert.Equal(RouteLegOutcomeReason.BlockedByPriorFailure, leg.Reason);
+        });
+    }
+
+    [Fact]
+    public async Task Failure_blocks_only_that_model_and_other_model_completes()
+    {
+        var noaa = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var ecmwf = new RecordingProvider(
+            ForecastModel.EcmwfIfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        var workflow = new RoutePlanRoutingWorkflow(
+            new RoutingWorkflow(
+                [noaa, ecmwf],
+                new DelegateRouteEngine((request, forecast, _) =>
+                    forecast.Request.Model == ForecastModel.NoaaGfs
+                        ? ValueTask.FromException<RouteResult>(
+                            new InvalidOperationException("NOAA search failed"))
+                        : ValueTask.FromResult(Route(
+                            request,
+                            forecast.Request.Model,
+                            TimeSpan.FromHours(2))))),
+            new RecordingRepository(),
+            new FixedTimeProvider(Now));
+
+        var result = await workflow.ExecuteAsync(new RoutePlanRoutingRequest(
+            plan,
+            Now.AddHours(1),
+            Now.AddDays(8),
+            [ForecastSelection.OfficialDownload(ForecastModel.NoaaGfs),
+             ForecastSelection.OfficialDownload(ForecastModel.EcmwfIfs)]));
+
+        Assert.Single(noaa.Requests);
+        Assert.Equal(3, ecmwf.Requests.Count);
+        var failed = result.Models.Single(model => model.Model == ForecastModel.NoaaGfs);
+        Assert.Equal(RoutePlanModelStatus.Failed, failed.Status);
+        Assert.Equal(RouteLegOutcomeState.Failed, failed.Legs[0].State);
+        Assert.All(failed.Legs.Skip(1), leg =>
+            Assert.Equal(RouteLegOutcomeState.Blocked, leg.State));
+        Assert.Equal(
+            RoutePlanModelStatus.Succeeded,
+            result.Models.Single(model => model.Model == ForecastModel.EcmwfIfs).Status);
+        Assert.Equal(RoutePlanRoutingStatus.PartialSuccess, result.Status);
+    }
+
+    [Fact]
+    public async Task Mid_run_cancellation_persists_success_and_marks_unfinished_not_calculated()
+    {
+        var secondLegStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        var engineCalls = 0;
+        var repository = new RecordingRepository();
+        var workflow = new RoutePlanRoutingWorkflow(
+            new RoutingWorkflow(
+                [provider],
+                new DelegateRouteEngine(async (request, forecast, cancellationToken) =>
+                {
+                    if (Interlocked.Increment(ref engineCalls) == 2)
+                    {
+                        secondLegStarted.SetResult();
+                        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                    }
+
+                    return Route(request, forecast.Request.Model, TimeSpan.FromHours(2));
+                })),
+            repository,
+            new FixedTimeProvider(Now));
+        using var cancellation = new CancellationTokenSource();
+
+        var execution = workflow.ExecuteAsync(
+            Request(plan, Now.AddHours(1), Now.AddDays(8)),
+            cancellationToken: cancellation.Token);
+        await secondLegStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        cancellation.Cancel();
+        var result = await execution;
+
+        Assert.Equal(RoutePlanRoutingStatus.Cancelled, result.Status);
+        var legs = Assert.Single(result.Models).Legs;
+        Assert.Equal(RouteLegOutcomeState.Succeeded, legs[0].State);
+        Assert.All(legs.Skip(1), leg =>
+        {
+            Assert.Equal(RouteLegOutcomeState.Cancelled, leg.State);
+            Assert.Equal(RouteLegOutcomeReason.CalculationCancelled, leg.Reason);
+            Assert.Null(leg.Route);
+        });
+        var persisted = await repository.OpenAsync(plan.Id);
+        Assert.Equal(legs, persisted.LatestResult(ForecastModel.NoaaGfs)!.Legs);
+        Assert.NotNull(persisted.LatestResult(ForecastModel.NoaaGfs)!.Session.CompletedAt);
+    }
+
+    [Fact]
+    public async Task Superseded_generation_cannot_publish_after_newer_result()
+    {
+        var firstStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource<ForecastAcquisition>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            async (request, _, _) =>
+            {
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    firstStarted.SetResult();
+                    return await releaseFirst.Task;
+                }
+
+                return Acquisition(request);
+            });
+        var plan = Plan(
+            new RouteWaypoint("Start", new Coordinate(30, -70)),
+            new RouteWaypoint("Finish", new Coordinate(40, -50)));
+        var repository = new RecordingRepository();
+        var workflow = new RoutePlanRoutingWorkflow(
+            new RoutingWorkflow(
+                [provider],
+                new DelegateRouteEngine((request, forecast, _) =>
+                    ValueTask.FromResult(Route(
+                        request,
+                        forecast.Request.Model,
+                        TimeSpan.FromHours(2))))),
+            repository,
+            new FixedTimeProvider(Now));
+        var request = Request(plan, Now.AddHours(1), Now.AddDays(8));
+
+        var staleExecution = workflow.ExecuteAsync(request);
+        await firstStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var current = await workflow.ExecuteAsync(request);
+        releaseFirst.SetResult(Acquisition(provider.Requests[0]));
+        var stale = await staleExecution;
+
+        Assert.True(current.IsCurrent);
+        Assert.False(stale.IsCurrent);
+        var persisted = await repository.OpenAsync(plan.Id);
+        Assert.Equal(
+            current.Plan.LatestResult(ForecastModel.NoaaGfs)!.Session.Id,
+            persisted.LatestResult(ForecastModel.NoaaGfs)!.Session.Id);
+    }
+
+    private static RoutePlanRoutingWorkflow CreateWorkflow(
+        IForecastProvider provider,
+        IRouteEngine engine) =>
+        new(
+            new RoutingWorkflow([provider], engine),
+            new RecordingRepository(),
+            new FixedTimeProvider(Now));
+
+    private static RoutePlanRoutingRequest Request(
+        RoutePlan plan,
+        DateTimeOffset departure,
+        DateTimeOffset cutoff) =>
+        new(
+            plan,
+            departure,
+            cutoff,
+            [ForecastSelection.OfficialDownload(ForecastModel.NoaaGfs)]);
+
+    private static RoutePlan Plan(params RouteWaypoint[] waypoints) =>
+        new("Passage", waypoints);
+
+    private static RoutePlan ThreeLegPlan() =>
+        Plan(
+            new RouteWaypoint("Start", new Coordinate(30, -70)),
+            new RouteWaypoint("One", new Coordinate(33, -63), TimeSpan.FromHours(1)),
+            new RouteWaypoint("Two", new Coordinate(36, -57), TimeSpan.FromHours(1)),
+            new RouteWaypoint("Finish", new Coordinate(40, -50)));
+
+    private static ForecastAcquisition Acquisition(
+        ForecastRequest request,
+        ForecastAcquisitionSource source = ForecastAcquisitionSource.Remote) =>
+        new(
+            request,
+            new ForecastRun(request.Provider, request.Model, request.From.AddHours(-6)),
+            new LocalGribArtifact(Path.GetFullPath($"{request.Model}.grib2")),
+            source,
+            source == ForecastAcquisitionSource.Cache
+                ? new CacheMetadata("compatible-parts", Now, Now.AddHours(6))
+                : null);
+
+    private static RouteResult Route(
+        RouteRequest request,
+        ForecastModel model,
+        TimeSpan duration,
+        RouteCompletion completion = RouteCompletion.DestinationReached)
+    {
+        var destination = completion == RouteCompletion.DestinationReached
+            ? request.Destination
+            : new Coordinate(
+                (request.Origin.Latitude + request.Destination.Latitude) / 2,
+                (request.Origin.Longitude + request.Destination.Longitude) / 2);
+        return new RouteResult(
+            request,
+            model,
+            [
+                new RoutePoint(request.Origin, request.DepartureTime, 90, 6, 15, 180, 0),
+                new RoutePoint(destination, request.DepartureTime + duration, 90, 6, 15, 180, 50)
+            ],
+            new RouteDiagnostics(1, 2, 1, 1),
+            completion);
+    }
+
+    private static void AssertProgressAverages(
+        IEnumerable<RoutePlanRoutingProgress> reports,
+        int unitCount)
+    {
+        var fractions = new Dictionary<(ForecastModel, int), double>();
+        foreach (var report in reports)
+        {
+            fractions[(report.Model, report.LegIndex)] = report.UnitFraction;
+            Assert.Equal(fractions.Values.Sum() / unitCount, report.OverallFraction, 10);
+        }
+    }
+
+    private sealed class RecordingProvider(
+        ForecastModel model,
+        Func<
+            ForecastRequest,
+            IProgress<ForecastProgress>?,
+            CancellationToken,
+            ValueTask<ForecastAcquisition>> acquire) : IForecastProvider
+    {
+        public ForecastProvider Provider => model.Provider();
+
+        public ForecastModel Model => model;
+
+        public List<ForecastRequest> Requests { get; } = [];
+
+        public ValueTask<ForecastAcquisition> AcquireAsync(
+            ForecastRequest request,
+            IProgress<ForecastProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            lock (Requests)
+            {
+                Requests.Add(request);
+            }
+
+            return acquire(request, progress, cancellationToken);
+        }
+    }
+
+    private sealed class DelegateRouteEngine(
+        Func<
+            RouteRequest,
+            ForecastAcquisition,
+            CancellationToken,
+            ValueTask<RouteResult>> calculate) : IRouteEngine
+    {
+        public ValueTask<RouteResult> CalculateAsync(
+            RouteRequest request,
+            ForecastAcquisition forecast,
+            IProgress<RouteCalculationProgress>? progress,
+            CancellationToken cancellationToken) =>
+            calculate(request, forecast, cancellationToken);
+    }
+
+    private sealed class RecordingRepository : IRoutePlanRepository
+    {
+        private readonly object _gate = new();
+        private RoutePlan? _plan;
+
+        public int SaveCount { get; private set; }
+
+        public ValueTask<ImmutableArray<RoutePlanSummary>> ListAsync(
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(ImmutableArray<RoutePlanSummary>.Empty);
+
+        public ValueTask<RoutePlan> OpenAsync(
+            RoutePlanId id,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                return ValueTask.FromResult(
+                    _plan is not null && _plan.Id == id
+                        ? _plan
+                        : throw new KeyNotFoundException());
+            }
+        }
+
+        public ValueTask SaveAsync(
+            RoutePlan plan,
+            CancellationToken cancellationToken = default)
+        {
+            lock (_gate)
+            {
+                _plan = plan;
+                SaveCount++;
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<RoutePlan> SaveAsAsync(
+            RoutePlan plan,
+            string name,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public ValueTask DeleteAsync(
+            RoutePlanId id,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
+    private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+    {
+        public void Report(T value) => report(value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a route-plan routing coordinator above the existing single-leg `RoutingWorkflow`
- run itinerary legs sequentially per model while allowing models to advance independently
- use one absolute forecast cutoff, apply stopovers with whole-second departures, and stop blocked/out-of-window chains before acquisition
- persist accepted and terminal per-leg outcomes incrementally with cancellation and stale-generation protection
- integrate intermediate-waypoint calculation into `MainViewModel` while preserving direct two-point routing
- surface aggregate and per-model/leg statuses and retain partial results

## Tests
- `dotnet test Navtool.sln --no-restore --nologo --verbosity minimal`
- Core: 52 passed
- Infrastructure: 79 passed
- App: 84 passed

## Stack note
PR #38 merged while this slice was in progress, so this commit was rebased from the requested `c6a1f77` foundation snapshot onto current `main` after incorporating Slice 1's final review changes.

## Deferred
- sailed/current-position rolling resume workflow
- selected-leg optimized rendering and per-leg weather-acquisition selection