### PR TITLE
Add rolling route resume workflow

### DIFF
--- a/src/Navtool.App/Models/MapInteractionState.cs
+++ b/src/Navtool.App/Models/MapInteractionState.cs
@@ -7,7 +7,8 @@ public enum MapInteractionMode
     Browse,
     SetStart,
     SetDestination,
-    SetWaypoint
+    SetWaypoint,
+    SetCurrentPosition
 }
 
 public sealed class MapInteractionState
@@ -46,6 +47,9 @@ public sealed class MapInteractionState
                 SetDestination(coordinate);
                 break;
             case MapInteractionMode.SetWaypoint:
+                Mode = MapInteractionMode.Browse;
+                break;
+            case MapInteractionMode.SetCurrentPosition:
                 Mode = MapInteractionMode.Browse;
                 break;
             default:

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -57,6 +57,7 @@ public sealed class RouteMapLayers
         }
     };
     private readonly MemoryLayer _waypointMarkers = new("Waypoint markers") { Style = null };
+    private readonly MemoryLayer _currentPositionMarkers = new("Current position") { Style = null };
 
     public RouteMapLayers(Map map)
     {
@@ -74,6 +75,7 @@ public sealed class RouteMapLayers
         map.Layers.Add(_noaaRoutes);
         map.Layers.Add(_ecmwfRoutes);
         map.Layers.Add(_waypointMarkers);
+        map.Layers.Add(_currentPositionMarkers);
     }
 
     public Map Map { get; }
@@ -85,6 +87,13 @@ public sealed class RouteMapLayers
     public int WaypointMarkerCount => _waypointMarkers.Features.Count();
 
     public int WaypointGuideSegmentCount => _waypointGuide.Features.Count();
+
+    /// <summary>
+    /// Number of rendered current-position markers (0 or 1). Distinct from
+    /// <see cref="WaypointMarkerCount"/> because a current position is a mid-itinerary session
+    /// marker, never a permanent waypoint.
+    /// </summary>
+    public int CurrentPositionMarkerCount => _currentPositionMarkers.Features.Count();
 
     public int GetIsochroneFrontCount(ForecastModel model) =>
         GetHistoricalFrontFeatures(model).Count;
@@ -118,6 +127,20 @@ public sealed class RouteMapLayers
         _waypointGuide.Features = CreateWaypointGuideFeatures(ordered);
         _waypointMarkers.FeaturesWereModified();
         _waypointGuide.FeaturesWereModified();
+        Map.Refresh(ChangeType.Discrete);
+    }
+
+    /// <summary>
+    /// Renders (or clears, when <paramref name="coordinate"/> is null) the distinct
+    /// current-position marker used for rolling-route resume. This is a session marker
+    /// representing where the vessel actually is now, not an itinerary waypoint.
+    /// </summary>
+    public void SetCurrentPosition(CoreCoordinate? coordinate)
+    {
+        _currentPositionMarkers.Features = coordinate is null
+            ? Array.Empty<IFeature>()
+            : [CreateCurrentPositionMarker(coordinate.Value)];
+        _currentPositionMarkers.FeaturesWereModified();
         Map.Refresh(ChangeType.Discrete);
     }
 
@@ -242,6 +265,23 @@ public sealed class RouteMapLayers
             BorderColor = MapsuiColor.White,
             BorderThickness = 2,
             CornerRounding = 14
+        });
+        return feature;
+    }
+
+    private static IFeature CreateCurrentPositionMarker(CoreCoordinate coordinate)
+    {
+        var point = MapProjection.ToMapPoint(coordinate);
+        var feature = new GeometryFeature(new Point(point.X, point.Y));
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = "\u2693",
+            Font = new Font { Size = 16, Bold = true },
+            ForeColor = MapsuiColor.White,
+            BackColor = new Brush(MapsuiColor.FromString("#00695C")),
+            BorderColor = MapsuiColor.White,
+            BorderThickness = 2,
+            CornerRounding = 20
         });
         return feature;
     }

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Navtool.App.Services;
 using Navtool.Core;
 
 namespace Navtool.App.ViewModels;
@@ -104,6 +105,67 @@ public sealed partial class WaypointEditorItemViewModel : ViewModelBase
     }
 }
 
+/// <summary>
+/// Displays a single itinerary leg's sailed/active state and exposes the mark/unmark-sailed and
+/// explicit-active-leg commands. Sailed is real-world itinerary progress: it is model-independent
+/// and never validates or depends on forecast data.
+/// </summary>
+public sealed partial class RouteLegEditorItemViewModel : ViewModelBase
+{
+    private readonly ItineraryEditorViewModel _owner;
+
+    internal RouteLegEditorItemViewModel(
+        ItineraryEditorViewModel owner,
+        RouteLegId id,
+        int index,
+        string fromName,
+        string toName)
+    {
+        _owner = owner;
+        Id = id;
+        Index = index;
+        FromName = fromName;
+        ToName = toName;
+    }
+
+    public RouteLegId Id { get; }
+
+    public int Index { get; }
+
+    public string FromName { get; }
+
+    public string ToName { get; }
+
+    public string Label => $"Leg {Index + 1}: {FromName} \u2192 {ToName}";
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(MarkSailedCommand))]
+    [NotifyCanExecuteChangedFor(nameof(UnmarkSailedCommand))]
+    [NotifyCanExecuteChangedFor(nameof(MakeActiveCommand))]
+    private bool _isSailed;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(MakeActiveCommand))]
+    private bool _isActive;
+
+    public string StatusLabel => IsSailed ? "Sailed" : IsActive ? "Active" : "Upcoming";
+
+    [RelayCommand(CanExecute = nameof(CanMarkSailed))]
+    private void MarkSailed() => _owner.MarkLegSailed(Id);
+
+    private bool CanMarkSailed() => !IsSailed;
+
+    [RelayCommand(CanExecute = nameof(CanUnmarkSailed))]
+    private void UnmarkSailed() => _owner.UnmarkLegSailed(Id);
+
+    private bool CanUnmarkSailed() => IsSailed;
+
+    [RelayCommand(CanExecute = nameof(CanMakeActive))]
+    private void MakeActive() => _owner.SetActiveLeg(Id);
+
+    private bool CanMakeActive() => !IsSailed && !IsActive;
+}
+
 public sealed partial class ItineraryEditorViewModel : ViewModelBase
 {
     private readonly IRoutePlanRepository? _repository;
@@ -144,6 +206,15 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
     [ObservableProperty]
     private WaypointEditorItemViewModel? _activeWaypoint;
 
+    [ObservableProperty]
+    private bool _isAwaitingCurrentPositionPlacement;
+
+    [ObservableProperty]
+    private DateTimeOffset? _currentPositionDepartureDate = DateTimeOffset.Now.Date;
+
+    [ObservableProperty]
+    private TimeSpan? _currentPositionDepartureTimeOfDay = DateTimeOffset.Now.TimeOfDay;
+
     public RoutePlanId PlanId { get; private set; }
 
     public long CalculationRevision { get; private set; }
@@ -154,11 +225,32 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
 
     public event EventHandler<WaypointEditorItemViewModel>? MapPlacementStarted;
 
+    public event EventHandler? CurrentPositionPlacementStarted;
+
+    public ObservableCollection<RouteLegEditorItemViewModel> Legs { get; } = [];
+
     public Coordinate? Start => Waypoints.FirstOrDefault()?.Coordinate;
 
     public Coordinate? Finish => Waypoints.LastOrDefault()?.Coordinate;
 
     public bool HasPendingWaypoint => Waypoints.Any(waypoint => waypoint.Coordinate is null);
+
+    /// <summary>
+    /// The user-placed current position, distinct from any itinerary waypoint. Null when the
+    /// itinerary should be routed from its start (no session in progress).
+    /// </summary>
+    public Coordinate? CurrentPositionCoordinate => _plan?.CurrentPosition?.Coordinate;
+
+    public DateTimeOffset? CurrentPositionDepartureTimeUtc => _plan?.CurrentPosition?.DepartureTime;
+
+    public bool HasCurrentPosition => _plan?.CurrentPosition is not null;
+
+    public string CurrentPositionDisplay => CurrentPositionCoordinate is not { } coordinate
+        ? "Not set"
+        : $"{Math.Abs(coordinate.Latitude):0.000}\u00b0 " +
+          $"{(coordinate.Latitude >= 0 ? "N" : "S")}, " +
+          $"{Math.Abs(coordinate.Longitude):0.000}\u00b0 " +
+          $"{(coordinate.Longitude >= 0 ? "E" : "W")}";
 
     public void SetEndpoints(Coordinate start, Coordinate finish)
     {
@@ -174,6 +266,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
             throw new ArgumentException("The waypoint does not belong to this itinerary.", nameof(waypoint));
         }
 
+        IsAwaitingCurrentPositionPlacement = false;
         ActiveWaypoint = waypoint;
         MapPlacementStarted?.Invoke(this, waypoint);
     }
@@ -191,6 +284,122 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
     }
 
     public void CancelMapPlacement() => ActiveWaypoint = null;
+
+    /// <summary>
+    /// Arms the distinct current-position map placement mode. This is never confused with
+    /// itinerary waypoint placement: it records a session-scoped "where the vessel is now"
+    /// marker, not a permanent route point.
+    /// </summary>
+    public void BeginCurrentPositionPlacement()
+    {
+        ActiveWaypoint = null;
+        IsAwaitingCurrentPositionPlacement = true;
+        CurrentPositionPlacementStarted?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void CancelCurrentPositionPlacement() => IsAwaitingCurrentPositionPlacement = false;
+
+    /// <summary>
+    /// Places the current position at the given coordinate with an explicit departure time (UTC).
+    /// Never derived from wall-clock or GPS; always the user-supplied session values.
+    /// </summary>
+    public bool PlaceCurrentPosition(Coordinate coordinate, DateTimeOffset departureTimeUtc, out string? error)
+    {
+        IsAwaitingCurrentPositionPlacement = false;
+        var applied = TryUpdatePlanEnsuringBuilt(
+            plan => plan.SetCurrentPosition(coordinate, departureTimeUtc),
+            out error);
+        if (applied)
+        {
+            NotifyCurrentPositionChanged();
+            CalculationRevision++;
+            MarkChanged();
+        }
+
+        return applied;
+    }
+
+    /// <summary>
+    /// Places the current position using the local <see cref="CurrentPositionDepartureDate"/>/
+    /// <see cref="CurrentPositionDepartureTimeOfDay"/> fields, converted to UTC via
+    /// <paramref name="localTimeZone"/>. This is the explicit, user-supplied departure time for
+    /// the current position; it is never derived from wall clock or GPS.
+    /// </summary>
+    public bool TryPlaceCurrentPosition(Coordinate coordinate, TimeZoneInfo localTimeZone, out string? error)
+    {
+        if (!LocalDepartureConverter.TryConvertToUtc(
+                CurrentPositionDepartureDate,
+                CurrentPositionDepartureTimeOfDay,
+                localTimeZone,
+                out var departureUtc,
+                out error))
+        {
+            IsAwaitingCurrentPositionPlacement = false;
+            return false;
+        }
+
+        return PlaceCurrentPosition(coordinate, departureUtc, out error);
+    }
+
+    public void ClearCurrentPosition()
+    {
+        if (_plan?.CurrentPosition is null)
+        {
+            return;
+        }
+
+        if (TryUpdatePlan(plan => plan.ClearCurrentPosition()))
+        {
+            NotifyCurrentPositionChanged();
+            CalculationRevision++;
+            MarkChanged();
+        }
+    }
+
+    internal void MarkLegSailed(RouteLegId legId)
+    {
+        if (TryUpdatePlanEnsuringBuilt(plan => plan.MarkSailed(legId), out _))
+        {
+            CalculationRevision++;
+            MarkChanged();
+        }
+    }
+
+    internal void UnmarkLegSailed(RouteLegId legId)
+    {
+        if (TryUpdatePlanEnsuringBuilt(plan => plan.UnmarkSailed(legId), out _))
+        {
+            CalculationRevision++;
+            MarkChanged();
+        }
+    }
+
+    /// <summary>
+    /// Explicitly selects the active leg to resume from, overriding the default (first
+    /// unfinished/unsailed leg). The leg must exist and must not already be sailed.
+    /// </summary>
+    internal void SetActiveLeg(RouteLegId legId)
+    {
+        if (TryUpdatePlanEnsuringBuilt(plan => plan.SetActiveLeg(legId), out _))
+        {
+            CalculationRevision++;
+            MarkChanged();
+        }
+    }
+
+    internal void ClearActiveLeg()
+    {
+        if (_plan?.ActiveLegId is null)
+        {
+            return;
+        }
+
+        if (TryUpdatePlan(plan => plan.ClearActiveLeg()))
+        {
+            CalculationRevision++;
+            MarkChanged();
+        }
+    }
 
     [RelayCommand]
     private void New() => NewDraft();
@@ -293,6 +502,8 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
             {
                 _plan = plan;
                 IsDirty = false;
+                RefreshLegs();
+                NotifyCurrentPositionChanged();
             }
 
             await RefreshSavedPlans();
@@ -368,7 +579,9 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
                         RouteName,
                         waypoints,
                         _plan.Results,
-                        _plan.SailedLegIds);
+                        _plan.SailedLegIds,
+                        _plan.CurrentPosition,
+                        _plan.ActiveLegId);
             }
 
             ValidationMessage = null;
