### PR TITLE
Polish map controls and add radial route calculation

### DIFF
--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -7,6 +7,7 @@ public enum RadialMenuAction
 {
     SetStart,
     SetDestination,
+    CalculateRoute,
     Inspect
 }
 
@@ -60,6 +61,7 @@ public static class RadialMenuPlacement
     [
         RadialMenuAction.SetStart,
         RadialMenuAction.SetDestination,
+        RadialMenuAction.CalculateRoute,
         RadialMenuAction.Inspect
     ];
 
@@ -136,21 +138,33 @@ public static class RadialMenuPlacement
         if (useHorizontal && horizontalGap is { } horizontalSpacing)
         {
             var step = actionSize.Width + horizontalSpacing;
-            offsets = [new ScreenPoint(-step, 0), new ScreenPoint(0, 0), new ScreenPoint(step, 0)];
-            halfWidth = step + (actionSize.Width / 2);
+            offsets =
+            [
+                new ScreenPoint(-1.5 * step, 0),
+                new ScreenPoint(-0.5 * step, 0),
+                new ScreenPoint(0.5 * step, 0),
+                new ScreenPoint(1.5 * step, 0)
+            ];
+            halfWidth = (1.5 * step) + (actionSize.Width / 2);
             halfHeight = actionSize.Height / 2;
         }
         else if (canUseVertical && verticalGap is { } verticalSpacing)
         {
             var step = actionSize.Height + verticalSpacing;
-            offsets = [new ScreenPoint(0, -step), new ScreenPoint(0, 0), new ScreenPoint(0, step)];
+            offsets =
+            [
+                new ScreenPoint(0, -1.5 * step),
+                new ScreenPoint(0, -0.5 * step),
+                new ScreenPoint(0, 0.5 * step),
+                new ScreenPoint(0, 1.5 * step)
+            ];
             halfWidth = actionSize.Width / 2;
-            halfHeight = step + (actionSize.Height / 2);
+            halfHeight = (1.5 * step) + (actionSize.Height / 2);
         }
         else
         {
             throw new ArgumentException(
-                "Visible bounds cannot contain a non-overlapping three-action menu.",
+                "Visible bounds cannot contain a non-overlapping four-action menu.",
                 nameof(safeBounds));
         }
 
@@ -168,13 +182,12 @@ public static class RadialMenuPlacement
 
     private static ImmutableArray<ScreenPoint> CreateRadialOffsets(double radius)
     {
-        var lowerX = radius * Math.Sqrt(3) / 2;
-        var lowerY = radius / 2;
         return
         [
             new ScreenPoint(0, -radius),
-            new ScreenPoint(lowerX, lowerY),
-            new ScreenPoint(-lowerX, lowerY)
+            new ScreenPoint(radius, 0),
+            new ScreenPoint(0, radius),
+            new ScreenPoint(-radius, 0)
         ];
     }
 

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -8,6 +8,11 @@
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryColor}" />
     </Style>
+    <Style Selector="TextBlock.field-label">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Foreground" Value="{DynamicResource TextSecondaryColor}" />
+    </Style>
     <Style Selector="TextBlock.muted">
         <Setter Property="Foreground" Value="{DynamicResource TextMutedColor}" />
         <Setter Property="FontSize" Value="12" />
@@ -22,7 +27,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="CornerRadius" Value="8" />
-        <Setter Property="Padding" Value="14" />
+        <Setter Property="Padding" Value="12" />
     </Style>
     <Style Selector="Border.subtle">
         <Setter Property="Background" Value="{DynamicResource SurfaceMutedColor}" />
@@ -43,6 +48,23 @@
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="MinHeight" Value="44" />
     </Style>
+    <Style Selector="Button.compact-action">
+        <Setter Property="MinWidth" Value="44" />
+        <Setter Property="Width" Value="44" />
+        <Setter Property="MinHeight" Value="44" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Foreground" Value="{DynamicResource TextSecondaryColor}" />
+    </Style>
+    <Style Selector="Grid.compact-action-row">
+        <Setter Property="ColumnSpacing" Value="8" />
+    </Style>
+    <Style Selector="StackPanel.compact-action-row">
+        <Setter Property="Orientation" Value="Horizontal" />
+        <Setter Property="Spacing" Value="4" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
     <Style Selector="Button.primary:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource AccentHoverColor}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentTextColor}" />
@@ -61,7 +83,8 @@
     </Style>
     <Style Selector="ToggleButton.map-tool">
         <Setter Property="MinHeight" Value="44" />
-        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Padding" Value="12,8" />
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
     </Style>
@@ -94,9 +117,11 @@
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
         <Setter Property="BorderThickness" Value="1" />
-        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontSize" Value="20" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="Padding" Value="0" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="ToggleButton.edge-handle:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ControlHoverColor}" />
@@ -117,7 +142,9 @@
         <Setter Property="BorderThickness" Value="2" />
         <Setter Property="CornerRadius" Value="24" />
         <Setter Property="FontWeight" Value="SemiBold" />
-        <Setter Property="Padding" Value="10,0" />
+        <Setter Property="Padding" Value="10,4" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
     <Style Selector="Button.radial-action:pointerover /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="Background" Value="{DynamicResource ControlHoverColor}" />
@@ -127,9 +154,31 @@
         <Setter Property="Background" Value="{DynamicResource ControlPressedColor}" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
     </Style>
+    <Style Selector="Button.radial-action:disabled /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource DisabledTextColor}" />
+    </Style>
     <Style Selector="Button.radial-action:focus-visible /template/ ContentPresenter#PART_ContentPresenter">
         <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
         <Setter Property="BorderThickness" Value="3" />
+    </Style>
+    <Style Selector="Button.radial-action.primary-radial">
+        <Setter Property="Background" Value="{DynamicResource AccentColor}" />
+        <Setter Property="Foreground" Value="{DynamicResource AccentTextColor}" />
+    </Style>
+    <Style Selector="Button.radial-action.primary-radial:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource AccentHoverColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentTextColor}" />
+    </Style>
+    <Style Selector="Button.radial-action.primary-radial:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource AccentPressedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentTextColor}" />
+    </Style>
+    <Style Selector="Button.radial-action.primary-radial:disabled /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource DisabledTextColor}" />
     </Style>
     <Style Selector="ComboBox.theme-picker">
         <Setter Property="MinWidth" Value="128" />

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -31,15 +31,16 @@
 
         <Grid x:Name="PlanningDrawer"
               Grid.Column="0"
+              ColumnDefinitions="*,44"
               Background="{DynamicResource SidebarBackgroundColor}">
             <Border x:Name="PlanningDrawerContent"