@@ -443,6 +656,8 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         ResultsInvalidated = plan.HasInvalidatedResults;
         IsDirty = false;
         StorageError = null;
+        RefreshLegs();
+        NotifyCurrentPositionChanged();
     }
 
     internal void Remove(WaypointEditorItemViewModel waypoint)
@@ -582,6 +797,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
             StorageError = null;
             ValidationMessage = null;
             ActiveWaypoint = null;
+            IsAwaitingCurrentPositionPlacement = false;
         }
         finally
         {
@@ -619,6 +835,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
             StorageError = null;
             ValidationMessage = null;
             ActiveWaypoint = null;
+            IsAwaitingCurrentPositionPlacement = false;
         }
         finally
         {
@@ -650,6 +867,34 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Like <see cref="TryUpdatePlan"/>, but builds the plan from the current waypoints first if
+    /// one does not exist yet. Used for state (current position, sailed legs, active leg) that
+    /// the user can set even before the itinerary has ever been calculated or saved.
+    /// </summary>
+    private bool TryUpdatePlanEnsuringBuilt(Func<RoutePlan, RoutePlan> update, out string? error)
+    {
+        if (_plan is null && !TryBuildPlan(out _plan, out error))
+        {
+            return false;
+        }
+
+        try
+        {
+            _plan = update(_plan!);
+            ResultsInvalidated = _plan.HasInvalidatedResults;
+            ValidationMessage = null;
+            error = null;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            error = exception.Message;
+            ValidationMessage = error;
+            return false;
+        }
+    }
+
     private void MarkChanged()
     {
         if (_suppressChanges)
@@ -670,8 +915,60 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         }
     }
 
+    /// <summary>
+    /// Rebuilds the <see cref="Legs"/> collection from the current plan, reflecting each leg's
+    /// sailed/active state. Called whenever the plan's legs, sailed set, or active leg changes.
+    /// </summary>
+    private void RefreshLegs()
+    {
+        Legs.Clear();
+        var planForLegs = _plan;
+        if (planForLegs is null)
+        {
+            // Sailed/active-leg state is model-independent and must be settable even before the
+            // itinerary has ever been calculated or saved, so speculatively build a plan here
+            // (without persisting it to `_plan`) purely to enumerate legs. Restore
+            // ValidationMessage afterward so an incomplete itinerary in progress doesn't surface
+            // a spurious "set every waypoint" validation error.
+            var previousValidationMessage = ValidationMessage;
+            if (TryBuildPlan(out var built, out _))
+            {
+                planForLegs = built;
+            }
+
+            ValidationMessage = previousValidationMessage;
+        }
+
+        if (planForLegs is null)
+        {
+            return;
+        }
+
+        var activeIndex = planForLegs.ActiveLegIndex;
+        foreach (var leg in planForLegs.Legs)
+        {
+            var from = planForLegs.Waypoints.Single(waypoint => waypoint.Id == leg.FromWaypointId);
+            var to = planForLegs.Waypoints.Single(waypoint => waypoint.Id == leg.ToWaypointId);
+            Legs.Add(new RouteLegEditorItemViewModel(this, leg.Id, leg.Index, from.Name, to.Name)
+            {
+                IsSailed = planForLegs.SailedLegIds.Contains(leg.Id),
+                IsActive = leg.Index == activeIndex
+            });
+        }
+    }
+
+    private void NotifyCurrentPositionChanged()
+    {
+        OnPropertyChanged(nameof(CurrentPositionCoordinate));
+        OnPropertyChanged(nameof(CurrentPositionDepartureTimeUtc));
+        OnPropertyChanged(nameof(HasCurrentPosition));
+        OnPropertyChanged(nameof(CurrentPositionDisplay));
+    }
+
     private void NotifyItineraryChanged()
     {
+        RefreshLegs();
+        NotifyCurrentPositionChanged();
         OnPropertyChanged(nameof(Start));
         OnPropertyChanged(nameof(Finish));
         OnPropertyChanged(nameof(HasPendingWaypoint));

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -257,6 +257,7 @@ public partial class MainViewModel : ViewModelBase
         Itinerary = new ItineraryEditorViewModel(routePlanRepository);
         Itinerary.ItineraryChanged += OnItineraryChanged;
         Itinerary.MapPlacementStarted += OnMapPlacementStarted;
+        Itinerary.CurrentPositionPlacementStarted += OnCurrentPositionPlacementStarted;
 
         Map = new Map
         {
@@ -310,6 +311,8 @@ public partial class MainViewModel : ViewModelBase
 
     public bool IsSettingWaypoint => InteractionMode == MapInteractionMode.SetWaypoint;
 
+    public bool IsSettingCurrentPosition => InteractionMode == MapInteractionMode.SetCurrentPosition;
+
     public string LocalGribDisplay => LocalForecast is null
         ? "No file selected"
         : $"{Path.GetFileName(LocalForecast.Artifact.Path)} · {ModelName(LocalForecast.Model)}\n" +
@@ -322,6 +325,8 @@ public partial class MainViewModel : ViewModelBase
         MapInteractionMode.SetStart => "Click the map to place the start",
         MapInteractionMode.SetDestination => "Click the map to place the finish",
         MapInteractionMode.SetWaypoint => $"Click the map to place {Itinerary.ActiveWaypoint?.Name ?? "the waypoint"}",
+        MapInteractionMode.SetCurrentPosition =>
+            "Click the map to place the current position (where the vessel is now)",
         _ => "Pan and zoom, or select an endpoint tool"
     };
 
@@ -443,6 +448,18 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        if (Itinerary.IsAwaitingCurrentPositionPlacement)
+        {
+            if (!Itinerary.TryPlaceCurrentPosition(coordinate, _localTimeZone, out var error))
+            {
+                ErrorMessage = error;
+            }
+
+            _interaction.Activate(MapInteractionMode.Browse);
+            CompleteEndpointPlacement();
+            return;
+        }
+
         if (_interaction.HandleMapClick(coordinate))
         {
             CompleteEndpointPlacement();
@@ -547,7 +564,20 @@ public partial class MainViewModel : ViewModelBase
         }
 
         RoutePlanRoutingRequest? planRequest = null;
-        if (Itinerary.Waypoints.Count > 2)
+        var useSequentialWorkflow = Itinerary.Waypoints.Count > 2;
+        RoutePlan? sequentialPlan = null;
+        if (!useSequentialWorkflow && Itinerary.Waypoints.Count == 2 &&
+            Itinerary.TryBuildPlan(out var twoPointPlan, out _) &&
+            (twoPointPlan!.CurrentPosition is not null || twoPointPlan.SailedLegIds.Count > 0))
+        {
+            // A two-waypoint itinerary with resume state (a placed current position, or a sailed
+            // leg) still needs sequential/mid-leg resume semantics, so route it through the same
+            // plan workflow used for longer itineraries instead of the legacy two-point path.
+            useSequentialWorkflow = true;
+            sequentialPlan = twoPointPlan;
+        }
+
+        if (useSequentialWorkflow)
         {
             if (_routePlanWorkflow is null)
             {
@@ -555,16 +585,19 @@ public partial class MainViewModel : ViewModelBase
                 return;
             }
 
-            if (!Itinerary.TryBuildPlan(out var plan, out validationError))
+            if (sequentialPlan is null && !Itinerary.TryBuildPlan(out sequentialPlan, out validationError))
             {
                 ErrorMessage = validationError;
                 return;
             }
 
+            // The explicit current-position departure time (never wall clock/GPS) takes priority
+            // over the itinerary-start departure fields once a current position has been placed.
+            var departureTime = sequentialPlan!.CurrentPosition?.DepartureTime ?? request!.Route.DepartureTime;
             planRequest = new RoutePlanRoutingRequest(
-                plan!,
-                request!.Route.DepartureTime,
-                request.Route.LatestArrivalTime,
+                sequentialPlan,
+                departureTime,
+                request!.Route.LatestArrivalTime,
                 request.Selections);
         }
 
@@ -827,6 +860,19 @@ public partial class MainViewModel : ViewModelBase
         Itinerary.BeginMapPlacement(Itinerary.Waypoints[^1]);
     }
 
+    /// <summary>
+    /// Arms the distinct current-position map placement mode. This is never the same interaction
+    /// as placing a waypoint: it records a session-scoped "where the vessel is now" marker used
+    /// to resume routing mid-itinerary, not a permanent route point.
+    /// </summary>
+    [RelayCommand]
+    private void SetCurrentPosition() => Itinerary.BeginCurrentPositionPlacement();
+
+    [RelayCommand(CanExecute = nameof(CanClearCurrentPosition))]
+    private void ClearCurrentPosition() => Itinerary.ClearCurrentPosition();
+
+    private bool CanClearCurrentPosition() => Itinerary.HasCurrentPosition;
+
     [RelayCommand(CanExecute = nameof(CanCalculate))]
     private Task Calculate() => CalculateRoutesAsync();
 
@@ -967,7 +1013,7 @@ public partial class MainViewModel : ViewModelBase
             }
 
             var legStatuses = outcome.Legs.Select((leg, index) =>
-                $"leg {index + 1} {LegStatusName(leg)}");
+                $"leg {index + 1} {LegStatusName(leg, result.Plan.SailedLegIds.Contains(leg.LegId))}");
             var modelStatus =
                 $"{(IsExperimentalDownload(result.Request.Selections, outcome.Model) ? "Experimental · " : string.Empty)}" +
                 string.Join(" · ", legStatuses);
@@ -1538,7 +1584,10 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsSettingDestination));
         OnPropertyChanged(nameof(IsEndpointPlacementArmed));
         OnPropertyChanged(nameof(IsSettingWaypoint));
+        OnPropertyChanged(nameof(IsSettingCurrentPosition));
+        ClearCurrentPositionCommand.NotifyCanExecuteChanged();
         UpdateWaypointLayers();
+        _mapLayers.SetCurrentPosition(Itinerary.CurrentPositionCoordinate);
         UpdateForecastAreaSummary();
     }
 
@@ -1675,18 +1724,29 @@ public partial class MainViewModel : ViewModelBase
         _ => status.ToString()
     };
 
-    private static string LegStatusName(RouteLegResult leg) => leg.State switch
+    private static string LegStatusName(RouteLegResult leg, bool isSailed = false)
     {
-        RouteLegOutcomeState.Succeeded
-            when leg.Reason == RouteLegOutcomeReason.ForecastExhausted => "forecast-limited",
-        RouteLegOutcomeState.Succeeded => "complete",
-        RouteLegOutcomeState.Failed => "failed",
-        RouteLegOutcomeState.Cancelled => "cancelled",
-        RouteLegOutcomeState.Blocked => "blocked by prior failure",
-        RouteLegOutcomeState.OutsideForecastWindow => "outside forecast window",
-        RouteLegOutcomeState.Invalidated => "invalidated",
-        _ => "not calculated"
-    };
+        if (isSailed)
+        {
+            return "sailed";
+        }
+
+        return leg.State switch
+        {
+            RouteLegOutcomeState.Succeeded
+                when leg.Reason == RouteLegOutcomeReason.ForecastExhausted => "forecast-limited",
+            RouteLegOutcomeState.Succeeded => "complete",
+            RouteLegOutcomeState.Failed => "failed",
+            RouteLegOutcomeState.Cancelled => "cancelled",
+            RouteLegOutcomeState.Blocked => "blocked by prior failure",
+            RouteLegOutcomeState.OutsideForecastWindow => "outside forecast window",
+            RouteLegOutcomeState.Invalidated
+                when leg.Reason == RouteLegOutcomeReason.CurrentPositionChanged =>
+                "active reroute pending (current position changed)",
+            RouteLegOutcomeState.Invalidated => "invalidated",
+            _ => "not calculated"
+        };
+    }
 
     private static string ProgressStageName(RoutingProgressStage stage) => stage switch
     {
@@ -1766,6 +1826,12 @@ public partial class MainViewModel : ViewModelBase
         NotifyInteractionChanged();
     }
 