+                    Grid.Column="0"
                     Background="{DynamicResource SidebarBackgroundColor}"
                     BorderBrush="{DynamicResource BorderColor}"
                     BorderThickness="0,0,1,0"
-                    Padding="0,0,44,0"
                     IsVisible="False">
                 <ScrollViewer>
-                    <StackPanel Margin="14"
+                    <StackPanel Margin="16"
                                 Spacing="12">
                         <Grid ColumnDefinitions="*,Auto">
                             <StackPanel Spacing="2">
@@ -51,39 +52,53 @@
                             </StackPanel>
                             <TextBlock Grid.Column="1"
                                       Text="NAVTOOL"
-                                       FontSize="10"
-                                       FontWeight="Bold"
+                                      FontSize="9"
+                                      FontWeight="SemiBold"
                                       Foreground="{DynamicResource TextSecondaryColor}"
-                                      VerticalAlignment="Center" />
+                                      TextAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      Opacity="0.75" />
                         </Grid>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="9">
+                            <StackPanel Spacing="8">
                                 <TextBlock Classes="section-title"
                                           Text="1  ITINERARY" />
-                                <TextBox Text="{Binding Itinerary.RouteName}"
-                                        Watermark="Route name" />
-                                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="6">
-                                    <Button Content="New"
-                                            Command="{Binding Itinerary.NewCommand}" />
-                                    <ComboBox Grid.Column="1"
-                                              ItemsSource="{Binding Itinerary.SavedPlans}"
-                                              SelectedItem="{Binding Itinerary.SelectedSavedPlan}">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate x:DataType="core:RoutePlanSummary">
-                                                <TextBlock Text="{Binding Name}" />
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                    <Button Grid.Column="2"
-                                            Content="Open"
-                                            Command="{Binding Itinerary.OpenCommand}" />
-                                </Grid>
+                                <StackPanel Spacing="4">
+                                    <TextBlock Classes="field-label"
+                                              Text="Route name" />
+                                    <TextBox Text="{Binding Itinerary.RouteName}"
+                                            Watermark="Route name" />
+                                </StackPanel>
+                                <StackPanel Spacing="4">
+                                    <TextBlock Classes="field-label"
+                                              Text="Saved route" />
+                                    <Grid x:Name="SavedRouteActions"
+                                         Classes="compact-action-row"
+                                         ColumnDefinitions="*,Auto,Auto">
+                                        <ComboBox ItemsSource="{Binding Itinerary.SavedPlans}"
+                                                 SelectedItem="{Binding Itinerary.SelectedSavedPlan}">
+                                           <ComboBox.ItemTemplate>
+                                               <DataTemplate x:DataType="core:RoutePlanSummary">
+                                                   <TextBlock Text="{Binding Name}" />
+                                               </DataTemplate>
+                                           </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                        <Button Grid.Column="1"
+                                               Content="New"
+                                               Command="{Binding Itinerary.NewCommand}" />
+                                        <Button Grid.Column="2"
+                                               Content="Open"
+                                               Command="{Binding Itinerary.OpenCommand}" />
+                                    </Grid>
+                                </StackPanel>
                                 <Button Content="Refresh saved routes"
                                         Command="{Binding Itinerary.RefreshSavedPlansCommand}" />
-                                <Grid ColumnDefinitions="*,*" ColumnSpacing="6">
+                                <Grid x:Name="EndpointActions"
+                                      ColumnDefinitions="*,*"
+                                      ColumnSpacing="8">
                                     <ToggleButton x:Name="SetStartButton"
-                                                  Classes="map-tool"
+                                                 Classes="map-tool"
                                                   Content="Set start"
                                                   IsChecked="{Binding IsSettingStart, Mode=OneWay}"
                                                   Command="{Binding SetStartCommand}"
@@ -101,47 +116,70 @@
                                         <DataTemplate x:DataType="vm:WaypointEditorItemViewModel">
                                             <Border Classes="subtle" Margin="0,0,0,6">
                                                 <StackPanel Spacing="6">
-                                                    <Grid ColumnDefinitions="28,*,Auto" ColumnSpacing="6">
+                                                    <Grid ColumnDefinitions="28,*,Auto" ColumnSpacing="8">
                                                         <Border Width="24"
                                                                 Height="24"
                                                                 CornerRadius="12"
-                                                                Background="#263238">
+                                                                Background="{DynamicResource AccentColor}"
+                                                                VerticalAlignment="Center">
                                                             <TextBlock Text="{Binding PositionLabel}"
-                                                                       Foreground="White"
+                                                                       Foreground="{DynamicResource AccentTextColor}"
                                                                        FontWeight="Bold"
                                                                        HorizontalAlignment="Center"
                                                                        VerticalAlignment="Center" />
                                                         </Border>
-                                                        <StackPanel Grid.Column="1">
+                                                        <StackPanel Grid.Column="1"
+                                                                    VerticalAlignment="Center"
+                                                                    Spacing="2">
                                                             <TextBox Text="{Binding Name}" />
                                                             <TextBlock Text="{Binding CoordinateDisplay}"
                                                                        Classes="muted" />
                                                         </StackPanel>
                                                         <Button Grid.Column="2"
                                                                 Content="Map"
+                                                                VerticalAlignment="Center"
                                                                 Command="{Binding SetOnMapCommand}" />
                                                     </Grid>
                                                     <Grid IsVisible="{Binding IsIntermediate}"
-                                                          ColumnDefinitions="Auto,*,Auto,Auto"
-                                                          ColumnSpacing="5">
+                                                          ColumnDefinitions="Auto,*"
+                                                          RowDefinitions="Auto,Auto"
+                                                          ColumnSpacing="8"
+                                                          RowSpacing="4">
                                                         <CheckBox Content="Stopover"
+                                                                  VerticalAlignment="Center"
                                                                   IsChecked="{Binding HasStopover}" />