+    private void OnCurrentPositionPlacementStarted(object? sender, EventArgs e)
+    {
+        _interaction.Activate(MapInteractionMode.SetCurrentPosition);
+        NotifyInteractionChanged();
+    }
+
     private void OnItineraryChanged(object? sender, EventArgs e)
     {
         if (IsCalculating &&
@@ -1782,7 +1848,7 @@ public partial class MainViewModel : ViewModelBase
             StatusMessage = "Calculation cancelled because the itinerary changed.";
         }
 
-        if (Itinerary.ActiveWaypoint is null)
+        if (Itinerary.ActiveWaypoint is null && !Itinerary.IsAwaitingCurrentPositionPlacement)
         {
             _interaction.Activate(MapInteractionMode.Browse);
         }

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -174,6 +174,65 @@
                         <Border Classes="card">
                             <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
+                                           Text="CURRENT POSITION &amp; PROGRESS" />
+                                <TextBlock Classes="muted"
+                                           Text="Mark completed legs as sailed, choose the active leg to resume from, and place the vessel's current position for a mid-leg reroute."
+                                           TextWrapping="Wrap" />
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                                    <ToggleButton x:Name="SetCurrentPositionButton"
+                                                  Classes="map-tool"
+                                                  Content="Set current position"
+                                                  IsChecked="{Binding IsSettingCurrentPosition, Mode=OneWay}"
+                                                  Command="{Binding SetCurrentPositionCommand}"
+                                                  ToolTip.Tip="Arm current-position placement, then select the map" />
+                                    <Button Grid.Column="1"
+                                            Content="Clear"
+                                            Command="{Binding ClearCurrentPositionCommand}"
+                                            ToolTip.Tip="Remove the placed current position" />
+                                </Grid>
+                                <Grid ColumnDefinitions="*,104"
+                                      ColumnSpacing="7">
+                                    <DatePicker SelectedDate="{Binding Itinerary.CurrentPositionDepartureDate}" />
+                                    <TimePicker Grid.Column="1"
+                                                SelectedTime="{Binding Itinerary.CurrentPositionDepartureTimeOfDay}"
+                                                ClockIdentifier="24HourClock" />
+                                </Grid>
+                                <TextBlock Classes="muted"
+                                           Text="{Binding Itinerary.CurrentPositionDisplay}"
+                                           TextWrapping="Wrap" />
+                                <ItemsControl ItemsSource="{Binding Itinerary.Legs}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:RouteLegEditorItemViewModel">
+                                            <Border Classes="subtle" Margin="0,0,0,6">
+                                                <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="5">
+                                                    <StackPanel>
+                                                        <TextBlock Text="{Binding Label}" />
+                                                        <TextBlock Text="{Binding StatusLabel}"
+                                                                   Classes="muted" />
+                                                    </StackPanel>
+                                                    <Button Grid.Column="1"
+                                                            Content="Sailed"
+                                                            Command="{Binding MarkSailedCommand}"
+                                                            ToolTip.Tip="Mark this leg as sailed/completed" />
+                                                    <Button Grid.Column="2"
+                                                            Content="Unmark"
+                                                            Command="{Binding UnmarkSailedCommand}"
+                                                            ToolTip.Tip="Unmark this leg as sailed" />
+                                                    <Button Grid.Column="3"
+                                                            Content="Active"
+                                                            Command="{Binding MakeActiveCommand}"
+                                                            ToolTip.Tip="Explicitly resume from this leg" />
+                                                </Grid>
+                                            </Border>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Classes="card">
+                            <StackPanel Spacing="9">
+                                <TextBlock Classes="section-title"
                                            Text="DEPARTURE &amp; DURATION" />
                                 <Grid ColumnDefinitions="*,104"
                                       ColumnSpacing="7">

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -45,6 +45,11 @@ public sealed record RoutePlanRoutingRequest
         ForecastCutoff = cutoffUtc;
         Selections = immutableSelections;
         Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
+        StartLegIndex = plan.ActiveLegIndex;
+        StartOrigin = plan.CurrentPosition?.Coordinate ??
+            (StartLegIndex < plan.Waypoints.Length
+                ? plan.Waypoints[StartLegIndex].Coordinate
+                : plan.Waypoints[^1].Coordinate);
     }
 
     public RoutePlan Plan { get; }
@@ -56,6 +61,20 @@ public sealed record RoutePlanRoutingRequest
     public ImmutableArray<ForecastSelection> Selections { get; }
 
     public ImmutableArray<ForecastModel> Models { get; }
+
+    /// <summary>
+    /// The index of the leg routing should resume from: <see cref="RoutePlan.ActiveLegIndex"/> at
+    /// the time the request was built. Legs before this index are carried forward unchanged
+    /// (sailed history, or explicitly skipped legs) rather than recalculated.
+    /// </summary>
+    public int StartLegIndex { get; }
+
+    /// <summary>
+    /// The origin coordinate for <see cref="StartLegIndex"/>: the plan's user-placed current
+    /// position when set, otherwise that leg's own start waypoint. Never a synthetic/permanent
+    /// waypoint.
+    /// </summary>
+    public Coordinate StartOrigin { get; }
 }
 
 public enum RoutePlanRoutingUnitStatus
@@ -159,10 +178,7 @@ public sealed class RoutePlanRoutingWorkflow
                     request.Plan.Id,
                     selection.Model,
                     _timeProvider.GetUtcNow()),
-                request.Plan.Legs.Select(leg => new RouteLegResult(
-                    leg.Id,
-                    RouteLegOutcomeState.Pending,
-                    RouteLegOutcomeReason.None)).ToArray()));
+                BuildInitialLegs(request, selection.Model)));
 
         async Task<bool> PublishAsync(ModelExecutionState modelState, bool completeSession)
         {
@@ -195,7 +211,7 @@ public sealed class RoutePlanRoutingWorkflow
             var departure = request.DepartureTime;
             try
             {
-                for (var legIndex = 0; legIndex < request.Plan.Legs.Length; legIndex++)
+                for (var legIndex = request.StartLegIndex; legIndex < request.Plan.Legs.Length; legIndex++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (departure >= request.ForecastCutoff)
@@ -213,11 +229,13 @@ public sealed class RoutePlanRoutingWorkflow
                     }
 
                     var leg = request.Plan.Legs[legIndex];
-                    var from = request.Plan.Waypoints[legIndex];
+                    var origin = legIndex == request.StartLegIndex
+                        ? request.StartOrigin
+                        : request.Plan.Waypoints[legIndex].Coordinate;
                     var to = request.Plan.Waypoints[legIndex + 1];
                     var route = new RouteRequest(
                         $"{request.Plan.Id}-leg-{legIndex}-{modelState.Session.Id}",
-                        from.Coordinate,
+                        origin,
                         to.Coordinate,
                         departure,
                         request.ForecastCutoff);
@@ -331,7 +349,11 @@ public sealed class RoutePlanRoutingWorkflow
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                await MarkCancelledAsync(modelState, PublishAsync, progressState).ConfigureAwait(false);
+                await MarkCancelledAsync(
+                    modelState,
+                    request.StartLegIndex,
+                    PublishAsync,
+                    progressState).ConfigureAwait(false);
             }
         }
 
@@ -403,10 +425,11 @@ public sealed class RoutePlanRoutingWorkflow
 
     private static async Task MarkCancelledAsync(
         ModelExecutionState modelState,
+        int firstLegIndex,
         Func<ModelExecutionState, bool, Task<bool>> publish,
         ProgressState progress)
     {
-        var pending = Enumerable.Range(0, modelState.Legs.Length)
+        var pending = Enumerable.Range(firstLegIndex, modelState.Legs.Length - firstLegIndex)
             .Where(index => modelState.Legs[index].State == RouteLegOutcomeState.Pending)
             .ToArray();
         for (var pendingIndex = 0; pendingIndex < pending.Length; pendingIndex++)
@@ -429,6 +452,47 @@ public sealed class RoutePlanRoutingWorkflow
                 1,
                 "Calculation cancelled.");
         }
+    }
+
+    /// <summary>
+    /// Seeds the per-model leg outcomes before a routing pass: legs before
+    /// <see cref="RoutePlanRoutingRequest.StartLegIndex"/> are carried forward unchanged from the
+    /// plan's latest result for this model (sailed history, or legs explicitly skipped by an
+    /// active-leg selection) rather than recalculated. Legs from that index forward start Pending.
+    /// A carried, unsailed leg whose accepted route used a current-position origin that no longer
+    /// applies (because a later leg is now active) is invalidated rather than carried as-is.
+    /// </summary>
+    private static RouteLegResult[] BuildInitialLegs(RoutePlanRoutingRequest request, ForecastModel model)
+    {
+        var plan = request.Plan;
+        var existingByLeg = plan.LatestResult(model)?.Legs.ToDictionary(leg => leg.LegId);
+        return plan.Legs.Select(leg =>
+        {
+            if (leg.Index >= request.StartLegIndex)
+            {
+                return new RouteLegResult(leg.Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None);
+            }
+
+            if (existingByLeg is null ||
+                !existingByLeg.TryGetValue(leg.Id, out var carried))
+            {
+                return new RouteLegResult(
+                    leg.Id,
+                    RouteLegOutcomeState.NotCalculated,
+                    RouteLegOutcomeReason.BeforeActiveLeg,
+                    detail: "Not calculated because the leg is before the active leg.");
+            }
+
+            if (plan.SailedLegIds.Contains(leg.Id) || carried.Route is null)
+            {
+                return carried;
+            }
+
+            var from = plan.Waypoints[leg.Index];
+            return carried.Route.Request.Origin.IsSameLocation(from.Coordinate)
+                ? carried
+                : carried.Invalidate(RouteLegOutcomeReason.CurrentPositionChanged);
+        }).ToArray();
     }
 
     private static RouteLegOutcomeReason FailureReason(ModelRouteFailureStage stage) => stage switch

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -47,9 +47,7 @@ public sealed record RoutePlanRoutingRequest
         Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
         StartLegIndex = plan.ActiveLegIndex;
         StartOrigin = plan.CurrentPosition?.Coordinate ??
-            (StartLegIndex < plan.Waypoints.Length
-                ? plan.Waypoints[StartLegIndex].Coordinate
-                : plan.Waypoints[^1].Coordinate);
+            plan.Waypoints[StartLegIndex].Coordinate;
     }
 
     public RoutePlan Plan { get; }

--- a/src/Navtool.Core/RoutePlans.cs
+++ b/src/Navtool.Core/RoutePlans.cs
@@ -159,6 +159,7 @@ public sealed record RouteCalculationSession
 public enum RouteLegOutcomeState
 {
     Pending,
+    NotCalculated,
     Succeeded,
     Failed,
     Cancelled,
@@ -170,6 +171,7 @@ public enum RouteLegOutcomeState
 public enum RouteLegOutcomeReason
 {
     None,
+    BeforeActiveLeg,
     CalculationSucceeded,
     ForecastExhausted,
     ForecastAcquisitionFailed,
@@ -182,7 +184,8 @@ public enum RouteLegOutcomeReason
     WaypointsReordered,
     StopoverChanged,
     WaypointAdded,
-    WaypointRemoved
+    WaypointRemoved,
+    CurrentPositionChanged
 }
 
 public sealed record RouteLegResult
@@ -298,6 +301,23 @@ public sealed record RoutePlanResult
         leg.DeferredInvalidationReason is not null);
 }
 
+/// <summary>
+/// A user-placed current-start marker: an arbitrary position (not a permanent waypoint) plus
+/// the explicit departure time from that position. Never inferred from wall clock or GPS.
+/// </summary>
+public sealed record RouteCurrentPosition
+{
+    public RouteCurrentPosition(Coordinate coordinate, DateTimeOffset departureTime)
+    {
+        Coordinate = coordinate;
+        DepartureTime = departureTime.ToUniversalTime();
+    }
+
+    public Coordinate Coordinate { get; }
+
+    public DateTimeOffset DepartureTime { get; }
+}
+
 public sealed record RoutePlan
 {
     public RoutePlan(
@@ -305,7 +325,9 @@ public sealed record RoutePlan
         string name,
         IEnumerable<RouteWaypoint> waypoints,
         IEnumerable<RoutePlanResult>? results = null,
-        IEnumerable<RouteLegId>? sailedLegIds = null)
+        IEnumerable<RouteLegId>? sailedLegIds = null,
+        RouteCurrentPosition? currentPosition = null,
+        RouteLegId? activeLegId = null)
     {
         if (id.Value == Guid.Empty)
         {
@@ -319,7 +341,14 @@ public sealed record RoutePlan
         var legs = CreateLegs(immutableWaypoints);
         var immutableResults = (results ?? []).ToImmutableArray();
         var immutableSailed = (sailedLegIds ?? []).ToImmutableHashSet();
-        ValidateReferences(id, immutableWaypoints, legs, immutableResults, immutableSailed);
+        ValidateReferences(
+            id,
+            immutableWaypoints,
+            legs,
+            immutableResults,
+            immutableSailed,
+            currentPosition,
+            activeLegId);
 
         Id = id;
         Name = name.Trim();
@@ -327,6 +356,8 @@ public sealed record RoutePlan
         Legs = legs;
         Results = immutableResults;
         SailedLegIds = immutableSailed;
+        CurrentPosition = currentPosition;
+        ActiveLegId = activeLegId;
     }
 
     public RoutePlan(string name, IEnumerable<RouteWaypoint> waypoints)
@@ -346,13 +377,43 @@ public sealed record RoutePlan
 
     public ImmutableHashSet<RouteLegId> SailedLegIds { get; }
 
+    /// <summary>
+    /// The user-placed current position and explicit departure time, or <c>null</c> when routing
+    /// should begin from the itinerary start. Never inferred from wall clock or GPS.
+    /// </summary>
+    public RouteCurrentPosition? CurrentPosition { get; }
+
+    /// <summary>
+    /// An explicit override for the leg future routing should resume from. When <c>null</c>, the
+    /// active leg defaults to the first unsailed leg.
+    /// </summary>
+    public RouteLegId? ActiveLegId { get; }
+
+    /// <summary>
+    /// The index of the leg future routing should resume from: the explicit <see cref="ActiveLegId"/>
+    /// when set, otherwise the first leg that has not been marked sailed. Equal to <see cref="Legs"/>
+    /// length when every leg has been sailed.
+    /// </summary>
+    public int ActiveLegIndex => ResolveActiveLegIndex(Legs, SailedLegIds, ActiveLegId);
+
+    public RouteLeg? ActiveLeg
+    {
+        get
+        {
+            var index = ActiveLegIndex;
+            return index < Legs.Length ? Legs[index] : null;
+        }
+    }
+
+    public bool IsItineraryComplete => ActiveLegIndex >= Legs.Length;
+
     public bool HasInvalidatedResults => Results.Any(result => result.IsInvalidated);
 
     public RoutePlanResult? LatestResult(ForecastModel model) =>
         Results.SingleOrDefault(result => result.Model == model);
 
     public RoutePlan Rename(string name) =>
-        new(Id, name, Waypoints, Results, SailedLegIds);
+        new(Id, name, Waypoints, Results, SailedLegIds, CurrentPosition, ActiveLegId);
 
     public RoutePlan RenameWaypoint(RouteWaypointId waypointId, string name)
     {
@@ -463,13 +524,33 @@ public sealed record RoutePlan
         }
 
         var retained = Results.Where(existing => existing.Model != result.Model);
-        return new RoutePlan(Id, Name, Waypoints, retained.Append(result), SailedLegIds);
+        return new RoutePlan(
+            Id,
+            Name,
+            Waypoints,
+            retained.Append(result),
+            SailedLegIds,
+            CurrentPosition,
+            ActiveLegId);
     }
 
+    /// <summary>
+    /// Marks a leg as sailed (a real-world, model-independent itinerary fact). Sailed results are
+    /// retained as history and are never invalidated by forecast recalculation. Does not itself
+    /// invalidate any results.
+    /// </summary>
     public RoutePlan MarkSailed(RouteLegId legId)
     {
         EnsureLegExists(legId);
-        return new RoutePlan(Id, Name, Waypoints, Results, SailedLegIds.Add(legId));
+        var newActiveLegId = ActiveLegId == legId ? null : ActiveLegId;
+        return new RoutePlan(
+            Id,
+            Name,
+            Waypoints,
+            Results,
+            SailedLegIds.Add(legId),
+            CurrentPosition,
+            newActiveLegId);
     }
 
     public RoutePlan UnmarkSailed(RouteLegId legId)
@@ -478,6 +559,8 @@ public sealed record RoutePlan
         var leg = Legs.Single(item => item.Id == legId);
         var from = Waypoints.Single(item => item.Id == leg.FromWaypointId);
         var to = Waypoints.Single(item => item.Id == leg.ToWaypointId);
+        var newSailed = SailedLegIds.Remove(legId);
+        var newActiveIndex = ResolveActiveLegIndex(Legs, newSailed, ActiveLegId);
         var updatedResults = Results.Select(result => new RoutePlanResult(
             result.Session,
             result.Legs.Select(outcome =>
@@ -492,18 +575,158 @@ public sealed record RoutePlan
                     return outcome.Invalidate(deferredReason);
                 }
 
-                return outcome.Route is not null &&
-                       (!outcome.Route.Request.Origin.IsSameLocation(from.Coordinate) ||
-                        !outcome.Route.Request.Destination.IsSameLocation(to.Coordinate))
-                    ? outcome.Invalidate(RouteLegOutcomeReason.WaypointCoordinateChanged)
-                    : outcome;
+                if (outcome.Route is null)
+                {
+                    return outcome;
+                }
+
+                var originMatchesWaypoint = outcome.Route.Request.Origin.IsSameLocation(from.Coordinate);
+                var originMatchesCurrentPosition =
+                    CurrentPosition is not null &&
+                    leg.Index == newActiveIndex &&
+                    outcome.Route.Request.Origin.IsSameLocation(CurrentPosition.Coordinate);
+                var destinationMatches = outcome.Route.Request.Destination.IsSameLocation(to.Coordinate);
+                return (originMatchesWaypoint || originMatchesCurrentPosition) && destinationMatches
+                    ? outcome
+                    : outcome.Invalidate(RouteLegOutcomeReason.WaypointCoordinateChanged);
             })));
         return new RoutePlan(
             Id,
             Name,
             Waypoints,
             updatedResults,
-            SailedLegIds.Remove(legId));
+            newSailed,
+            CurrentPosition,
+            ActiveLegId);
+    }
+
+    /// <summary>
+    /// Records the user-placed current position and its explicit departure time. Retains the
+    /// existing stable leg identity of the active leg and never inserts a permanent waypoint.
+    /// Invalidates only unsailed results from the active leg forward; sailed results and earlier
+    /// legs are untouched.
+    /// </summary>
+    public RoutePlan SetCurrentPosition(Coordinate coordinate, DateTimeOffset departureTime)
+    {
+        var updatedPosition = new RouteCurrentPosition(coordinate, departureTime);
+        if (CurrentPosition == updatedPosition)
+        {
+            return this;
+        }
+
+        var updatedResults = Results
+            .Select(result => RebuildResult(
+                result,
+                Legs,
+                ActiveLegIndex,
+                RouteLegOutcomeReason.CurrentPositionChanged))
+            .ToArray();
+        return new RoutePlan(
+            Id,
+            Name,
+            Waypoints,
+            updatedResults,
+            SailedLegIds,
+            updatedPosition,
+            ActiveLegId);
+    }
+
+    /// <summary>
+    /// Clears the current position so routing resumes from the itinerary start (or the active
+    /// leg's own start waypoint). Invalidates only unsailed results from the active leg forward
+    /// (mirroring <see cref="SetCurrentPosition"/>), since any accepted route for the active leg
+    /// may have used the now-removed current-position origin. Sailed results and earlier legs are
+    /// untouched.
+    /// </summary>
+    public RoutePlan ClearCurrentPosition()
+    {
+        if (CurrentPosition is null)
+        {
+            return this;
+        }
+
+        var updatedResults = Results
+            .Select(result => RebuildResult(
+                result,
+                Legs,
+                ActiveLegIndex,
+                RouteLegOutcomeReason.CurrentPositionChanged))
+            .ToArray();
+        return new RoutePlan(Id, Name, Waypoints, updatedResults, SailedLegIds, null, ActiveLegId);
+    }
+
+    /// <summary>
+    /// Explicitly selects the leg that future routing should resume from, overriding the default
+    /// first-unfinished-leg resolution. The leg must exist and must not already be sailed.
+    /// Invalidates any other unsailed leg's stored route whose origin depended on the current
+    /// position, since that origin is only valid for whichever leg is currently active.
+    /// </summary>
+    public RoutePlan SetActiveLeg(RouteLegId legId)
+    {
+        EnsureLegExists(legId);
+        if (SailedLegIds.Contains(legId))
+        {
+            throw new InvalidOperationException("A sailed leg cannot be selected as the active leg.");
+        }
+
+        return ActiveLegId == legId
+            ? this
+            : WithActiveLeg(legId);
+    }
+
+    /// <summary>
+    /// Clears any explicit active-leg selection, reverting to the default first-unfinished-leg
+    /// resolution. Invalidates any unsailed leg's stored route left stranded by the resulting
+    /// active-leg change, mirroring <see cref="SetActiveLeg"/>.
+    /// </summary>
+    public RoutePlan ClearActiveLeg() =>
+        ActiveLegId is null
+            ? this
+            : WithActiveLeg(null);
+
+    private RoutePlan WithActiveLeg(RouteLegId? activeLegId)
+    {
+        var newActiveIndex = ResolveActiveLegIndex(Legs, SailedLegIds, activeLegId);
+        var updatedResults = Results
+            .Select(result => InvalidateStaleCurrentPositionOrigin(result, newActiveIndex))
+            .ToArray();
+        return new RoutePlan(Id, Name, Waypoints, updatedResults, SailedLegIds, CurrentPosition, activeLegId);
+    }
+
+    /// <summary>
+    /// Invalidates any non-sailed leg outcome (other than <paramref name="newActiveIndex"/>) whose
+    /// accepted route origin matches <see cref="CurrentPosition"/>. Such an origin is only ever
+    /// valid for the current active leg (see <see cref="ValidateReferences"/>), so it becomes
+    /// stale the moment a different leg becomes active.
+    /// </summary>
+    private RoutePlanResult InvalidateStaleCurrentPositionOrigin(RoutePlanResult result, int newActiveIndex)
+    {
+        if (CurrentPosition is null)
+        {
+            return result;
+        }
+
+        var updated = result.Legs.Select(outcome =>
+        {
+            if (outcome.Route is null || SailedLegIds.Contains(outcome.LegId))
+            {
+                return outcome;
+            }
+
+            var leg = Legs.Single(item => item.Id == outcome.LegId);
+            if (leg.Index == newActiveIndex)
+            {
+                return outcome;
+            }
+
+            var from = Waypoints.Single(item => item.Id == leg.FromWaypointId);
+            var originIsCurrentPosition = outcome.Route.Request.Origin.IsSameLocation(CurrentPosition.Coordinate);
+            var originIsOwnWaypoint = outcome.Route.Request.Origin.IsSameLocation(from.Coordinate);
+            return originIsCurrentPosition && !originIsOwnWaypoint
+                ? outcome.Invalidate(RouteLegOutcomeReason.CurrentPositionChanged)
+                : outcome;
+        });
+        return new RoutePlanResult(result.Session, updated);
     }
 
     private RoutePlan ReplaceWaypoint(
@@ -514,7 +737,7 @@ public sealed record RoutePlan
     {
         var updated = Waypoints.SetItem(index, waypoint);
         return invalidFromLeg is null
-            ? new RoutePlan(Id, Name, updated, Results, SailedLegIds)
+            ? new RoutePlan(Id, Name, updated, Results, SailedLegIds, CurrentPosition, ActiveLegId)
             : Rebuild(updated, invalidFromLeg.Value, reason);
     }
 
@@ -532,10 +755,23 @@ public sealed record RoutePlan
             throw new InvalidOperationException("Unmark sailed legs before changing their waypoint boundaries.");
         }
 
+        if (ActiveLegId is { } activeId && !newLegIds.Contains(activeId))
+        {
+            throw new InvalidOperationException(
+                "Clear or reassign the active leg before changing its waypoint boundaries.");
+        }
+
         var updatedResults = Results
             .Select(result => RebuildResult(result, newLegs, invalidFromLeg, reason))
             .ToArray();