-                                                        <NumericUpDown Grid.Column="1"
-                                                                       Minimum="0.25"
-                                                                       Maximum="240"
-                                                                       Increment="0.25"
-                                                                       Value="{Binding StopoverHours}"
-                                                                       IsEnabled="{Binding HasStopover}" />
-                                                        <Button Grid.Column="2"
-                                                                Content="↑"
-                                                                Command="{Binding MoveUpCommand}" />
-                                                        <Button Grid.Column="3"
-                                                                Content="↓"
-                                                                Command="{Binding MoveDownCommand}" />
+                                                        <Grid Grid.Column="1"
+                                                              ColumnDefinitions="*,Auto"
+                                                              ColumnSpacing="4">
+                                                            <NumericUpDown MinWidth="88"
+                                                                           Minimum="0.25"
+                                                                           Maximum="240"
+                                                                           Increment="0.25"
+                                                                           Value="{Binding StopoverHours}"
+                                                                           IsEnabled="{Binding HasStopover}" />
+                                                            <TextBlock Grid.Column="1"
+                                                                       Classes="field-label"
+                                                                       Text="hours"
+                                                                       VerticalAlignment="Center" />
+                                                        </Grid>
+                                                        <StackPanel Grid.Row="1"
+                                                                    Grid.ColumnSpan="2"
+                                                                    Classes="compact-action-row"
+                                                                    HorizontalAlignment="Right">
+                                                            <Button Classes="compact-action"
+                                                                    Content="↑"
+                                                                    ToolTip.Tip="Move waypoint earlier"
+                                                                    Command="{Binding MoveUpCommand}" />
+                                                            <Button Classes="compact-action"
+                                                                    Content="↓"
+                                                                    ToolTip.Tip="Move waypoint later"
+                                                                    Command="{Binding MoveDownCommand}" />
+                                                            <Button Classes="compact-action"
+                                                                    Content="×"
+                                                                    ToolTip.Tip="Remove waypoint"
+                                                                    Command="{Binding RemoveCommand}" />
+                                                        </StackPanel>
                                                     </Grid>
-                                                    <Button IsVisible="{Binding IsIntermediate}"
-                                                            Content="Remove waypoint"
-                                                            Command="{Binding RemoveCommand}" />
                                                 </StackPanel>
                                             </Border>
                                         </DataTemplate>
@@ -149,15 +187,18 @@
                                 </ItemsControl>
                                 <Button Content="Add waypoint"
                                         Command="{Binding Itinerary.AddWaypointCommand}" />
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                                <Grid x:Name="SaveRouteActions"
+                                      Classes="compact-action-row"
+                                      ColumnDefinitions="*,Auto,Auto">
                                     <TextBox Text="{Binding Itinerary.SaveAsName}"
                                              Watermark="Save-as name" />
                                     <Button Grid.Column="1"
                                             Content="Save as"
                                             Command="{Binding Itinerary.SaveAsCommand}" />
+                                    <Button Grid.Column="2"
+                                            Content="Save"
+                                            Command="{Binding Itinerary.SaveCommand}" />
                                 </Grid>
-                                <Button Content="Save"
-                                        Command="{Binding Itinerary.SaveCommand}" />
                                 <TextBlock Text="{Binding Itinerary.StorageError}"
                                            Classes="error"
                                            TextWrapping="Wrap" />
@@ -172,21 +213,30 @@
                         </Border>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="9">
+                            <StackPanel Spacing="8">
                                 <TextBlock Classes="section-title"
                                            Text="DEPARTURE &amp; DURATION" />
-                                <Grid ColumnDefinitions="*,104"
-                                      ColumnSpacing="7">
-                                    <DatePicker SelectedDate="{Binding DepartureDate}" />
-                                    <TimePicker Grid.Column="1"
-                                                SelectedTime="{Binding DepartureTime}"
-                                                ClockIdentifier="24HourClock" />
+                                <Grid x:Name="DepartureFields"
+                                      ColumnDefinitions="*,104"
+                                      ColumnSpacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label"
+                                                   Text="Departure date" />
+                                        <DatePicker SelectedDate="{Binding DepartureDate}" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1"
+                                                Spacing="4">
+                                        <TextBlock Classes="field-label"
+                                                   Text="Departure time" />
+                                        <TimePicker SelectedTime="{Binding DepartureTime}"
+                                                    ClockIdentifier="24HourClock" />
+                                    </StackPanel>
                                 </Grid>
                                 <Grid ColumnDefinitions="*,*"
-                                      ColumnSpacing="7">
-                                    <StackPanel Spacing="3">
-                                        <TextBlock Text="Days"
-                                                   Classes="muted" />
+                                      ColumnSpacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Text="Passage days"
+                                                   Classes="field-label" />
                                         <NumericUpDown x:Name="PassageDaysInput"
                                                        Minimum="0"
                                                        Maximum="10"
@@ -195,9 +245,9 @@
                                                        Value="{Binding PassageDays}" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="1"
-                                                Spacing="3">
-                                        <TextBlock Text="Hours"
-                                                   Classes="muted" />
+                                                Spacing="4">
+                                        <TextBlock Text="Passage hours"
+                                                   Classes="field-label" />
                                         <NumericUpDown x:Name="PassageHoursInput"
                                                        Minimum="0"
                                                        Maximum="23"
@@ -221,7 +271,7 @@
                         </Border>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="9">
+                            <StackPanel Spacing="8">
                                 <TextBlock Classes="section-title"
                                            Text="FORECAST SOURCE" />
                                 <RadioButton x:Name="DownloadForecastSource"
@@ -344,6 +394,7 @@
             </Border>
 
             <ToggleButton x:Name="PlanningDrawerHandle"
+                          Grid.Column="1"
                           Classes="edge-handle"
                           Width="44"
                           MinHeight="44"
@@ -367,65 +418,82 @@
 
             <Border HorizontalAlignment="Left"
                     VerticalAlignment="Top"
-                    Margin="14"
+                    Margin="16"
                     Classes="map-overlay"
                     CornerRadius="6"
-                    Padding="10,7"
+                    Padding="9,6"
                     IsHitTestVisible="False">
-                <StackPanel Spacing="0">
+                <StackPanel Spacing="0"
+                            HorizontalAlignment="Center">
                     <TextBlock Text="NAVTOOL"
-                               FontSize="12"
-                               FontWeight="Bold"
-                               LetterSpacing="1.2" />
+                               FontSize="11"
+                               FontWeight="SemiBold"
+                               LetterSpacing="1"
+                               TextAlignment="Center" />
                     <TextBlock Text="WEATHER ROUTING"
                                Classes="muted"
-                               FontSize="8" />
+                               FontSize="8"
+                               TextAlignment="Center"
+                               Opacity="0.8" />
                 </StackPanel>
             </Border>
 
             <Border x:Name="InstrumentRail"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Top"
-                    Margin="14"
+                    Margin="16"
                     MaxWidth="720"
                     Classes="map-overlay"
                     CornerRadius="18"
                     Padding="14,7"
                     IsHitTestVisible="False">
                 <StackPanel Orientation="Horizontal"
-                            Spacing="11">
+                            Spacing="11"
+                            VerticalAlignment="Center">
                     <TextBlock Text="{Binding SelectedRouteTitle}"
                                FontWeight="SemiBold"
                                FontSize="11"
                                MaxWidth="150"
-                               TextTrimming="CharacterEllipsis" />
+                               TextTrimming="CharacterEllipsis"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center" />
                     <Border Width="1"
                             Background="{DynamicResource OverlayBorderColor}" />
                     <TextBlock Text="{Binding StatusMessage}"
                                Classes="muted"
                                FontSize="11"
                                MaxWidth="210"
-                               TextTrimming="CharacterEllipsis" />
+                               TextTrimming="CharacterEllipsis"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center" />
                     <Border Width="1"
                             Background="{DynamicResource OverlayBorderColor}" />
                     <TextBlock Text="{Binding ActiveWeatherDisplay}"
                                Classes="muted"
                                FontSize="11"
                                MaxWidth="140"
-                               TextTrimming="CharacterEllipsis" />
+                               TextTrimming="CharacterEllipsis"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center" />
                     <TextBlock Text="{Binding TimelineDisplay}"
                                Classes="muted"
                                FontSize="11"
                                MaxWidth="160"
-                               TextTrimming="CharacterEllipsis" />
+                               TextTrimming="CharacterEllipsis"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center" />
                     <TextBlock Text="!"
                                Foreground="{DynamicResource WarningTextColor}"
                                FontWeight="Bold"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center"
                                IsVisible="{Binding HasWarning}"
                                ToolTip.Tip="{Binding WarningMessage}" />
                     <TextBlock Text="!"
                                Foreground="{DynamicResource DangerTextColor}"
                                FontWeight="Bold"
+                               TextAlignment="Center"
+                               VerticalAlignment="Center"
                                IsVisible="{Binding HasError}"
                                ToolTip.Tip="{Binding ErrorMessage}" />
                 </StackPanel>
@@ -464,33 +532,53 @@
                         Click="OnSetStartRadialClicked"
                         ToolTip.Tip="Set passage start at this map point"
                         AutomationProperties.Name="Set start here"
-                        Content="Set start" />
+                        Content="Set start"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center" />
                 <Button x:Name="SetDestinationRadialButton"
                         Classes="radial-action"
                         Click="OnSetDestinationRadialClicked"
                         ToolTip.Tip="Set passage destination at this map point"
                         AutomationProperties.Name="Set destination here"
-                        Content="Set destination" />
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center">
+                    <TextBlock Text="Set&#x0a;destination"
+                               TextAlignment="Center"
+                               LineHeight="16" />
+                </Button>
+                <Button x:Name="CalculateRadialButton"
+                        Classes="radial-action primary-radial"
+                        Command="{Binding CalculateCommand}"
+                        Click="OnCalculateRadialClicked"
+                        ToolTip.Tip="Calculate route using the current passage plan"
+                        AutomationProperties.Name="Calculate route">
+                    <TextBlock Text="Calculate&#x0a;route"
+                               TextAlignment="Center"
+                               LineHeight="16" />
+                </Button>
                 <Button x:Name="InspectRadialButton"
                         Classes="radial-action"
                         Click="OnInspectRadialClicked"
                         ToolTip.Tip="Inspect the captured route point"
                         AutomationProperties.Name="Inspect route point"
-                        Content="Inspect" />
+                        Content="Inspect"
+                        HorizontalContentAlignment="Center"
+                        VerticalContentAlignment="Center" />
             </Canvas>
         </Grid>
 
         <Grid x:Name="RouteDrawer"
               Grid.Column="2"
+              ColumnDefinitions="44,*"
               Background="{DynamicResource SidebarBackgroundColor}">
             <Border x:Name="RouteDrawerContent"
+                    Grid.Column="1"
                     Background="{DynamicResource SidebarBackgroundColor}"
                     BorderBrush="{DynamicResource BorderColor}"
                     BorderThickness="1,0,0,0"
-                    Padding="44,0,0,0"
                     IsVisible="False">
                 <ScrollViewer>
-                    <StackPanel Margin="14"
+                    <StackPanel Margin="16"
                                 Spacing="12">
                         <StackPanel Spacing="2">
                             <TextBlock Text="Route &amp; weather"
@@ -501,7 +589,7 @@
                         </StackPanel>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="9">
+                            <StackPanel Spacing="8">
                                 <TextBlock Text="{Binding SelectedRouteTitle}"
                                            FontSize="16"
                                            FontWeight="SemiBold" />
@@ -516,24 +604,29 @@
                         </Border>
 
                         <Border Classes="card">
-                            <StackPanel Spacing="9">
+                            <StackPanel Spacing="8">
                                 <TextBlock Classes="section-title"
                                            Text="TIMELINE" />
-                                <Grid ColumnDefinitions="44,44,*,Auto"
-                                      ColumnSpacing="7">
+                                <Grid x:Name="TimelineControls"
+                                      ColumnDefinitions="44,44,*"
+                                      ColumnSpacing="8">
                                     <Button x:Name="PreviousTimelineButton"
                                             Content="◀"
                                             ToolTip.Tip="Previous point"
                                             AutomationProperties.Name="Previous timeline point"
                                             Command="{Binding PreviousTimelineCommand}"
-                                            MinWidth="44" />
+                                            MinWidth="44"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center" />
                                     <Button x:Name="NextTimelineButton"
                                             Grid.Column="1"
                                             Content="▶"
                                             ToolTip.Tip="Next point"
                                             AutomationProperties.Name="Next timeline point"
                                             Command="{Binding NextTimelineCommand}"
-                                            MinWidth="44" />
+                                            MinWidth="44"
+                                            HorizontalContentAlignment="Center"
+                                            VerticalContentAlignment="Center" />
                                     <Slider x:Name="TimelineSlider"
                                             Grid.Column="2"
                                             Minimum="0"
@@ -541,13 +634,12 @@
                                             Value="{Binding TimelinePosition}"
                                             IsEnabled="{Binding HasTimeline}"
                                             VerticalAlignment="Center" />
-                                    <TextBlock Grid.Column="3"
-                                               Text="{Binding TimelineDisplay}"
-                                               Classes="muted"
-                                               VerticalAlignment="Center"
-                                               MaxWidth="92"
-                                               TextWrapping="Wrap" />
                                 </Grid>
+                                <TextBlock Text="{Binding TimelineDisplay}"
+                                           Classes="muted"
+                                           HorizontalAlignment="Center"
+                                           TextAlignment="Center"
+                                           TextWrapping="Wrap" />
                             </StackPanel>
                         </Border>
 
@@ -555,7 +647,7 @@
                                   Header="Route legend"
                                   IsExpanded="False">
                             <Border Classes="card"