-        return new RoutePlan(Id, Name, waypoints, updatedResults, SailedLegIds);
+        return new RoutePlan(
+            Id,
+            Name,
+            waypoints,
+            updatedResults,
+            SailedLegIds,
+            CurrentPosition,
+            ActiveLegId);
     }
 
     private RoutePlanResult RebuildResult(
@@ -643,13 +879,35 @@ public sealed record RoutePlan
         ImmutableArray<RouteWaypoint> waypoints,
         ImmutableArray<RouteLeg> legs,
         ImmutableArray<RoutePlanResult> results,
-        ImmutableHashSet<RouteLegId> sailedLegIds)
+        ImmutableHashSet<RouteLegId> sailedLegIds,
+        RouteCurrentPosition? currentPosition,
+        RouteLegId? activeLegId)
     {
         if (results.Select(result => result.Model).Distinct().Count() != results.Length)
         {
             throw new ArgumentException("Only the latest result for each forecast model may be stored.", nameof(results));
         }
 
+        var legIds = legs.Select(leg => leg.Id).ToImmutableHashSet();
+        if (!sailedLegIds.IsSubsetOf(legIds))
+        {
+            throw new ArgumentException("A sailed-leg reference does not exist in the route plan.", nameof(sailedLegIds));
+        }
+
+        if (activeLegId is { } explicitActiveId)
+        {
+            if (!legIds.Contains(explicitActiveId))
+            {
+                throw new ArgumentException("The active-leg reference does not exist in the route plan.", nameof(activeLegId));
+            }
+
+            if (sailedLegIds.Contains(explicitActiveId))
+            {
+                throw new ArgumentException("The active leg cannot already be marked sailed.", nameof(activeLegId));
+            }
+        }
+
+        var activeIndex = ResolveActiveLegIndex(legs, sailedLegIds, activeLegId);
         foreach (var result in results)
         {
             if (result.Session.PlanId != planId)
@@ -668,19 +926,43 @@ public sealed record RoutePlan
                 var leg = legs.Single(item => item.Id == legResult.LegId);
                 var from = waypoints.Single(item => item.Id == leg.FromWaypointId);
                 var to = waypoints.Single(item => item.Id == leg.ToWaypointId);
-                if (!legResult.Route!.Request.Origin.IsSameLocation(from.Coordinate) ||
-                    !legResult.Route.Request.Destination.IsSameLocation(to.Coordinate))
+                if (!legResult.Route!.Request.Destination.IsSameLocation(to.Coordinate))
+                {
+                    throw new ArgumentException("A route result does not match its referenced leg endpoints.", nameof(results));
+                }
+
+                var originMatchesWaypoint = legResult.Route.Request.Origin.IsSameLocation(from.Coordinate);
+                var originMatchesCurrentPosition =
+                    currentPosition is not null &&
+                    leg.Index == activeIndex &&
+                    legResult.Route.Request.Origin.IsSameLocation(currentPosition.Coordinate);
+                if (!originMatchesWaypoint && !originMatchesCurrentPosition)
                 {
                     throw new ArgumentException("A route result does not match its referenced leg endpoints.", nameof(results));
                 }
             }
         }
+    }
 
-        var legIds = legs.Select(leg => leg.Id).ToImmutableHashSet();
-        if (!sailedLegIds.IsSubsetOf(legIds))
+    private static int ResolveActiveLegIndex(
+        ImmutableArray<RouteLeg> legs,
+        ImmutableHashSet<RouteLegId> sailedLegIds,
+        RouteLegId? activeLegId)
+    {
+        if (activeLegId is { } explicitId)
         {
-            throw new ArgumentException("A sailed-leg reference does not exist in the route plan.", nameof(sailedLegIds));
+            return legs.Single(leg => leg.Id == explicitId).Index;
         }
+
+        for (var index = 0; index < legs.Length; index++)
+        {
+            if (!sailedLegIds.Contains(legs[index].Id))
+            {
+                return index;
+            }
+        }
+
+        return legs.Length;
     }
 
     private static void ValidateResultLegs(RoutePlanResult result, ImmutableArray<RouteLeg> legs)

--- a/src/Navtool.Core/RoutePlans.cs
+++ b/src/Navtool.Core/RoutePlans.cs
@@ -586,9 +586,18 @@ public sealed record RoutePlan
                     leg.Index == newActiveIndex &&
                     outcome.Route.Request.Origin.IsSameLocation(CurrentPosition.Coordinate);
                 var destinationMatches = outcome.Route.Request.Destination.IsSameLocation(to.Coordinate);
-                return (originMatchesWaypoint || originMatchesCurrentPosition) && destinationMatches
-                    ? outcome
-                    : outcome.Invalidate(RouteLegOutcomeReason.WaypointCoordinateChanged);
+                if ((originMatchesWaypoint || originMatchesCurrentPosition) && destinationMatches)
+                {
+                    return outcome;
+                }
+
+                var usedCurrentPosition =
+                    CurrentPosition is not null &&
+                    !originMatchesWaypoint &&
+                    outcome.Route.Request.Origin.IsSameLocation(CurrentPosition.Coordinate);
+                return outcome.Invalidate(usedCurrentPosition
+                    ? RouteLegOutcomeReason.CurrentPositionChanged
+                    : RouteLegOutcomeReason.WaypointCoordinateChanged);
             })));
         return new RoutePlan(
             Id,

--- a/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
+++ b/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
@@ -12,14 +12,83 @@ public interface IRoutePlanSchemaMigrator
 
 public sealed class RoutePlanSchemaMigrator : IRoutePlanSchemaMigrator
 {
-    public JsonDocument MigrateToCurrent(JsonDocument document, int fromVersion, int currentVersion) =>
+    public JsonDocument MigrateToCurrent(JsonDocument document, int fromVersion, int currentVersion)
+    {
+        if (fromVersion == 1 && currentVersion == 2)
+        {
+            return MigrateV1ToV2(document);
+        }
+
         throw new InvalidDataException(
             $"Route plan schema version {fromVersion} is not supported by this application version.");
+    }
+
+    /// <summary>
+    /// Rewrites a version-1 route plan document to version 2 by adding the new
+    /// <c>currentPosition</c> and <c>activeLegId</c> fields (both absent/null for plans that
+    /// predate Slice 3's current-position/active-leg feature) and bumping <c>schemaVersion</c>.
+    /// The plan's own <c>sailedLegIds</c> collection already existed pre-migration and is
+    /// preserved as-is.
+    /// </summary>
+    private static JsonDocument MigrateV1ToV2(JsonDocument document)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            WriteMigratedEnvelope(writer, document.RootElement);
+        }
+
+        stream.Position = 0;
+        return JsonDocument.Parse(stream.ToArray());
+    }
+
+    private static void WriteMigratedEnvelope(Utf8JsonWriter writer, JsonElement root)
+    {
+        writer.WriteStartObject();
+        foreach (var property in root.EnumerateObject())
+        {
+            if (property.NameEquals("schemaVersion"))
+            {
+                writer.WriteNumber("schemaVersion", 2);
+                continue;
+            }
+
+            if (property.NameEquals("plan"))
+            {
+                WriteMigratedPlan(writer, "plan", property.Value);
+                continue;
+            }
+
+            property.WriteTo(writer);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static void WriteMigratedPlan(Utf8JsonWriter writer, string propertyName, JsonElement plan)
+    {
+        writer.WritePropertyName(propertyName);
+        if (plan.ValueKind != JsonValueKind.Object)
+        {
+            plan.WriteTo(writer);
+            return;
+        }
+
+        writer.WriteStartObject();
+        foreach (var property in plan.EnumerateObject())
+        {
+            property.WriteTo(writer);
+        }
+
+        writer.WriteNull("currentPosition");
+        writer.WriteNull("activeLegId");
+        writer.WriteEndObject();
+    }
 }
 
 public sealed class RoutePlanJsonRepository : IRoutePlanRepository
 {
-    public const int CurrentSchemaVersion = 1;
+    public const int CurrentSchemaVersion = 2;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         WriteIndented = true,
@@ -323,7 +392,14 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
                 waypoint.Coordinate.Longitude,
                 waypoint.Stopover?.Ticks)).ToArray(),
             plan.Results.Select(ToDto).ToArray(),
-            plan.SailedLegIds.Select(id => id.Value).ToArray());
+            plan.SailedLegIds.Select(id => id.Value).ToArray(),
+            plan.CurrentPosition is null
+                ? null
+                : new RouteCurrentPositionDto(
+                    plan.CurrentPosition.Coordinate.Latitude,
+                    plan.CurrentPosition.Coordinate.Longitude,
+                    plan.CurrentPosition.DepartureTime),
+            plan.ActiveLegId?.Value);
 
     private static RoutePlanResultDto ToDto(RoutePlanResult result) =>
         new(
@@ -408,12 +484,26 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
             throw new InvalidDataException("A stored route plan contains empty or duplicate sailed-leg IDs.");
         }
 
+        var currentPosition = dto.CurrentPosition is null
+            ? null
+            : new RouteCurrentPosition(
+                new Coordinate(dto.CurrentPosition.Latitude, dto.CurrentPosition.Longitude),
+                dto.CurrentPosition.DepartureTime);
+        if (dto.ActiveLegId is Guid activeLegGuid && activeLegGuid == Guid.Empty)
+        {
+            throw new InvalidDataException("A stored route plan has an empty active-leg ID.");
+        }
+
+        var activeLegId = dto.ActiveLegId is Guid guid ? new RouteLegId(guid) : (RouteLegId?)null;
+
         return new RoutePlan(
             new RoutePlanId(dto.Id),
             dto.Name,
             waypoints,
             results,
-            sailedIds);
+            sailedIds,
+            currentPosition,
+            activeLegId);
     }
 
     private static RoutePlanResult FromDto(
@@ -517,7 +607,14 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
         string Name,
         RouteWaypointDto[] Waypoints,
         RoutePlanResultDto[] Results,
-        Guid[] SailedLegIds);
+        Guid[] SailedLegIds,
+        RouteCurrentPositionDto? CurrentPosition = null,
+        Guid? ActiveLegId = null);
+
+    private sealed record RouteCurrentPositionDto(
+        double Latitude,
+        double Longitude,
+        DateTimeOffset DepartureTime);
 
     private sealed record RouteWaypointDto(
         Guid Id,

--- a/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
+++ b/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
@@ -151,6 +151,133 @@ public sealed class ItineraryEditorViewModelTests
         Assert.Equal("Edited while saving", editor.RouteName);
     }
 
+    [Fact]
+    public void Legs_populate_from_a_fresh_itinerary_and_mark_unmark_sailed_toggles_state()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+
+        var leg = Assert.Single(editor.Legs);
+        Assert.False(leg.IsSailed);
+        Assert.True(leg.IsActive);
+        Assert.Equal("Active", leg.StatusLabel);
+
+        Assert.True(leg.MarkSailedCommand.CanExecute(null));
+        leg.MarkSailedCommand.Execute(null);
+
+        Assert.True(editor.Legs[0].IsSailed);
+        Assert.Equal("Sailed", editor.Legs[0].StatusLabel);
+        Assert.False(editor.Legs[0].MarkSailedCommand.CanExecute(null));
+        Assert.True(editor.Legs[0].UnmarkSailedCommand.CanExecute(null));
+
+        editor.Legs[0].UnmarkSailedCommand.Execute(null);
+
+        Assert.False(editor.Legs[0].IsSailed);
+        Assert.True(editor.Legs[0].IsActive);
+    }
+
+    [Fact]
+    public void Explicit_active_leg_selection_updates_legs_and_can_be_cleared()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 3));
+        editor.AddWaypointCommand.Execute(null);
+        var middle = editor.Waypoints[1];
+        middle.SetOnMapCommand.Execute(null);
+        editor.PlaceActiveWaypoint(new Coordinate(0, 1.5));
+
+        Assert.Equal(2, editor.Legs.Count);
+        Assert.True(editor.Legs[0].IsActive);
+        Assert.False(editor.Legs[1].IsActive);
+
+        Assert.True(editor.Legs[1].MakeActiveCommand.CanExecute(null));
+        editor.Legs[1].MakeActiveCommand.Execute(null);
+
+        Assert.False(editor.Legs[0].IsActive);
+        Assert.True(editor.Legs[1].IsActive);
+
+        editor.ClearActiveLeg();
+
+        Assert.True(editor.Legs[0].IsActive);
+        Assert.False(editor.Legs[1].IsActive);
+    }
+
+    [Fact]
+    public void Place_current_position_records_coordinate_and_explicit_departure_time()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+        var departure = new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+        editor.BeginCurrentPositionPlacement();
+        Assert.True(editor.IsAwaitingCurrentPositionPlacement);
+
+        var placed = editor.PlaceCurrentPosition(new Coordinate(0.2, 0.4), departure, out var error);
+
+        Assert.True(placed, error);
+        Assert.False(editor.IsAwaitingCurrentPositionPlacement);
+        Assert.True(editor.HasCurrentPosition);
+        Assert.Equal(new Coordinate(0.2, 0.4), editor.CurrentPositionCoordinate);
+        Assert.Equal(departure, editor.CurrentPositionDepartureTimeUtc);
+        Assert.NotEqual("Not set", editor.CurrentPositionDisplay);
+
+        editor.ClearCurrentPosition();
+
+        Assert.False(editor.HasCurrentPosition);
+        Assert.Null(editor.CurrentPositionCoordinate);
+        Assert.Equal("Not set", editor.CurrentPositionDisplay);
+    }
+
+    [Fact]
+    public void Cancel_current_position_placement_leaves_existing_current_position_untouched()
+    {
+        var editor = new ItineraryEditorViewModel();
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 1));
+        editor.PlaceCurrentPosition(
+            new Coordinate(0.2, 0.4),
+            new DateTimeOffset(2026, 8, 1, 12, 0, 0, TimeSpan.Zero),
+            out _);
+
+        editor.BeginCurrentPositionPlacement();
+        editor.CancelCurrentPositionPlacement();
+
+        Assert.False(editor.IsAwaitingCurrentPositionPlacement);
+        Assert.True(editor.HasCurrentPosition);
+        Assert.Equal(new Coordinate(0.2, 0.4), editor.CurrentPositionCoordinate);
+    }
+
+    [Fact]
+    public async Task Save_and_open_restore_sailed_active_leg_and_current_position_state()
+    {
+        var repository = new MemoryRepository();
+        var editor = new ItineraryEditorViewModel(repository);
+        editor.SetEndpoints(new Coordinate(0, 0), new Coordinate(0, 3));
+        editor.AddWaypointCommand.Execute(null);
+        var middle = editor.Waypoints[1];
+        middle.SetOnMapCommand.Execute(null);
+        editor.PlaceActiveWaypoint(new Coordinate(0, 1.5));
+
+        var firstLegId = editor.Legs[0].Id;
+        editor.Legs[0].MarkSailedCommand.Execute(null);
+        var departure = new DateTimeOffset(2026, 8, 1, 9, 0, 0, TimeSpan.Zero);
+        editor.PlaceCurrentPosition(new Coordinate(0.1, 0.9), departure, out var placeError);
+        Assert.Null(placeError);
+
+        await editor.SaveCommand.ExecuteAsync(null);
+        var reopened = new ItineraryEditorViewModel(repository);
+        await reopened.RefreshSavedPlansCommand.ExecuteAsync(null);
+        reopened.SelectedSavedPlan = reopened.SavedPlans.Single();
+        await reopened.OpenCommand.ExecuteAsync(null);
+
+        Assert.Equal(2, reopened.Legs.Count);
+        Assert.Equal(firstLegId, reopened.Legs[0].Id);
+        Assert.True(reopened.Legs[0].IsSailed);
+        Assert.True(reopened.Legs[1].IsActive);
+        Assert.True(reopened.HasCurrentPosition);
+        Assert.Equal(new Coordinate(0.1, 0.9), reopened.CurrentPositionCoordinate);
+        Assert.Equal(departure, reopened.CurrentPositionDepartureTimeUtc);
+    }
+
     private static RoutePlan CreatePlanWithPendingResult()
     {
         var plan = new RoutePlan(

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -342,6 +342,187 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Marking_a_leg_sailed_skips_it_during_recalculation_and_retains_history()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-sailed-leg-{Guid.NewGuid():N}");
+        var repository = new RoutePlanJsonRepository(root);
+        var routeRequests = new List<RouteRequest>();
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routeRequests.Add(request);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        var intermediate = viewModel.Itinerary.Waypoints[1];
+        intermediate.SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(2, routeRequests.Count);
+        Assert.Equal(2, viewModel.Itinerary.Legs.Count);
+        var firstLegId = viewModel.Itinerary.Legs[0].Id;
+        var firstLegRoute = routeRequests[0];
+
+        viewModel.Itinerary.Legs[0].MarkSailedCommand.Execute(null);
+        Assert.True(viewModel.Itinerary.Legs[0].IsSailed);
+        Assert.True(viewModel.Itinerary.Legs[1].IsActive);
+        routeRequests.Clear();
+
+        // Sailed leg geometry/results are history: recalculation replaces only the eligible
+        // current/future leg, never the sailed one.
+        await viewModel.CalculateRoutesAsync();
+
+        var recalculated = Assert.Single(routeRequests);
+        Assert.Equal(intermediate.Coordinate!.Value, recalculated.Origin);
+
+        var reopened = await repository.OpenAsync(viewModel.Itinerary.PlanId);
+        Assert.Contains(firstLegId, reopened.SailedLegIds);
+        var recalculatedResult = reopened.LatestResult(ForecastModel.NoaaGfs)!;
+        var retainedFirstLeg = recalculatedResult.Legs[0];
+        Assert.Equal(firstLegRoute.RouteId, retainedFirstLeg.Route!.Request.RouteId);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, retainedFirstLeg.State);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, recalculatedResult.Legs[1].State);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task Explicit_active_leg_selection_skips_the_earlier_unfinished_leg()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var routeRequests = new List<RouteRequest>();
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routeRequests.Add(request);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-active-leg-{Guid.NewGuid():N}");
+        var repository = new RoutePlanJsonRepository(root);
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        var intermediate = viewModel.Itinerary.Waypoints[1];
+        intermediate.SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+
+        Assert.Equal(2, viewModel.Itinerary.Legs.Count);
+        // Explicitly select leg 2 as active without ever calculating (or marking sailed) leg 1.
+        viewModel.Itinerary.Legs[1].MakeActiveCommand.Execute(null);
+        Assert.False(viewModel.Itinerary.Legs[0].IsActive);
+        Assert.True(viewModel.Itinerary.Legs[1].IsActive);
+
+        await viewModel.CalculateRoutesAsync();
+
+        var routed = Assert.Single(routeRequests);
+        Assert.Equal(intermediate.Coordinate!.Value, routed.Origin);
+
+        var reopened = await repository.OpenAsync(viewModel.Itinerary.PlanId);
+        var result = reopened.LatestResult(ForecastModel.NoaaGfs)!;
+        Assert.Equal(RouteLegOutcomeState.NotCalculated, result.Legs[0].State);
+        Assert.Equal(RouteLegOutcomeReason.BeforeActiveLeg, result.Legs[0].Reason);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, result.Legs[1].State);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task Current_position_overrides_origin_and_departure_time_never_wall_clock()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var routeRequests = new List<RouteRequest>();
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routeRequests.Add(request);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-current-position-{Guid.NewGuid():N}");
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: new RoutePlanJsonRepository(root));
+        var currentPosition = new Coordinate(35.5, -60);
+        var explicitDeparture = Now.AddHours(9);
+        viewModel.Itinerary.PlaceCurrentPosition(currentPosition, explicitDeparture, out var error);
+        Assert.Null(error);
+
+        await viewModel.CalculateRoutesAsync();
+
+        var routed = Assert.Single(routeRequests);
+        Assert.Equal(currentPosition, routed.Origin);
+        Assert.Equal(explicitDeparture, routed.DepartureTime);
+        Assert.NotEqual(viewModel.DepartureDate, routed.DepartureTime);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
+    public async Task Cancelling_a_multi_leg_calculation_preserves_the_completed_leg()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var secondLegStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var engine = new StreamingRouteEngine(async (request, forecast, progress, cancellationToken) =>
+        {
+            if (request.RouteId.Contains("leg-1", StringComparison.Ordinal))
+            {
+                secondLegStarted.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                throw new InvalidOperationException("Unreachable.");
+            }
+
+            progress?.Report(new RouteCalculationProgress(1, "fake route"));
+            return CreateRoute(request, forecast.Request.Model);
+        });
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-cancel-multi-leg-{Guid.NewGuid():N}");
+        var repository = new RoutePlanJsonRepository(root);
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        var intermediate = viewModel.Itinerary.Waypoints[1];
+        intermediate.SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+
+        var calculation = viewModel.CalculateRoutesAsync();
+        await secondLegStarted.Task;
+        viewModel.CancelCommand.Execute(null);
+        await calculation;
+
+        // Manual cancellation preserves completed results; the unfinished leg is cancelled, not
+        // silently dropped or reported as outside the forecast window.
+        var reopened = await repository.OpenAsync(viewModel.Itinerary.PlanId);
+        var result = reopened.LatestResult(ForecastModel.NoaaGfs)!;
+        Assert.Equal(RouteLegOutcomeState.Succeeded, result.Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.Cancelled, result.Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.CalculationCancelled, result.Legs[1].Reason);
+        Directory.Delete(root, recursive: true);
+    }
+
+    [Fact]
     public async Task LocalGribSelectionRoutesWithoutCallingForecastProvider()
     {
         var noaa = new DelegateForecastProvider(

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -14,6 +14,7 @@ using Navtool.App.Models;
 using Navtool.App.Services;
 using Navtool.App.ViewModels;
 using Navtool.App.Views;
+using Navtool.Core;
 using Navtool.Infrastructure;
 
 namespace Navtool.App.Tests;
@@ -38,6 +39,7 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(window.FindControl<ComboBox>("ThemeSelector"));
             Assert.NotNull(window.FindControl<ToggleButton>("SetStartButton"));
             Assert.NotNull(window.FindControl<ToggleButton>("SetDestinationButton"));
+            Assert.NotNull(window.FindControl<ToggleButton>("SetCurrentPositionButton"));
             Assert.NotNull(window.FindControl<Button>("CalculateRoutesButton"));
             Assert.NotNull(window.FindControl<NumericUpDown>("PassageDaysInput"));
             Assert.NotNull(window.FindControl<NumericUpDown>("PassageHoursInput"));
@@ -341,6 +343,88 @@ public sealed class MainWindowLayoutTests
         var window = CreateWindow();
         Assert.Equal(1040, window.MinWidth);
         Assert.Equal(680, window.MinHeight);
+    }
+
+    [AvaloniaFact]
+    public void LegsListButtonsAreWiredToTheRealMarkAndUnmarkSailedCommands()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            TimeProvider.System,
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+        viewModel.SetEndpoints(new Coordinate(34, -64), new Coordinate(39, -52));
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        var intermediate = viewModel.Itinerary.Waypoints[1];
+        intermediate.SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+        var window = new MainWindow { DataContext = viewModel };
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            Dispatcher.UIThread.RunJobs();
+            Assert.Equal(2, viewModel.Itinerary.Legs.Count);
+            var firstLegId = viewModel.Itinerary.Legs[0].Id;
+
+            var sailedButton = window.GetVisualDescendants()
+                .OfType<Button>()
+                .Single(button =>
+                    button.DataContext is RouteLegEditorItemViewModel leg &&
+                    leg.Id == firstLegId &&
+                    Equals(button.Content, "Sailed"));
+            Assert.True(sailedButton.Command?.CanExecute(null));
+            sailedButton.Command!.Execute(null);
+            Dispatcher.UIThread.RunJobs();
+
+            // Marking sailed rebuilds the Legs collection with fresh items, so re-index instead
+            // of relying on the (now stale) view-model instance captured before the click.
+            Assert.True(viewModel.Itinerary.Legs[0].IsSailed);
+            Assert.Equal("Sailed", viewModel.Itinerary.Legs[0].StatusLabel);
+
+            var unmarkButton = window.GetVisualDescendants()
+                .OfType<Button>()
+                .Single(button =>
+                    button.DataContext is RouteLegEditorItemViewModel leg &&
+                    leg.Id == firstLegId &&
+                    Equals(button.Content, "Unmark"));
+            Assert.True(unmarkButton.Command?.CanExecute(null));
+            unmarkButton.Command!.Execute(null);
+
+            Assert.False(viewModel.Itinerary.Legs[0].IsSailed);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void CurrentPositionButtonArmsPlacementModeThroughTheRealBinding()
+    {
+        var window = CreateWindow();
+        var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
+
+        try
+        {
+            window.Show();
+            var setCurrentPosition = Assert.IsType<ToggleButton>(
+                window.FindControl<ToggleButton>("SetCurrentPositionButton"));
+
+            setCurrentPosition.Command?.Execute(null);
+
+            Assert.Equal(MapInteractionMode.SetCurrentPosition, viewModel.InteractionMode);
+            Assert.True(viewModel.IsSettingCurrentPosition);
+            Assert.True(viewModel.Itinerary.IsAwaitingCurrentPositionPlacement);
+        }
+        finally
+        {
+            window.Close();
+        }
     }
 
     private static MainWindow CreateWindow() =>

--- a/tests/Navtool.App.Tests/MapInteractionStateTests.cs
+++ b/tests/Navtool.App.Tests/MapInteractionStateTests.cs
@@ -61,4 +61,24 @@ public sealed class MapInteractionStateTests
         Assert.Equal(destination, state.Destination);
         Assert.Equal(MapInteractionMode.Browse, state.Mode);
     }