-                                    Margin="0,7,0,0">
+                                    Margin="0,8,0,0">
                                 <Grid ColumnDefinitions="24,*"
                                       RowDefinitions="Auto,Auto,Auto,Auto,Auto"
                                       RowSpacing="7">
@@ -566,7 +658,8 @@
                                             VerticalAlignment="Center" />
                                     <TextBlock Grid.Column="1"
                                                Text="NOAA GFS"
-                                               FontSize="11" />
+                                               FontSize="11"
+                                               VerticalAlignment="Center" />
                                     <Border Grid.Row="1"
                                             Width="20"
                                             Height="4"
@@ -576,7 +669,8 @@
                                     <TextBlock Grid.Row="1"
                                                Grid.Column="1"
                                                Text="ECMWF IFS"
-                                               FontSize="11" />
+                                               FontSize="11"
+                                               VerticalAlignment="Center" />
                                     <Border x:Name="HistoricalIsochroneLegendSwatch"
                                             Grid.Row="2"
                                             Width="20"
@@ -588,7 +682,8 @@
                                     <TextBlock Grid.Row="2"
                                                Grid.Column="1"
                                                Text="Historical isochrone fronts"
-                                               FontSize="11" />
+                                               FontSize="11"
+                                               VerticalAlignment="Center" />
                                     <Border x:Name="DestinationFrontLegendSwatch"
                                             Grid.Row="3"
                                             Width="20"
@@ -600,7 +695,8 @@
                                     <TextBlock Grid.Row="3"
                                                Grid.Column="1"
                                                Text="Latest isochrone front"
-                                               FontSize="11" />
+                                               FontSize="11"
+                                               VerticalAlignment="Center" />
                                     <Border Grid.Row="4"
                                             Width="20"
                                             Height="3"
@@ -611,7 +707,8 @@
                                     <TextBlock Grid.Row="4"
                                                Grid.Column="1"
                                                Text="Latest provisional route"
-                                               FontSize="11" />
+                                               FontSize="11"
+                                               VerticalAlignment="Center" />
                                 </Grid>
                             </Border>
                         </Expander>
@@ -620,7 +717,7 @@
                                   Header="Weather overlay"
                                   IsExpanded="False">
                             <Border Classes="card"
-                                    Margin="0,7,0,0">
+                                    Margin="0,8,0,0">
                                 <StackPanel Spacing="8">
                                     <StackPanel Spacing="5">
                                         <RadioButton Content="NOAA GFS"
@@ -634,18 +731,24 @@
                                     </StackPanel>
                                     <TextBlock Text="{Binding ActiveWeatherDisplay}"
                                                Classes="muted" />
-                                    <StackPanel Orientation="Horizontal"
-                                                Spacing="3">
-                                        <Border Width="19" Height="8" Background="#5BC0EB" />
-                                        <Border Width="19" Height="8" Background="#00A6A6" />
-                                        <Border Width="19" Height="8" Background="#7FB800" />
-                                        <Border Width="19" Height="8" Background="#F4D35E" />
-                                        <Border Width="19" Height="8" Background="#E4572E" />
-                                        <Border Width="19" Height="8" Background="#9B2C67" />
-                                    </StackPanel>
-                                    <TextBlock Text="0   5   10   15   25   35+ knots"
-                                               FontSize="10"
-                                               Foreground="{DynamicResource TextSecondaryColor}" />
+                                    <Grid x:Name="WeatherLegend"
+                                          ColumnDefinitions="*,*,*,*,*,*"
+                                          RowDefinitions="8,Auto"
+                                          ColumnSpacing="3"
+                                          RowSpacing="4">
+                                        <Border Background="#5BC0EB" />
+                                        <Border Grid.Column="1" Background="#00A6A6" />
+                                        <Border Grid.Column="2" Background="#7FB800" />
+                                        <Border Grid.Column="3" Background="#F4D35E" />
+                                        <Border Grid.Column="4" Background="#E4572E" />
+                                        <Border Grid.Column="5" Background="#9B2C67" />
+                                        <TextBlock Grid.Row="1" Text="0" FontSize="10" TextAlignment="Center" />
+                                        <TextBlock Grid.Row="1" Grid.Column="1" Text="5" FontSize="10" TextAlignment="Center" />
+                                        <TextBlock Grid.Row="1" Grid.Column="2" Text="10" FontSize="10" TextAlignment="Center" />
+                                        <TextBlock Grid.Row="1" Grid.Column="3" Text="15" FontSize="10" TextAlignment="Center" />
+                                        <TextBlock Grid.Row="1" Grid.Column="4" Text="25" FontSize="10" TextAlignment="Center" />
+                                        <TextBlock Grid.Row="1" Grid.Column="5" Text="35+ kt" FontSize="10" TextAlignment="Center" />
+                                    </Grid>
                                     <TextBlock Text="{Binding WeatherLayerError}"
                                                TextWrapping="Wrap"
                                                Classes="error"
@@ -672,6 +775,7 @@
             </Border>
 
             <ToggleButton x:Name="RouteDrawerHandle"
+                          Grid.Column="0"
                           Classes="edge-handle"
                           Width="44"
                           MinHeight="44"

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -325,10 +325,18 @@ public partial class MainWindow : Window
             new ScreenSize(RadialActionWidth, RadialActionHeight),
             RadialRadius,
             RadialSafeMargin);
-        PositionRadialAction(_setStartRadialButton, placement.Actions[0].Bounds);
-        PositionRadialAction(_setDestinationRadialButton, placement.Actions[1].Bounds);
-        PositionRadialAction(_calculateRadialButton, placement.Actions[2].Bounds);
-        PositionRadialAction(_inspectRadialButton, placement.Actions[3].Bounds);
+        PositionRadialAction(
+            _setStartRadialButton,
+            GetActionBounds(placement, RadialMenuAction.SetStart));
+        PositionRadialAction(
+            _setDestinationRadialButton,
+            GetActionBounds(placement, RadialMenuAction.SetDestination));
+        PositionRadialAction(
+            _calculateRadialButton,
+            GetActionBounds(placement, RadialMenuAction.CalculateRoute));
+        PositionRadialAction(
+            _inspectRadialButton,
+            GetActionBounds(placement, RadialMenuAction.Inspect));
         ApplyConnector(placement);
         _radialMenuLayer.IsVisible = true;
         _setStartRadialButton.Focus();
@@ -361,6 +369,11 @@ public partial class MainWindow : Window
         Canvas.SetLeft(control, bounds.X);
         Canvas.SetTop(control, bounds.Y);
     }
+
+    private static ScreenRect GetActionBounds(
+        RadialMenuPlacementResult placement,
+        RadialMenuAction action) =>
+        placement.Actions.Single(candidate => candidate.Action == action).Bounds;
 
     private void OnSetStartRadialClicked(object? sender, RoutedEventArgs e)
     {

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -27,9 +27,9 @@ public partial class MainWindow : Window
         Route
     }
 
-    internal const double DrawerBreakpoint = 1220;
+    internal const double DrawerBreakpoint = 1280;
     internal const double ClosedDrawerWidth = 44;
-    internal const double PlanningDrawerWidth = 320;
+    internal const double PlanningDrawerWidth = 380;
     internal const double RouteDrawerWidth = 340;
 
     private const double RadialActionWidth = 112;
@@ -55,6 +55,7 @@ public partial class MainWindow : Window
     private Canvas? _radialMenuLayer;
     private Button? _setStartRadialButton;
     private Button? _setDestinationRadialButton;
+    private Button? _calculateRadialButton;
     private Button? _inspectRadialButton;
     private Line? _radialConnector;
     private Ellipse? _radialAnchor;
@@ -116,6 +117,7 @@ public partial class MainWindow : Window
         _radialMenuLayer = this.FindControl<Canvas>("RadialMenuLayer")!;
         _setStartRadialButton = this.FindControl<Button>("SetStartRadialButton")!;
         _setDestinationRadialButton = this.FindControl<Button>("SetDestinationRadialButton")!;
+        _calculateRadialButton = this.FindControl<Button>("CalculateRadialButton")!;
         _inspectRadialButton = this.FindControl<Button>("InspectRadialButton")!;
         _radialConnector = this.FindControl<Line>("RadialConnector")!;
         _radialAnchor = this.FindControl<Ellipse>("RadialAnchor")!;
@@ -242,6 +244,7 @@ public partial class MainWindow : Window
         {
             return button == _setStartRadialButton ||
                    button == _setDestinationRadialButton ||
+                   button == _calculateRadialButton ||
                    button == _inspectRadialButton;
         }
 
@@ -249,6 +252,7 @@ public partial class MainWindow : Window
                visual.GetVisualAncestors().OfType<Button>().Any(button =>
                    button == _setStartRadialButton ||
                    button == _setDestinationRadialButton ||
+                   button == _calculateRadialButton ||
                    button == _inspectRadialButton);
     }
 
@@ -299,6 +303,7 @@ public partial class MainWindow : Window
             _radialMenuLayer is null ||
             _setStartRadialButton is null ||
             _setDestinationRadialButton is null ||
+            _calculateRadialButton is null ||
             _inspectRadialButton is null ||
             _radialConnector is null ||
             _radialAnchor is null ||
@@ -322,7 +327,8 @@ public partial class MainWindow : Window
             RadialSafeMargin);
         PositionRadialAction(_setStartRadialButton, placement.Actions[0].Bounds);
         PositionRadialAction(_setDestinationRadialButton, placement.Actions[1].Bounds);
-        PositionRadialAction(_inspectRadialButton, placement.Actions[2].Bounds);
+        PositionRadialAction(_calculateRadialButton, placement.Actions[2].Bounds);
+        PositionRadialAction(_inspectRadialButton, placement.Actions[3].Bounds);
         ApplyConnector(placement);
         _radialMenuLayer.IsVisible = true;
         _setStartRadialButton.Focus();
@@ -336,7 +342,9 @@ public partial class MainWindow : Window
         }
 
         _radialConnector.IsVisible = placement.Connector is not null;
-        _radialAnchor.IsVisible = placement.Connector is not null;
+        _radialAnchor.IsVisible = true;
+        Canvas.SetLeft(_radialAnchor, placement.Anchor.X - (_radialAnchor.Width / 2));
+        Canvas.SetTop(_radialAnchor, placement.Anchor.Y - (_radialAnchor.Height / 2));
         if (placement.Connector is not { } connector)
         {
             return;
@@ -344,8 +352,6 @@ public partial class MainWindow : Window
 
         _radialConnector.StartPoint = new Point(connector.Start.X, connector.Start.Y);
         _radialConnector.EndPoint = new Point(connector.End.X, connector.End.Y);
-        Canvas.SetLeft(_radialAnchor, connector.Start.X - (_radialAnchor.Width / 2));
-        Canvas.SetTop(_radialAnchor, connector.Start.Y - (_radialAnchor.Height / 2));
     }
 
     private static void PositionRadialAction(Control control, ScreenRect bounds)
@@ -389,6 +395,11 @@ public partial class MainWindow : Window
             viewModel.SelectRoutePoint(selection);
         }
 
+        CloseRadialMenu();
+    }
+
+    private void OnCalculateRadialClicked(object? sender, RoutedEventArgs e)
+    {
         CloseRadialMenu();
     }
 

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
+using Avalonia.Layout;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Mapsui.Extensions;
@@ -39,6 +40,7 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(window.FindControl<ToggleButton>("SetStartButton"));
             Assert.NotNull(window.FindControl<ToggleButton>("SetDestinationButton"));
             Assert.NotNull(window.FindControl<Button>("CalculateRoutesButton"));
+            Assert.NotNull(window.FindControl<Button>("CalculateRadialButton"));
             Assert.NotNull(window.FindControl<NumericUpDown>("PassageDaysInput"));
             Assert.NotNull(window.FindControl<NumericUpDown>("PassageHoursInput"));
             Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