+
+    [Fact]
+    public void SetCurrentPositionModeConsumesClickAndResetsToBrowseWithoutTouchingEndpoints()
+    {
+        var state = new MapInteractionState();
+        var start = new Coordinate(41.2, -70.4);
+        state.Activate(MapInteractionMode.SetStart);
+        state.HandleMapClick(start);
+
+        state.Activate(MapInteractionMode.SetCurrentPosition);
+        var handled = state.HandleMapClick(new Coordinate(30, -60));
+
+        // The current-position marker is distinct, session-scoped state owned by the itinerary
+        // editor (not MapInteractionState's Start/Destination), so this click must not alter
+        // either fixed endpoint while still being consumed (not falling through to Browse).
+        Assert.True(handled);
+        Assert.Equal(MapInteractionMode.Browse, state.Mode);
+        Assert.Equal(start, state.Start);
+        Assert.Null(state.Destination);
+    }
 }

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -15,6 +15,7 @@ using Navtool.App.Views;
 using AvaloniaColor = Avalonia.Media.Color;
 using LineString = NetTopologySuite.Geometries.LineString;
 using MultiLineString = NetTopologySuite.Geometries.MultiLineString;
+using Point = NetTopologySuite.Geometries.Point;
 
 namespace Navtool.App.Tests;
 
@@ -159,7 +160,8 @@ public sealed class MapRenderingTests
                 "ECMWF IFS provisional route",
                 "NOAA GFS routes",
                 "ECMWF IFS routes",
-                "Waypoint markers"
+                "Waypoint markers",
+                "Current position"
             ],
             layers.Skip(1).Select(layer => layer.Name));
     }
@@ -197,6 +199,41 @@ public sealed class MapRenderingTests
         {
             Assert.True(Math.Abs(line.Coordinates[index].X - line.Coordinates[index - 1].X) < 500_000);
         }
+    }
+
+    [Fact]
+    public void Current_position_marker_is_distinct_from_waypoint_markers_and_clears_on_null()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        layers.SetWaypoints(
+        [
+            new WaypointMapMarker(1, "Start", new Coordinate(10, 20)),
+            new WaypointMapMarker(2, "Finish", new Coordinate(11, 21))
+        ]);
+
+        Assert.Equal(0, layers.CurrentPositionMarkerCount);
+
+        var position = new Coordinate(10.5, 20.5);
+        layers.SetCurrentPosition(position);
+
+        Assert.Equal(1, layers.CurrentPositionMarkerCount);
+        // Waypoint markers are unaffected: a current-position marker is a distinct session
+        // marker, not an itinerary waypoint.
+        Assert.Equal(2, layers.WaypointMarkerCount);
+        var markerLayer = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "Current position"));
+        var feature = Assert.Single(markerLayer.Features);
+        var point = Assert.IsType<Point>(Assert.IsType<GeometryFeature>(feature).Geometry);
+        var expected = MapProjection.ToMapPoint(position);
+        Assert.Equal(expected.X, point.X, 6);
+        Assert.Equal(expected.Y, point.Y, 6);
+        var label = Assert.IsType<LabelStyle>(Assert.Single(feature.Styles));
+        Assert.Equal("\u2693", label.GetLabelText(feature));
+
+        layers.SetCurrentPosition(null);
+
+        Assert.Equal(0, layers.CurrentPositionMarkerCount);
     }
 
     [Fact]

--- a/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanRoutingWorkflowTests.cs
@@ -303,6 +303,148 @@ public sealed class RoutePlanRoutingWorkflowTests
             persisted.LatestResult(ForecastModel.NoaaGfs)!.Session.Id);
     }
 
+    [Fact]
+    public async Task Resume_routes_only_active_and_later_legs_from_current_position()
+    {
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        var sailedResult = SuccessfulResult(plan, ForecastModel.NoaaGfs);
+        plan = plan.WithResult(sailedResult).MarkSailed(plan.Legs[0].Id);
+        var currentPosition = new Coordinate(31.5, -66.5);
+        plan = plan.SetCurrentPosition(currentPosition, Now.AddHours(2));
+        var workflow = CreateWorkflow(
+            provider,
+            new DelegateRouteEngine((request, forecast, _) =>
+                ValueTask.FromResult(Route(request, forecast.Request.Model, TimeSpan.FromHours(2)))));
+
+        var result = await workflow.ExecuteAsync(
+            Request(plan, plan.CurrentPosition!.DepartureTime, Now.AddDays(8)));
+
+        var model = Assert.Single(result.Models);
+        // Leg 0 (sailed) is carried forward untouched; only legs 1 and 2 are recalculated.
+        Assert.Equal(2, provider.Requests.Count);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[0].State);
+        Assert.Same(sailedResult.Legs[0].Route, model.Legs[0].Route);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[1].State);
+        Assert.Equal(currentPosition, model.Legs[1].Route!.Request.Origin);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[2].State);
+        Assert.Equal(plan.Waypoints[2].Coordinate, model.Legs[2].Route!.Request.Origin);
+    }
+
+    [Fact]
+    public async Task Explicit_active_leg_skips_earlier_unsailed_leg_carrying_its_history_forward()
+    {
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        var existingResult = SuccessfulResult(plan, ForecastModel.NoaaGfs);
+        plan = plan.WithResult(existingResult).SetActiveLeg(plan.Legs[1].Id);
+        var workflow = CreateWorkflow(
+            provider,
+            new DelegateRouteEngine((request, forecast, _) =>
+                ValueTask.FromResult(Route(request, forecast.Request.Model, TimeSpan.FromHours(2)))));
+
+        var result = await workflow.ExecuteAsync(
+            Request(plan, Now.AddHours(1), Now.AddDays(8)));
+
+        var model = Assert.Single(result.Models);
+        Assert.Equal(2, provider.Requests.Count);
+        // Leg 0 was explicitly skipped (not sailed) but its prior successful, waypoint-anchored
+        // result is carried forward rather than recalculated.
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[0].State);
+        Assert.Same(existingResult.Legs[0].Route, model.Legs[0].Route);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[1].State);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[2].State);
+    }
+
+    [Fact]
+    public async Task New_model_records_legs_before_active_leg_as_not_calculated()
+    {
+        var provider = new RecordingProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(Acquisition(request)));
+        var plan = ThreeLegPlan();
+        plan = plan.MarkSailed(plan.Legs[0].Id);
+        var workflow = CreateWorkflow(
+            provider,
+            new DelegateRouteEngine((request, forecast, _) =>
+                ValueTask.FromResult(Route(request, forecast.Request.Model, TimeSpan.FromHours(2)))));
+
+        var result = await workflow.ExecuteAsync(
+            Request(plan, Now.AddHours(1), Now.AddDays(8)));
+
+        var model = Assert.Single(result.Models);
+        Assert.Equal(RouteLegOutcomeState.NotCalculated, model.Legs[0].State);
+        Assert.Equal(RouteLegOutcomeReason.BeforeActiveLeg, model.Legs[0].Reason);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[1].State);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, model.Legs[2].State);
+    }
+
+    [Fact]
+    public void Building_initial_legs_invalidates_a_carried_leg_whose_stale_current_position_origin_no_longer_applies()
+    {
+        var plan = ThreeLegPlan();
+        var currentPosition = new Coordinate(31.5, -66.5);
+        var positioned = plan.SetCurrentPosition(currentPosition, Now.AddHours(1));
+        var request = new RouteRequest(
+            "leg-0-from-current-position",
+            currentPosition,
+            plan.Waypoints[1].Coordinate,
+            Now.AddHours(1),
+            Now.AddDays(8));
+        var route = Route(request, ForecastModel.NoaaGfs, TimeSpan.FromHours(2));
+        var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, Now).Complete(Now.AddMinutes(1));
+        var accepted = positioned.WithResult(new RoutePlanResult(session,
+        [
+            new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, route),
+            new RouteLegResult(plan.Legs[1].Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None),
+            new RouteLegResult(plan.Legs[2].Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None)
+        ]));
+
+        // Skip ahead to leg 1 as the active leg without marking leg 0 sailed: leg 0's carried
+        // result used the current-position origin, which no longer applies once leg 0 is not the
+        // active leg, so RoutePlanRoutingWorkflow's BuildInitialLegs must invalidate it rather
+        // than carry it through (avoiding a validation failure when the new result is saved).
+        var skippedAhead = accepted.SetActiveLeg(plan.Legs[1].Id);
+        var buildInitialLegs = typeof(RoutePlanRoutingWorkflow).GetMethod(
+            "BuildInitialLegs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var routingRequest = Request(skippedAhead, Now.AddHours(2), Now.AddDays(8));
+
+        var initialLegs = (RouteLegResult[])buildInitialLegs.Invoke(
+            null, [routingRequest, ForecastModel.NoaaGfs])!;
+
+        Assert.Equal(RouteLegOutcomeState.Invalidated, initialLegs[0].State);
+        Assert.Equal(RouteLegOutcomeReason.CurrentPositionChanged, initialLegs[0].Reason);
+        Assert.Null(initialLegs[0].Route);
+    }
+
+    private static RoutePlanResult SuccessfulResult(RoutePlan plan, ForecastModel model)
+    {
+        var session = new RouteCalculationSession(plan.Id, model, Now).Complete(Now.AddMinutes(1));
+        var outcomes = plan.Legs.Select(leg =>
+        {
+            var from = plan.Waypoints[leg.Index];
+            var to = plan.Waypoints[leg.Index + 1];
+            var request = new RouteRequest(
+                $"existing-{leg.Index}",
+                from.Coordinate,
+                to.Coordinate,
+                Now,
+                Now.AddDays(8));
+            return new RouteLegResult(
+                leg.Id,
+                RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded,
+                Route(request, model, TimeSpan.FromHours(2)));
+        });
+        return new RoutePlanResult(session, outcomes);
+    }
+
     private static RoutePlanRoutingWorkflow CreateWorkflow(
         IForecastProvider provider,
         IRouteEngine engine) =>

--- a/tests/Navtool.Core.Tests/RoutePlanTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanTests.cs
@@ -329,6 +329,15 @@ public sealed class RoutePlanTests
         // should be retained rather than incorrectly invalidated for a coordinate "mismatch".
         Assert.Equal(RouteLegOutcomeState.Succeeded, unmarked.Results[0].Legs[0].State);
         Assert.Equal(0, unmarked.ActiveLegIndex);
+
+        var laterActive = sailed
+            .SetActiveLeg(plan.Legs[1].Id)
+            .UnmarkSailed(plan.Legs[0].Id);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, laterActive.Results[0].Legs[0].State);
+        Assert.Equal(
+            RouteLegOutcomeReason.CurrentPositionChanged,
+            laterActive.Results[0].Legs[0].Reason);
+        Assert.Equal(1, laterActive.ActiveLegIndex);
     }
 
     [Fact]

--- a/tests/Navtool.Core.Tests/RoutePlanTests.cs
+++ b/tests/Navtool.Core.Tests/RoutePlanTests.cs
@@ -144,6 +144,209 @@ public sealed class RoutePlanTests
             [new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Pending, RouteLegOutcomeReason.None)])));
     }
 