@@ -54,8 +56,9 @@ public sealed class MainWindowLayoutTests
     [Fact]
     public void SizingPolicyPreservesTheMapFloorAndUsesTheRequestedBreakpoint()
     {
+        Assert.False(MainWindow.AllowsBothDrawers(1279.99));
         Assert.False(MainWindow.AllowsBothDrawers(1219.99));
-        Assert.True(MainWindow.AllowsBothDrawers(1220));
+        Assert.True(MainWindow.AllowsBothDrawers(1280));
         Assert.Equal(
             560,
             MainWindow.DrawerBreakpoint -
@@ -94,7 +97,7 @@ public sealed class MainWindowLayoutTests
     public void WideWindowsCanKeepBothDrawersOpen()
     {
         var window = CreateWindow();
-        window.Width = 1220;
+        window.Width = 1280;
 
         try
         {
@@ -118,7 +121,7 @@ public sealed class MainWindowLayoutTests
     public void CrossingBelowTheBreakpointKeepsTheMostRecentlyOpenedDrawer()
     {
         var window = CreateWindow();
-        window.Width = 1220;
+        window.Width = 1280;
 
         try
         {
@@ -126,7 +129,7 @@ public sealed class MainWindowLayoutTests
             window.SetPlanningDrawerOpen(true);
             window.SetRouteDrawerOpen(true);
 
-            window.Width = 1219;
+            window.Width = 1279;
             Dispatcher.UIThread.RunJobs();
 
             Assert.False(window.IsPlanningDrawerOpen);
@@ -194,6 +197,7 @@ public sealed class MainWindowLayoutTests
             {
                 Assert.IsType<Button>(window.FindControl<Button>("SetStartRadialButton")),
                 Assert.IsType<Button>(window.FindControl<Button>("SetDestinationRadialButton")),
+                Assert.IsType<Button>(window.FindControl<Button>("CalculateRadialButton")),
                 Assert.IsType<Button>(window.FindControl<Button>("InspectRadialButton"))
             };
             Assert.Equal(buttons, layer.Children.OfType<Button>());
@@ -202,8 +206,32 @@ public sealed class MainWindowLayoutTests
                 Assert.True(button.Width >= 44);
                 Assert.True(button.Height >= 44);
                 Assert.NotNull(ToolTip.GetTip(button));
+                Assert.Equal(HorizontalAlignment.Center, button.HorizontalContentAlignment);
+                Assert.Equal(VerticalAlignment.Center, button.VerticalContentAlignment);
             });
-            Assert.False(buttons[2].IsEnabled);
+            var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
+            Assert.Same(viewModel.CalculateCommand, buttons[2].Command);
+            Assert.True(buttons[2].IsEffectivelyEnabled);
+            Assert.False(buttons[3].IsEnabled);
+            viewModel.ForecastInputMode = ForecastInputMode.LocalFile;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(buttons[2].IsEffectivelyEnabled);
+            Assert.Equal(
+                HorizontalAlignment.Center,
+                Assert.IsType<ToggleButton>(
+                    window.FindControl<ToggleButton>("PlanningDrawerHandle"))
+                    .HorizontalContentAlignment);
+            Assert.Equal(
+                VerticalAlignment.Center,
+                Assert.IsType<ToggleButton>(
+                    window.FindControl<ToggleButton>("RouteDrawerHandle"))
+                    .VerticalContentAlignment);
+            var anchor = Assert.IsType<Avalonia.Controls.Shapes.Ellipse>(
+                window.FindControl<Avalonia.Controls.Shapes.Ellipse>("RadialAnchor"));
+            var connector = Assert.IsType<Avalonia.Controls.Shapes.Line>(
+                window.FindControl<Avalonia.Controls.Shapes.Line>("RadialConnector"));
+            Assert.True(anchor.IsVisible);
+            Assert.False(connector.IsVisible);
         }
         finally
         {
@@ -341,6 +369,91 @@ public sealed class MainWindowLayoutTests
         var window = CreateWindow();
         Assert.Equal(1040, window.MinWidth);
         Assert.Equal(680, window.MinHeight);
+    }
+
+    [AvaloniaFact]
+    public void PlanningDrawerUsesContentAndHandleColumnsWithoutDuplicateGutter()
+    {
+        var window = CreateWindow();
+        window.Width = 1040;
+        window.Height = 680;
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            Assert.IsType<MainViewModel>(window.DataContext)
+                .Itinerary.AddWaypointCommand.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            var shell = Assert.IsType<Grid>(window.FindControl<Grid>("ShellGrid"));
+            var drawer = Assert.IsType<Grid>(window.FindControl<Grid>("PlanningDrawer"));
+            var content = Assert.IsType<Border>(
+                window.FindControl<Border>("PlanningDrawerContent"));
+            var handle = Assert.IsType<ToggleButton>(
+                window.FindControl<ToggleButton>("PlanningDrawerHandle"));
+            var endpoints = Assert.IsType<Grid>(
+                window.FindControl<Grid>("EndpointActions"));
+
+            Assert.Equal(380, shell.ColumnDefinitions[0].Width.Value);
+            Assert.Equal(2, drawer.ColumnDefinitions.Count);
+            Assert.Equal(new GridLength(1, GridUnitType.Star), drawer.ColumnDefinitions[0].Width);
+            Assert.Equal(44, drawer.ColumnDefinitions[1].Width.Value);
+            Assert.Equal(0, Grid.GetColumn(content));
+            Assert.Equal(1, Grid.GetColumn(handle));
+            Assert.Equal(default, content.Padding);
+            Assert.Equal(2, endpoints.ColumnDefinitions.Count);
+            Assert.Equal(
+                endpoints.ColumnDefinitions[0].Width,
+                endpoints.ColumnDefinitions[1].Width);
+            Assert.True(shell.ColumnDefinitions[1].ActualWidth >= 560);
+            var stopoverHours = content
+                .GetVisualDescendants()
+                .OfType<NumericUpDown>()
+                .Single(input => input.Maximum == 240 && input.IsEffectivelyVisible);
+            Assert.True(stopoverHours.Bounds.Width >= 88);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void FieldLayoutsExposeLabelsAndAlignedActionRows()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+
+            var departure = Assert.IsType<Grid>(
+                window.FindControl<Grid>("DepartureFields"));
+            var saved = Assert.IsType<Grid>(
+                window.FindControl<Grid>("SavedRouteActions"));
+            var save = Assert.IsType<Grid>(
+                window.FindControl<Grid>("SaveRouteActions"));
+
+            Assert.Equal(2, departure.Children.OfType<StackPanel>().Count());
+            Assert.All(
+                departure.Children.OfType<StackPanel>(),
+                field => Assert.Contains(
+                    field.Children.OfType<TextBlock>(),
+                    label => label.Classes.Contains("field-label")));
+            Assert.Equal(8, departure.ColumnSpacing);
+            Assert.Equal(3, saved.ColumnDefinitions.Count);
+            Assert.Equal(8, saved.ColumnSpacing);
+            Assert.Contains("compact-action-row", saved.Classes);
+            Assert.Equal(3, save.ColumnDefinitions.Count);
+            Assert.Equal(8, save.ColumnSpacing);
+            Assert.Contains("compact-action-row", save.Classes);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static MainWindow CreateWindow() =>

--- a/tests/Navtool.App.Tests/MapInputRoutingTests.cs
+++ b/tests/Navtool.App.Tests/MapInputRoutingTests.cs
@@ -101,4 +101,48 @@ public sealed class MapInputRoutingTests
             window.Close();
         }
     }
+
+    [AvaloniaFact]
+    public void CalculateRadialActionExecutesBoundCommandClosesAndDoesNotLeakToMap()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            TimeProvider.System,
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+        var window = new MainWindow { DataContext = viewModel };
+        var mapPresses = 0;
+
+        try
+        {
+            window.Show();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            map.AddHandler(
+                InputElement.PointerPressedEvent,
+                (_, _) => mapPresses++,
+                RoutingStrategies.Bubble);
+            var mapPoint = map.TranslatePoint(map.Bounds.Center, window);
+            Assert.NotNull(mapPoint);
+            window.MouseDown(mapPoint.Value, MouseButton.Right, RawInputModifiers.None);
+            window.MouseUp(mapPoint.Value, MouseButton.Right, RawInputModifiers.None);
+            var calculate = Assert.IsType<Button>(
+                window.FindControl<Button>("CalculateRadialButton"));
+            Assert.Same(viewModel.CalculateCommand, calculate.Command);
+            calculate.Focus();
+            window.KeyPress(
+                Key.Enter,
+                RawInputModifiers.None,
+                PhysicalKey.Enter,
+                "\r");
+
+            Assert.False(window.IsRadialMenuOpen);
+            Assert.Equal("Routing services are unavailable in the designer.", viewModel.ErrorMessage);
+            Assert.Equal(0, mapPresses);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
 }

--- a/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
+++ b/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
@@ -22,18 +22,28 @@ public sealed class RadialMenuPlacementTests
             [
                 RadialMenuAction.SetStart,
                 RadialMenuAction.SetDestination,
+                RadialMenuAction.CalculateRoute,
                 RadialMenuAction.Inspect
             ],
             result.Actions.Select(action => action.Action));
         Assert.True(result.Actions[0].Center.Y < result.Center.Y);
         Assert.True(result.Actions[1].Center.X > result.Center.X);
-        Assert.True(result.Actions[1].Center.Y > result.Center.Y);
-        Assert.True(result.Actions[2].Center.X < result.Center.X);
+        Assert.Equal(result.Center.Y, result.Actions[1].Center.Y, 6);
         Assert.True(result.Actions[2].Center.Y > result.Center.Y);
+        Assert.True(result.Actions[3].Center.X < result.Center.X);
+        Assert.Equal(result.Center.Y, result.Actions[3].Center.Y, 6);
     }
 