+    [Fact]
+    public void Active_leg_index_defaults_to_first_unsailed_leg()
+    {
+        var plan = CreatePlan();
+        Assert.Equal(0, plan.ActiveLegIndex);
+        Assert.Equal(plan.Legs[0].Id, plan.ActiveLeg!.Id);
+        Assert.False(plan.IsItineraryComplete);
+
+        var sailedFirst = plan.MarkSailed(plan.Legs[0].Id);
+        Assert.Equal(1, sailedFirst.ActiveLegIndex);
+        Assert.Equal(plan.Legs[1].Id, sailedFirst.ActiveLeg!.Id);
+
+        var sailedAll = sailedFirst.MarkSailed(plan.Legs[1].Id);
+        Assert.Equal(plan.Legs.Length, sailedAll.ActiveLegIndex);
+        Assert.Null(sailedAll.ActiveLeg);
+        Assert.True(sailedAll.IsItineraryComplete);
+    }
+
+    [Fact]
+    public void Explicit_active_leg_overrides_default_and_is_validated()
+    {
+        var plan = CreatePlan();
+        var withActive = plan.SetActiveLeg(plan.Legs[1].Id);
+        Assert.Equal(plan.Legs[1].Id, withActive.ActiveLegId);
+        Assert.Equal(1, withActive.ActiveLegIndex);
+
+        Assert.Throws<KeyNotFoundException>(() => plan.SetActiveLeg(new RouteLegId(Guid.NewGuid())));
+
+        var sailed = plan.MarkSailed(plan.Legs[0].Id);
+        Assert.Throws<InvalidOperationException>(() => sailed.SetActiveLeg(plan.Legs[0].Id));
+
+        var cleared = withActive.ClearActiveLeg();
+        Assert.Null(cleared.ActiveLegId);
+        Assert.Equal(0, cleared.ActiveLegIndex);
+    }
+
+    [Fact]
+    public void Set_current_position_invalidates_only_active_and_later_unsailed_legs()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+        plan = plan.MarkSailed(plan.Legs[0].Id);
+
+        var withPosition = plan.SetCurrentPosition(new Coordinate(0.2, 0.5), Now.AddHours(1));
+
+        Assert.NotNull(withPosition.CurrentPosition);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, withPosition.Results[0].Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, withPosition.Results[0].Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.CurrentPositionChanged, withPosition.Results[0].Legs[1].Reason);
+    }
+
+    [Fact]
+    public void Clear_current_position_invalidates_only_active_and_later_unsailed_legs()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+        var sailedLeg = plan.Legs[0].Id;
+        plan = plan.MarkSailed(sailedLeg).SetCurrentPosition(new Coordinate(0.2, 0.5), Now.AddHours(1));
+
+        var cleared = plan.ClearCurrentPosition();
+
+        Assert.Null(cleared.CurrentPosition);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, cleared.Results[0].Legs[0].State);
+        Assert.Equal(RouteLegOutcomeState.Invalidated, cleared.Results[0].Legs[1].State);
+        Assert.Equal(RouteLegOutcomeReason.CurrentPositionChanged, cleared.Results[0].Legs[1].Reason);
+    }
+
+    [Fact]
+    public void Clear_current_position_is_a_no_op_when_none_is_set()
+    {
+        var plan = WithSuccessfulResult(CreatePlan());
+
+        var cleared = plan.ClearCurrentPosition();
+
+        Assert.Same(plan, cleared);
+    }
+
+    [Fact]
+    public void Route_result_origin_may_match_current_position_only_for_the_active_leg()
+    {
+        var plan = CreatePlan();
+        var currentPosition = new Coordinate(0.4, 0.9);
+        var activeLegRequest = new RouteRequest(
+            "active",
+            currentPosition,
+            plan.Waypoints[1].Coordinate,
+            Now,
+            Now.AddHours(2));
+        var activeLegRoute = new RouteResult(
+            activeLegRequest,
+            ForecastModel.NoaaGfs,
+            [
+                new RoutePoint(currentPosition, Now, 90, 5, 10, 180, 0),
+                new RoutePoint(plan.Waypoints[1].Coordinate, Now.AddHours(1), 90, 5, 10, 180, 30)
+            ],
+            new RouteDiagnostics(1, 1, 1, 1));
+        var laterLegRequest = new RouteRequest(
+            "later",
+            plan.Waypoints[1].Coordinate,
+            plan.Waypoints[2].Coordinate,
+            Now.AddHours(1),
+            Now.AddHours(3));
+        var laterLegRoute = new RouteResult(
+            laterLegRequest,
+            ForecastModel.NoaaGfs,
+            [
+                new RoutePoint(plan.Waypoints[1].Coordinate, Now.AddHours(1), 90, 5, 10, 180, 0),
+                new RoutePoint(plan.Waypoints[2].Coordinate, Now.AddHours(2), 90, 5, 10, 180, 30)
+            ],
+            new RouteDiagnostics(1, 1, 1, 1));
+        var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, Now).Complete(Now.AddHours(2));
+        var result = new RoutePlanResult(session,
+        [
+            new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, activeLegRoute),
+            new RouteLegResult(plan.Legs[1].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, laterLegRoute)
+        ]);
+
+        // Accepted while leg 0 is the active leg (default, since nothing is sailed yet) and its
+        // origin matches the current position.
+        var withCurrentPosition = plan.SetCurrentPosition(currentPosition, Now);
+        var accepted = withCurrentPosition.WithResult(result);
+        Assert.Equal(RouteLegOutcomeState.Succeeded, accepted.Results[0].Legs[0].State);
+
+        // The same origin substitution is rejected for a leg that is not the active leg: swap
+        // which leg claims the current-position origin and confirm the constructor rejects it.
+        var swappedResult = new RoutePlanResult(session,
+        [
+            new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, laterLegRoute),
+            new RouteLegResult(plan.Legs[1].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, activeLegRoute)
+        ]);
+        Assert.Throws<ArgumentException>(() => withCurrentPosition.WithResult(swappedResult));
+    }
+
+    [Fact]
+    public void Unmark_sailed_retains_result_routed_from_current_position_while_leg_was_active()
+    {
+        var plan = CreatePlan();
+        var currentPosition = new Coordinate(0.4, 0.9);
+        var withPosition = plan.SetCurrentPosition(currentPosition, Now);
+        var request = new RouteRequest(
+            "from-current-position",
+            currentPosition,
+            plan.Waypoints[1].Coordinate,
+            Now,
+            Now.AddHours(2));
+        var route = new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            [
+                new RoutePoint(currentPosition, Now, 90, 5, 10, 180, 0),
+                new RoutePoint(plan.Waypoints[1].Coordinate, Now.AddHours(1), 90, 5, 10, 180, 30)
+            ],
+            new RouteDiagnostics(1, 1, 1, 1));
+        var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, Now).Complete(Now.AddHours(1));
+        var laterLegRequest = new RouteRequest(
+            "later",
+            plan.Waypoints[1].Coordinate,
+            plan.Waypoints[2].Coordinate,
+            Now.AddHours(1),
+            Now.AddHours(3));
+        var laterLegRoute = new RouteResult(
+            laterLegRequest,
+            ForecastModel.NoaaGfs,
+            [
+                new RoutePoint(plan.Waypoints[1].Coordinate, Now.AddHours(1), 90, 5, 10, 180, 0),
+                new RoutePoint(plan.Waypoints[2].Coordinate, Now.AddHours(2), 90, 5, 10, 180, 30)
+            ],
+            new RouteDiagnostics(1, 1, 1, 1));
+        var calculated = withPosition.WithResult(new RoutePlanResult(session,
+        [
+            new RouteLegResult(plan.Legs[0].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, route),
+            new RouteLegResult(plan.Legs[1].Id, RouteLegOutcomeState.Succeeded,
+                RouteLegOutcomeReason.CalculationSucceeded, laterLegRoute)
+        ]));
+
+        var sailed = calculated.MarkSailed(plan.Legs[0].Id);
+        var unmarked = sailed.UnmarkSailed(plan.Legs[0].Id);
+
+        // Leg 0 becomes active again after unmarking, so its current-position-origin result
+        // should be retained rather than incorrectly invalidated for a coordinate "mismatch".
+        Assert.Equal(RouteLegOutcomeState.Succeeded, unmarked.Results[0].Legs[0].State);
+        Assert.Equal(0, unmarked.ActiveLegIndex);
+    }
+
+    [Fact]
+    public void Active_leg_must_be_cleared_or_reassigned_before_removing_its_boundary_waypoint()
+    {
+        var plan = new RoutePlan(
+            "Four",
+            [Waypoint("Start", 0), Waypoint("A", 1), Waypoint("B", 2), Waypoint("Finish", 3)]);
+        var withActive = plan.SetActiveLeg(plan.Legs[1].Id);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            withActive.RemoveWaypoint(withActive.Waypoints[2].Id));
+
+        var cleared = withActive.ClearActiveLeg();
+        var removed = cleared.RemoveWaypoint(cleared.Waypoints[2].Id);
+        Assert.Null(removed.ActiveLegId);
+    }
+
     private static RoutePlan CreatePlan() =>
         new("Passage", [Waypoint("Start", 0), Waypoint("Mid", 1), Waypoint("Finish", 2)]);
 

--- a/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
@@ -160,6 +160,69 @@ public sealed class RoutePlanJsonRepositoryTests
         Assert.Empty(Directory.EnumerateFiles(repository.RootDirectory, "*.tmp"));
     }
 
+    [Fact]
+    public async Task Version_one_documents_are_migrated_with_null_current_position_and_active_leg()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var id = new RoutePlanId();
+        var json = """
+            {"schemaVersion":1,"plan":{"id":"__ID__","name":"Legacy",
+            "waypoints":[{"id":"11111111-1111-1111-1111-111111111111","name":"Start",
+            "latitude":10,"longitude":20,"stopoverTicks":null},
+            {"id":"22222222-2222-2222-2222-222222222222","name":"Finish",
+            "latitude":11,"longitude":21,"stopoverTicks":null}],
+            "results":[],"sailedLegIds":[]}}
+            """.Replace("__ID__", id.Value.ToString());
+        await File.WriteAllTextAsync(
+            Path.Combine(repository.RootDirectory, $"{id}.route.json"),
+            json);
+
+        var loaded = await repository.OpenAsync(id);
+
+        Assert.Equal("Legacy", loaded.Name);
+        Assert.Null(loaded.CurrentPosition);
+        Assert.Null(loaded.ActiveLegId);
+        Assert.Equal(0, loaded.ActiveLegIndex);
+    }
+
+    [Fact]
+    public async Task Current_position_and_active_leg_round_trip_through_save_and_open()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = CreatePlan();
+        var activeLegId = plan.Legs[1].Id;
+        var withActiveLeg = plan.SetActiveLeg(activeLegId);
+        var departure = new DateTimeOffset(2026, 8, 2, 6, 0, 0, TimeSpan.Zero);
+        var withCurrentPosition = withActiveLeg.SetCurrentPosition(new Coordinate(36, -62), departure);
+
+        await repository.SaveAsync(withCurrentPosition);
+        var loaded = await repository.OpenAsync(withCurrentPosition.Id);
+
+        Assert.NotNull(loaded.CurrentPosition);
+        Assert.Equal(new Coordinate(36, -62), loaded.CurrentPosition!.Coordinate);
+        Assert.Equal(departure, loaded.CurrentPosition.DepartureTime);
+        Assert.Equal(activeLegId, loaded.ActiveLegId);
+    }
+
+    [Fact]
+    public async Task Unknown_active_leg_reference_is_rejected_on_load()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = CreatePlan();
+        await repository.SaveAsync(plan);
+        var path = Path.Combine(repository.RootDirectory, $"{plan.Id}.route.json");
+        var node = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(path))!;
+        node["plan"]!["activeLegId"] = "99999999-9999-9999-9999-999999999999";
+        await File.WriteAllTextAsync(path, node.ToJsonString());
+
+        var exception = await Assert.ThrowsAsync<RoutePlanRepositoryException>(async () =>
+            await repository.OpenAsync(plan.Id));
+        Assert.Contains("active-leg", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static RoutePlan CreatePlan()
     {
         var plan = new RoutePlan(


### PR DESCRIPTION
## Why

Forecast availability changes over a trip, so sailors need to resume routing from an explicitly chosen current position and departure time without losing completed-leg history or changing itinerary identity.

## What changed

- Adds model-independent sailed/unmark lifecycle and defaults routing to the first unfinished leg, with explicit active-leg selection.
- Routes the active leg from a distinct user-placed current-position marker to its existing destination, then continues sequentially through later waypoints.
- Preserves sailed geometry/results as history while invalidating and replacing only eligible current/future estimates.
- Persists current-position and active-leg metadata through an explicit schema v1-to-v2 migration while continuing to reject future versions and inconsistent references.
- Keeps accepted results on cancellation, distinguishes not-calculated, cancelled, blocked, and outside-window outcomes, and supports later forecast-window resume.
- Adds UI controls, status text, map placement mode, and a visually distinct current-position marker.

## Tests

- `dotnet test Navtool.sln --no-restore`
- 64 core, 82 infrastructure, and 97 app tests passing.

## Deliberate deferrals

Final selected-leg route emphasis and timeline redesign remain deferred to Slice 4. This change does not add GPS support or native ABI changes.