-    [Fact]
-    public void ClampsCenterSoEveryActionStaysInsideSafeBounds()
+    [Theory]
+    [InlineData(100, 50)]
+    [InlineData(300, 50)]
+    [InlineData(500, 50)]
+    [InlineData(100, 200)]
+    [InlineData(500, 200)]
+    [InlineData(100, 350)]
+    [InlineData(300, 350)]
+    [InlineData(500, 350)]
+    public void ClampsEveryEdgeAndCornerInsideSafeBounds(double anchorX, double anchorY)
     {
         var visibleBounds = new ScreenRect(100, 50, 400, 300);
         const double margin = 16;
@@ -42,7 +52,7 @@ public sealed class RadialMenuPlacementTests
             visibleBounds.Y + margin,
             visibleBounds.Width - (margin * 2),
             visibleBounds.Height - (margin * 2));
-        var anchor = new ScreenPoint(490, 55);
+        var anchor = new ScreenPoint(anchorX, anchorY);
 
         var result = RadialMenuPlacement.Calculate(
             visibleBounds,
@@ -59,10 +69,10 @@ public sealed class RadialMenuPlacementTests
     }
 
     [Fact]
-    public void UsesCompactLinearFallbackWhenRadialGeometryCannotFit()
+    public void UsesFourActionHorizontalFallbackWhenRadialGeometryCannotFit()
     {
-        var visibleBounds = new ScreenRect(0, 0, 280, 90);
-        var safeBounds = new ScreenRect(8, 8, 264, 74);
+        var visibleBounds = new ScreenRect(0, 0, 380, 90);
+        var safeBounds = new ScreenRect(8, 8, 364, 74);
 
         var result = RadialMenuPlacement.Calculate(
             visibleBounds,
@@ -76,8 +86,33 @@ public sealed class RadialMenuPlacementTests
         Assert.All(result.Actions, action => Assert.True(safeBounds.Contains(action.Bounds)));
         Assert.True(result.Actions[0].Center.X < result.Actions[1].Center.X);
         Assert.True(result.Actions[1].Center.X < result.Actions[2].Center.X);
+        Assert.True(result.Actions[2].Center.X < result.Actions[3].Center.X);
         Assert.All(
             result.Actions,
             action => Assert.Equal(result.Center.Y, action.Center.Y, 6));
+    }
+
+    [Fact]
+    public void UsesFourActionVerticalFallbackWhenHorizontalCannotFit()
+    {
+        var visibleBounds = new ScreenRect(0, 0, 110, 260);
+        var safeBounds = new ScreenRect(8, 8, 94, 244);
+
+        var result = RadialMenuPlacement.Calculate(
+            visibleBounds,
+            new ScreenPoint(55, 20),
+            new ScreenSize(80, 40),
+            radius: 70,
+            safeMargin: 8);
+
+        Assert.Equal(RadialMenuLayout.Linear, result.Layout);
+        Assert.True(result.NeedsConnector);
+        Assert.All(result.Actions, action => Assert.True(safeBounds.Contains(action.Bounds)));
+        Assert.True(result.Actions[0].Center.Y < result.Actions[1].Center.Y);
+        Assert.True(result.Actions[1].Center.Y < result.Actions[2].Center.Y);
+        Assert.True(result.Actions[2].Center.Y < result.Actions[3].Center.Y);
+        Assert.All(
+            result.Actions,
+            action => Assert.Equal(result.Center.X, action.Center.X, 6));
     }
 }


### PR DESCRIPTION
## Summary
- add a fourth, primary `Calculate route` action to the on-map radial palette, bound directly to `CalculateCommand`, with cardinal placement, marker/connector handling, and preserved input/focus behavior
- expand and re-grid the planning drawer, standardize shared spacing/labels/action rows, and align itinerary, departure, instrument, timeline, and legend controls
- extend placement, layout, theme, and input-routing coverage for four actions, edge/corner clamping, linear fallbacks, responsive drawer structure, command enablement, and action consumption

## Tests
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~RadialMenuPlacementTests|FullyQualifiedName~MainWindowLayoutTests|FullyQualifiedName~MapInputRoutingTests"` (29 passed)
- `dotnet test Navtool.sln --configuration Release --no-restore` (219 passed)

## Visual smoke
- launched only through `./scripts/run.sh`; native bridge built and its test passed
- the app could not create Avalonia's render timer in this headless macOS session (`Avalonia.Native` error `-6661`), so Light/Dark/Kind of Blue observations at 1280x800 and 1040x680 could not be captured reliably; headless layout/theme tests cover the requested structure and states without claiming manual visual verification