### PR TITLE
Add full-route multi-leg visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ It targets macOS, Windows, and Linux.
 - Compare model routes with distinct map colors. ECMWF is shown as an
   experimental option and currently fails explicitly because official indexed
   retrieval is not implemented.
-- Scrub a shared UTC timeline or move among route-point timestamps.
-- Click near a route to select and focus its nearest point.
+- Render every saved successful itinerary leg together on one full-route map,
+  including sailed history, while retaining waypoint guides for blocked,
+  uncalculated, and out-of-window legs.
+- Select a leg from the ordered list or map to emphasize it without hiding the
+  rest of the route, then fit the leg or focus an individual route point.
+- Scrub a route-wide UTC timeline for one active forecast model at a time, move
+  among that model's route-point timestamps, and see waypoint stopovers as
+  explicit stationary holds.
 - Display time-varying wind-speed colors and directional arrows for the active
   model.
 - Switch at runtime among Light, Dark, and the midnight-blue and brass
@@ -96,6 +102,30 @@ cmake --build native/Navtool.RouterBridge/build --config Release --parallel
 
 `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` can also be overridden if you need to
 fetch releases from a different fork.
+
+## Multi-point routes and visualization
+
+Each forecast model calculates itinerary legs sequentially. A successful leg's
+arrival plus the destination waypoint's optional stopover determines that
+model's next departure; NOAA and ECMWF may therefore reach the same leg at
+different UTC times. Failure, cancellation, forecast exhaustion, or a departure
+beyond the rolling forecast cutoff is recorded per model and leg. Later legs
+remain visibly listed with their status, but Navtool never draws invented
+optimized geometry between successful legs.
+
+The map stores feature identity as plan, stable leg, model, calculation session,
+and route-result ID. This keeps revisions and parallel model results distinct
+during list selection, map hit testing, selected-leg emphasis, and timeline
+navigation. The active model's timeline spans its saved successful legs in
+chronological order. Stopover gaps are stationary holds at the waypoint; the
+timeline does not compare unrelated nearest NOAA and ECMWF points as though they
+represented the same forecast instant.
+
+Marking a leg sailed preserves its latest model geometry as historical context.
+An explicit active leg and optional current-position marker can resume a rolling
+route without changing stable itinerary leg IDs. Recalculation publishes each
+completed leg atomically, so cancellation retains completed work while stale
+calculation generations cannot replace newer itinerary state.
 
 ## Streaming route visualization
 
@@ -175,6 +205,9 @@ Route plans are stored atomically as JSON beneath `routes/` in the same root.
 Plan files contain waypoint, stopover, calculation-session, leg-outcome, sailed
 state, and route-point metadata, but never forecast binaries. Files from unknown
 future schemas or with inconsistent IDs/references are rejected visibly.
+Opening a saved plan restores full-route geometry, sailed history, per-model leg
+status, and the model-specific timeline. Weather overlays are not restored from
+route JSON.
 
 NOAA data is downloaded from the operational NOMADS GFS filter. Navtool derives
 an antimeridian-safe buffered passage area, requests every available forecast
@@ -197,6 +230,13 @@ contain compatible paired 10 m U/V fields, and cover both the buffered route
 area and the full departure-to-arrival interval. Choosing a local file performs
 no forecast HTTP request. If inspection or routing setup fails, the app reports
 that separately from online forecast acquisition.
+
+Weather availability is scoped to the selected leg and forecast model. Navtool
+uses an in-memory acquisition only when its model, time range, and geographic
+bounds cover that leg. Switching legs or models cancels stale sampling and
+clears the overlay before a compatible acquisition is selected. Saved route
+geometry and details remain available after restart, but the UI explicitly
+reports weather unavailable until a compatible forecast is acquired again.
 
 The default map uses standard OpenStreetMap tiles with attribution. Those tiles
 are intended for normal interactive use, not bulk/offline prefetching. A
@@ -244,11 +284,11 @@ field/step selection but not server-side geographic cropping, and indexed
 10u/10v retrieval has not yet been implemented in this application. No fallback
 or other model is presented as ECMWF data.
 
-Ordered waypoint editing and persistence are available now, while route
-calculation remains intentionally limited to a direct two-waypoint plan.
-Sequential calculation across intermediate waypoints and optimized multi-leg
-rendering are deferred; remove intermediate waypoints to calculate a direct
-route with the existing native engine.
+Multi-point results depend on the forecast available when each leg was
+calculated. A sailed line is historical planning context, not a recorded vessel
+track, and a stationary stopover is a schedule representation rather than
+evidence that the vessel remained at that exact coordinate. Blocked or
+out-of-window legs intentionally show only itinerary guides and status.
 
 Saildocs is not used as an application API: it is an asynchronous email service
 for bandwidth-constrained users rather than a reliable regional download

--- a/src/Navtool.App/Models/RouteMapSelection.cs
+++ b/src/Navtool.App/Models/RouteMapSelection.cs
@@ -8,13 +8,50 @@ public enum RouteHitKind
     RoutePoint
 }
 
-public sealed record RouteMapSelection(
-    RouteResult Route,
-    int PointIndex,
-    RoutePoint Point,
-    RouteHitKind HitKind,
-    double DistancePixels)
+public sealed record RouteMapSelection
 {
+    public RouteMapSelection(
+        RouteLegVisualization leg,
+        int pointIndex,
+        RoutePoint point,
+        RouteHitKind hitKind,
+        double distancePixels)
+        : this(leg.Route!, pointIndex, point, hitKind, distancePixels)
+    {
+        Leg = leg;
+    }
+
+    public RouteMapSelection(
+        RouteResult route,
+        int pointIndex,
+        RoutePoint point,
+        RouteHitKind hitKind,
+        double distancePixels)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        ArgumentNullException.ThrowIfNull(point);
+        Route = route;
+        PointIndex = pointIndex;
+        Point = point;
+        HitKind = hitKind;
+        DistancePixels = distancePixels;
+    }
+
+    public RouteLegVisualization? Leg { get; }
+
+    public RouteVisualizationKey? Key => Leg?.Key;
+
+    public RouteResult Route { get; }
+
+    public int PointIndex { get; }
+
+    public RoutePoint Point { get; }
+
+    public RouteHitKind HitKind { get; }
+
+    public double DistancePixels { get; }
+
     public DateTimeOffset TimelineTimestamp => Point.Timestamp;
+
     public Coordinate FocusCoordinate => Point.Location;
 }

--- a/src/Navtool.App/Services/RouteHitTester.cs
+++ b/src/Navtool.App/Services/RouteHitTester.cs
@@ -6,6 +6,28 @@ namespace Navtool.App.Services;
 public static class RouteHitTester
 {
     public static RouteMapSelection? FindNearest(
+        IEnumerable<RouteLegVisualization> legs,
+        Func<RouteLegVisualization, IReadOnlyList<ScreenPoint>> projectToScreen,
+        ScreenPoint click,
+        double routeTolerancePixels = 10,
+        double pointTolerancePixels = 14)
+    {
+        ArgumentNullException.ThrowIfNull(legs);
+        ArgumentNullException.ThrowIfNull(projectToScreen);
+        ValidateTolerance(routeTolerancePixels, nameof(routeTolerancePixels));
+        ValidateTolerance(pointTolerancePixels, nameof(pointTolerancePixels));
+
+        var projected = legs
+            .Where(leg => leg.HasOptimizedGeometry)
+            .Select(leg => new ProjectedLeg(
+                leg,
+                ValidateProjectedPoints(leg.Route!, projectToScreen(leg))))
+            .ToArray();
+        var pointHit = FindNearestLegPoint(projected, click, pointTolerancePixels);
+        return pointHit ?? FindNearestLegSegment(projected, click, routeTolerancePixels);
+    }
+
+    public static RouteMapSelection? FindNearest(
         IEnumerable<RouteResult> routes,
         Func<Coordinate, ScreenPoint> projectToScreen,
         ScreenPoint click,
@@ -140,6 +162,85 @@ public static class RouteHitTester
         return nearest;
     }
 
+    private static RouteMapSelection? FindNearestLegPoint(
+        IEnumerable<ProjectedLeg> legs,
+        ScreenPoint click,
+        double tolerance)
+    {
+        if (!IsFinite(click))
+        {
+            return null;
+        }
+
+        RouteMapSelection? nearest = null;
+        foreach (var leg in legs)
+        {
+            for (var index = 0; index < leg.Points.Length; index++)
+            {
+                if (!IsFinite(leg.Points[index]))
+                {
+                    continue;
+                }
+
+                var distance = click.DistanceTo(leg.Points[index]);
+                if (distance <= tolerance && (nearest is null || distance < nearest.DistancePixels))
+                {
+                    nearest = new RouteMapSelection(
+                        leg.Leg,
+                        index,
+                        leg.Leg.Route!.Points[index],
+                        RouteHitKind.RoutePoint,
+                        distance);
+                }
+            }
+        }
+
+        return nearest;
+    }
+
+    private static RouteMapSelection? FindNearestLegSegment(
+        IEnumerable<ProjectedLeg> legs,
+        ScreenPoint click,
+        double tolerance)
+    {
+        if (!IsFinite(click))
+        {
+            return null;
+        }
+
+        RouteMapSelection? nearest = null;
+        foreach (var leg in legs)
+        {
+            for (var index = 1; index < leg.Points.Length; index++)
+            {
+                if (!IsFinite(leg.Points[index - 1]) || !IsFinite(leg.Points[index]))
+                {
+                    continue;
+                }
+
+                var distance = DistanceToSegment(click, leg.Points[index - 1], leg.Points[index]);
+                if (!double.IsFinite(distance) ||
+                    distance > tolerance ||
+                    (nearest is not null && distance >= nearest.DistancePixels))
+                {
+                    continue;
+                }
+
+                var pointIndex = click.DistanceTo(leg.Points[index - 1]) <= click.DistanceTo(leg.Points[index])
+                    ? index - 1
+                    : index;
+                nearest = new RouteMapSelection(
+                    leg.Leg,
+                    pointIndex,
+                    leg.Leg.Route!.Points[pointIndex],
+                    RouteHitKind.Route,
+                    distance);
+            }
+        }
+
+        return nearest;
+    }
+
     private static RouteMapSelection CreateSelection(
         RouteResult route,
         int pointIndex,
@@ -177,4 +278,6 @@ public static class RouteHitTester
         double.IsFinite(point.X) && double.IsFinite(point.Y);
 
     private sealed record ProjectedRoute(RouteResult Route, ScreenPoint[] Points);
+
+    private sealed record ProjectedLeg(RouteLegVisualization Leg, ScreenPoint[] Points);
 }

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -29,8 +29,8 @@ public sealed class RouteMapLayers
     public const float DestinationFrontOpacity = 0.92f;
     private const int IsochroneSmoothingIterations = 2;
 
-    private readonly MemoryLayer _noaaRoutes = CreateRouteLayer("NOAA GFS routes", NoaaColor);
-    private readonly MemoryLayer _ecmwfRoutes = CreateRouteLayer("ECMWF IFS routes", EcmwfColor);
+    private readonly MemoryLayer _noaaRoutes = CreateRouteLayer("NOAA GFS routes");
+    private readonly MemoryLayer _ecmwfRoutes = CreateRouteLayer("ECMWF IFS routes");
     private readonly MemoryLayer _noaaHistoricalFronts = CreateHistoricalFrontLayer("NOAA GFS isochrone fronts");
     private readonly MemoryLayer _ecmwfHistoricalFronts = CreateHistoricalFrontLayer("ECMWF IFS isochrone fronts");
     private readonly MemoryLayer _noaaDestinationFront = CreateDestinationFrontLayer("NOAA GFS latest isochrone front");
@@ -82,6 +82,11 @@ public sealed class RouteMapLayers
 
     public IReadOnlyList<RouteResult> Routes { get; private set; } = Array.Empty<RouteResult>();
 
+    public IReadOnlyList<RouteLegVisualization> RouteLegs { get; private set; } =
+        Array.Empty<RouteLegVisualization>();
+
+    public RouteVisualizationKey? SelectedRouteKey { get; private set; }
+
     public int WeatherCellCount { get; private set; }
 
     public int WaypointMarkerCount => _waypointMarkers.Features.Count();
@@ -108,13 +113,43 @@ public sealed class RouteMapLayers
     {
         ArgumentNullException.ThrowIfNull(routes);
         Routes = routes.ToArray();
+        RouteLegs = Array.Empty<RouteLegVisualization>();
+        SelectedRouteKey = null;
 
-        _noaaRoutes.Features = CreateRouteFeatures(Routes.Where(route => route.Model == ForecastModel.NoaaGfs));
-        _ecmwfRoutes.Features = CreateRouteFeatures(Routes.Where(route => route.Model == ForecastModel.EcmwfIfs));
+        _noaaRoutes.Features = CreateRouteFeatures(
+            Routes.Where(route => route.Model == ForecastModel.NoaaGfs),
+            NoaaColor);
+        _ecmwfRoutes.Features = CreateRouteFeatures(
+            Routes.Where(route => route.Model == ForecastModel.EcmwfIfs),
+            EcmwfColor);
         _noaaRoutes.FeaturesWereModified();
         _ecmwfRoutes.FeaturesWereModified();
         Map.Refresh(ChangeType.Discrete);
     }
+
+    public void SetRouteLegs(
+        IEnumerable<RouteLegVisualization> legs,
+        RouteVisualizationKey? selectedKey = null)
+    {
+        ArgumentNullException.ThrowIfNull(legs);
+        RouteLegs = legs.Where(leg => leg.HasOptimizedGeometry).ToArray();
+        Routes = RouteLegs.Select(leg => leg.Route!).ToArray();
+        SelectedRouteKey = selectedKey;
+        _noaaRoutes.Features = CreateRouteFeatures(
+            RouteLegs.Where(leg => leg.Key.Model == ForecastModel.NoaaGfs),
+            NoaaColor,
+            selectedKey);
+        _ecmwfRoutes.Features = CreateRouteFeatures(
+            RouteLegs.Where(leg => leg.Key.Model == ForecastModel.EcmwfIfs),
+            EcmwfColor,
+            selectedKey);
+        _noaaRoutes.FeaturesWereModified();
+        _ecmwfRoutes.FeaturesWereModified();
+        Map.Refresh(ChangeType.Discrete);
+    }
+
+    public void SelectRouteLeg(RouteVisualizationKey? key) =>
+        SetRouteLegs(RouteLegs, key);
 
     public void SetWaypoints(IEnumerable<WaypointMapMarker> waypoints)
     {
@@ -146,10 +181,19 @@ public sealed class RouteMapLayers
 
     public void FitRoutes()
     {
-        var projected = Routes
-            .SelectMany(route => MapProjection.ToContinuousMapPoints(
-                route.Points.Select(point => point.Location)))
+        var projected = Enum.GetValues<ForecastModel>()
+            .SelectMany(model => ProjectRouteLegs(
+                RouteLegs.Where(leg => leg.Key.Model == model)))
+            .SelectMany(item => item.Points)
             .ToArray();
+        if (projected.Length == 0)
+        {
+            projected = Routes
+                .SelectMany(route => MapProjection.ToContinuousMapPoints(
+                    route.Points.Select(point => point.Location)))
+                .ToArray();
+        }
+
         if (projected.Length == 0)
         {
             return;
@@ -162,6 +206,37 @@ public sealed class RouteMapLayers
             projected.Max(point => point.Y));
         Map.Navigator.ZoomToBox(extent.Grow(
             Math.Max(extent.Width, extent.Height) * 0.08 + 1_000));
+    }
+
+    public void FitRouteLeg(RouteVisualizationKey key)
+    {
+        var projected = ProjectRouteLegs(
+                RouteLegs.Where(leg => leg.Key.Model == key.Model))
+            .SingleOrDefault(item => item.Leg.Key == key)
+            ?.Points;
+        if (projected is null || projected.Count == 0)
+        {
+            return;
+        }
+
+        var extent = new MRect(
+            projected.Min(point => point.X),
+            projected.Min(point => point.Y),
+            projected.Max(point => point.X),
+            projected.Max(point => point.Y));
+        Map.Navigator.ZoomToBox(extent.Grow(
+            Math.Max(extent.Width, extent.Height) * 0.12 + 1_000));
+    }
+
+    public MPoint? GetProjectedRoutePoint(RouteVisualizationKey key, int pointIndex)
+    {
+        var projected = ProjectRouteLegs(
+                RouteLegs.Where(leg => leg.Key.Model == key.Model))
+            .SingleOrDefault(item => item.Leg.Key == key)
+            ?.Points;
+        return projected is not null && pointIndex >= 0 && pointIndex < projected.Count
+            ? projected[pointIndex]
+            : null;
     }
 
     public void AddCalculationSnapshot(
@@ -237,16 +312,10 @@ public sealed class RouteMapLayers
         Map.Refresh(ChangeType.Discrete);
     }
 
-    private static MemoryLayer CreateRouteLayer(string name, MapsuiColor color) =>
+    private static MemoryLayer CreateRouteLayer(string name) =>
         new(name)
         {
-            Style = new VectorStyle
-            {
-                Line = new Pen(color, 4)
-                {
-                    PenStrokeCap = PenStrokeCap.Round
-                }
-            }
+            Style = null
         };
 
     private static IFeature CreateWaypointMarker(WaypointMapMarker marker)
@@ -365,11 +434,85 @@ public sealed class RouteMapLayers
             }
         };
 
-    private static IEnumerable<IFeature> CreateRouteFeatures(IEnumerable<RouteResult> routes) =>
+    private static IEnumerable<IFeature> CreateRouteFeatures(
+        IEnumerable<RouteResult> routes,
+        MapsuiColor color) =>
         routes
-            .Select(CreateRouteFeature)
+            .Select(route =>
+            {
+                var feature = CreateRouteFeature(route);
+                if (feature is not null)
+                {
+                    feature.Styles.Add(CreateRouteStyle(color, 4, 0.92f));
+                }
+
+                return feature;
+            })
             .OfType<IFeature>()
             .ToArray();
+
+    private static IEnumerable<IFeature> CreateRouteFeatures(
+        IEnumerable<RouteLegVisualization> legs,
+        MapsuiColor color,
+        RouteVisualizationKey? selectedKey) =>
+        ProjectRouteLegs(legs)
+            .Select(projected =>
+            {
+                var leg = projected.Leg;
+                var feature = CreateRouteFeature(projected.Points, leg);
+                if (feature is null)
+                {
+                    return null;
+                }
+
+                var isSelected = selectedKey == leg.Key;
+                feature.Styles.Add(CreateRouteStyle(
+                    color,
+                    isSelected ? 6 : selectedKey is null ? 4 : 2.25,
+                    isSelected ? 1f : selectedKey is null ? 0.92f : 0.3f));
+                return feature;
+            })
+            .OfType<IFeature>()
+            .ToArray();
+
+    private static IReadOnlyList<ProjectedRouteLeg> ProjectRouteLegs(
+        IEnumerable<RouteLegVisualization> legs)
+    {
+        var projected = new List<ProjectedRouteLeg>();
+        double? referenceX = null;
+        foreach (var leg in legs
+                     .OrderBy(item => item.LegIndex)
+                     .ThenBy(item => item.Route!.Request.DepartureTime))
+        {
+            var points = referenceX is { } reference
+                ? MapProjection.ToContinuousMapPointsNear(
+                    leg.Route!.Points.Select(point => point.Location),
+                    reference)
+                : MapProjection.ToContinuousMapPoints(
+                    leg.Route!.Points.Select(point => point.Location));
+            if (points.Count > 0)
+            {
+                referenceX = points[^1].X;
+            }
+
+            projected.Add(new ProjectedRouteLeg(leg, points));
+        }
+
+        return projected;
+    }
+
+    private static VectorStyle CreateRouteStyle(
+        MapsuiColor color,
+        double width,
+        float opacity) =>
+        new()
+        {
+            Line = new Pen(color, width)
+            {
+                PenStrokeCap = PenStrokeCap.Round
+            },
+            Opacity = opacity
+        };
 
     private static IFeature? CreateRouteFeature(RouteResult route) =>
         CreateRouteFeature(route.Points, route);
@@ -392,6 +535,27 @@ public sealed class RouteMapLayers
         feature.Data = data;
         return feature;
     }
+
+    private static IFeature? CreateRouteFeature(
+        IReadOnlyList<MPoint> points,
+        object data)
+    {
+        if (points.Count < 2)
+        {
+            return null;
+        }
+
+        return new GeometryFeature(new LineString(points
+            .Select(point => new NtsCoordinate(point.X, point.Y))
+            .ToArray()))
+        {
+            Data = data
+        };
+    }
+
+    private sealed record ProjectedRouteLeg(
+        RouteLegVisualization Leg,
+        IReadOnlyList<MPoint> Points);
 
     private static IEnumerable<IFeature> CreateIsochroneFrontFeatures(
         RouteCalculationSnapshot snapshot)

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -1008,6 +1008,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         RouteLegOutcomeState.Blocked => "blocked",
         RouteLegOutcomeState.OutsideForecastWindow => "outside window",
         RouteLegOutcomeState.Invalidated => "stale",
+        RouteLegOutcomeState.Pending => "pending",
         _ => "not calculated"
     };
 

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -119,13 +119,15 @@ public sealed partial class RouteLegEditorItemViewModel : ViewModelBase
         RouteLegId id,
         int index,
         string fromName,
-        string toName)
+        string toName,
+        string outcomeStatus)
     {
         _owner = owner;
         Id = id;
         Index = index;
         FromName = fromName;
         ToName = toName;
+        OutcomeStatus = outcomeStatus;
     }
 
     public RouteLegId Id { get; }
@@ -138,6 +140,8 @@ public sealed partial class RouteLegEditorItemViewModel : ViewModelBase
 
     public string Label => $"Leg {Index + 1}: {FromName} \u2192 {ToName}";
 
+    public string OutcomeStatus { get; }
+
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(MarkSailedCommand))]
     [NotifyCanExecuteChangedFor(nameof(UnmarkSailedCommand))]
@@ -148,7 +152,13 @@ public sealed partial class RouteLegEditorItemViewModel : ViewModelBase
     [NotifyCanExecuteChangedFor(nameof(MakeActiveCommand))]
     private bool _isActive;
 
+    [ObservableProperty]
+    private bool _isSelected;
+
     public string StatusLabel => IsSailed ? "Sailed" : IsActive ? "Active" : "Upcoming";
+
+    [RelayCommand]
+    private void Select() => _owner.SelectLeg(Id);
 
     [RelayCommand(CanExecute = nameof(CanMarkSailed))]
     private void MarkSailed() => _owner.MarkLegSailed(Id);
@@ -227,7 +237,11 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
 
     public event EventHandler? CurrentPositionPlacementStarted;
 
+    public event EventHandler<RouteLegId>? LegSelected;
+
     public ObservableCollection<RouteLegEditorItemViewModel> Legs { get; } = [];
+
+    public RoutePlan? CurrentPlan => _plan;
 
     public Coordinate? Start => Waypoints.FirstOrDefault()?.Coordinate;
 
@@ -398,6 +412,16 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         {
             CalculationRevision++;
             MarkChanged();
+        }
+    }
+
+    internal void SelectLeg(RouteLegId legId) => LegSelected?.Invoke(this, legId);
+
+    public void SetSelectedLeg(RouteLegId? legId)
+    {
+        foreach (var leg in Legs)
+        {
+            leg.IsSelected = leg.Id == legId;
         }
     }
 
@@ -949,13 +973,43 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         {
             var from = planForLegs.Waypoints.Single(waypoint => waypoint.Id == leg.FromWaypointId);
             var to = planForLegs.Waypoints.Single(waypoint => waypoint.Id == leg.ToWaypointId);
-            Legs.Add(new RouteLegEditorItemViewModel(this, leg.Id, leg.Index, from.Name, to.Name)
+            var outcomes = planForLegs.Results
+                .Select(result =>
+                {
+                    var outcome = result.Legs.Single(item => item.LegId == leg.Id);
+                    return $"{ModelShortName(result.Model)} {OutcomeStatusName(outcome)}";
+                })
+                .ToArray();
+            Legs.Add(new RouteLegEditorItemViewModel(
+                this,
+                leg.Id,
+                leg.Index,
+                from.Name,
+                to.Name,
+                outcomes.Length == 0 ? "not calculated" : string.Join(" · ", outcomes))
             {
                 IsSailed = planForLegs.SailedLegIds.Contains(leg.Id),
                 IsActive = leg.Index == activeIndex
             });
         }
+
     }
+
+    private static string ModelShortName(ForecastModel model) =>
+        model == ForecastModel.NoaaGfs ? "NOAA" : "ECMWF";
+
+    private static string OutcomeStatusName(RouteLegResult outcome) => outcome.State switch
+    {
+        RouteLegOutcomeState.Succeeded
+            when outcome.Reason == RouteLegOutcomeReason.ForecastExhausted => "forecast-limited",
+        RouteLegOutcomeState.Succeeded => "complete",
+        RouteLegOutcomeState.Failed => "failed",
+        RouteLegOutcomeState.Cancelled => "cancelled",
+        RouteLegOutcomeState.Blocked => "blocked",
+        RouteLegOutcomeState.OutsideForecastWindow => "outside window",
+        RouteLegOutcomeState.Invalidated => "stale",
+        _ => "not calculated"
+    };
 
     private void NotifyCurrentPositionChanged()
     {

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -2169,6 +2169,11 @@ public partial class MainViewModel : ViewModelBase
         var candidates = _visualizationLegs.Where(leg => leg.Key.LegId == legId).ToArray();
         if (candidates.Length == 0)
         {
+            SelectedRoutePoint = null;
+            SelectedLeg = null;
+            _selectedStopoverLabel = null;
+            _mapLayers.SelectRouteLeg(null);
+            UpdateWeatherAvailability();
             Itinerary.SetSelectedLeg(legId);
             StatusMessage = "This leg has not been calculated by any forecast model.";
             return;

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -2199,6 +2199,7 @@ public partial class MainViewModel : ViewModelBase
         }
 
         SelectLegGeometry(target.Key);
+        _selectedStopoverLabel = null;
         if (target.Route is { } route)
         {
             SetTimelineUtc(route.Request.DepartureTime);
@@ -2212,8 +2213,9 @@ public partial class MainViewModel : ViewModelBase
         else
         {
             SelectedRoutePoint = null;
-            UpdateWeatherAvailability();
         }
+
+        UpdateWeatherAvailability();
     }
 
     private void OnItineraryChanged(object? sender, EventArgs e)

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -48,7 +48,7 @@ public partial class MainViewModel : ViewModelBase
     private readonly TimeZoneInfo _localTimeZone;
     private readonly ILogger<MainViewModel> _logger;
     private readonly Dictionary<ForecastModel, double> _modelProgress = new();
-    private readonly Dictionary<ForecastModel, ForecastAcquisition> _acquisitions = new();
+    private readonly Dictionary<ForecastModel, ImmutableArray<ForecastAcquisition>> _acquisitions = new();
     private readonly object _progressGate = new();
     private CancellationTokenSource? _calculationCancellation;
     private CancellationTokenSource? _weatherCancellation;
@@ -60,6 +60,8 @@ public partial class MainViewModel : ViewModelBase
     private long _activeCalculationRevision;
     private long _weatherGeneration;
     private bool _updatingTimelinePosition;
+    private ImmutableArray<RouteLegVisualization> _visualizationLegs = [];
+    private string? _selectedStopoverLabel;
 
     [ObservableProperty]
     private DateTimeOffset? _departureDate = DateTimeOffset.Now.Date;
@@ -129,6 +131,9 @@ public partial class MainViewModel : ViewModelBase
     private RouteMapSelection? _selectedRoutePoint;
 
     [ObservableProperty]
+    private RouteLegVisualization? _selectedLeg;
+
+    [ObservableProperty]
     private double _timelinePosition;
 
     [ObservableProperty]
@@ -141,6 +146,9 @@ public partial class MainViewModel : ViewModelBase
 
     [ObservableProperty]
     private ForecastModel? _activeWeatherModel;
+
+    [ObservableProperty]
+    private ForecastModel? _activeRouteModel;
 
     [ObservableProperty]
     private bool _hasNoaaWeather;
@@ -258,6 +266,7 @@ public partial class MainViewModel : ViewModelBase
         Itinerary.ItineraryChanged += OnItineraryChanged;
         Itinerary.MapPlacementStarted += OnMapPlacementStarted;
         Itinerary.CurrentPositionPlacementStarted += OnCurrentPositionPlacementStarted;
+        Itinerary.LegSelected += OnLegSelected;
 
         Map = new Map
         {
@@ -330,9 +339,11 @@ public partial class MainViewModel : ViewModelBase
         _ => "Pan and zoom, or select an endpoint tool"
     };
 
-    public string SelectedRouteTitle => SelectedRoutePoint is null
+    public string SelectedRouteTitle => SelectedLeg is null && SelectedRoutePoint is null
         ? "No route point selected"
-        : $"{ModelName(SelectedRoutePoint.Route.Model)} · point {SelectedRoutePoint.PointIndex + 1}";
+        : (SelectedLeg ?? SelectedRoutePoint!.Leg) is { } leg
+            ? $"Leg {leg.LegIndex + 1}: {leg.From.Name} → {leg.To.Name} · {ModelName(leg.Key.Model)}"
+            : $"{ModelName(SelectedRoutePoint!.Route.Model)} · point {SelectedRoutePoint.PointIndex + 1}";
 
     public string SelectedRouteDetails
     {
@@ -340,18 +351,26 @@ public partial class MainViewModel : ViewModelBase
         {
             if (SelectedRoutePoint is null)
             {
-                return "Click near a displayed route to inspect its nearest point.";
+                return SelectedLeg is null
+                    ? "Select an itinerary leg or click near a displayed route."
+                    : FormatSelectedLegDetails(SelectedLeg);
             }
 
             var selection = SelectedRoutePoint;
             var point = selection.Point;
-            _acquisitions.TryGetValue(selection.Route.Model, out var acquisition);
+            var acquisition = FindCompatibleAcquisition(selection.Leg, selection.Route.Model);
             var forecast = acquisition is null
-                ? "forecast metadata unavailable"
+                ? "weather unavailable (saved geometry does not include forecast binaries)"
                 : $"run {acquisition.Run.InitializedAt:yyyy-MM-dd HH:mm} UTC · " +
                   $"{acquisition.Source} · {acquisition.Artifact.Path}";
-            return $"{point.Timestamp:yyyy-MM-dd HH:mm:ss} UTC\n" +
-                   $"{point.Location.Latitude:0.0000}°, {point.Location.Longitude:0.0000}° · " +
+            var legDetails = selection.Leg is null
+                ? string.Empty
+                : FormatSelectedLegDetails(selection.Leg);
+            var stopover = _selectedStopoverLabel is null
+                ? string.Empty
+                : $"{_selectedStopoverLabel} · stationary hold\n";
+            return $"{legDetails}{stopover}{point.Timestamp:yyyy-MM-dd HH:mm:ss} UTC\n" +
+                  $"{point.Location.Latitude:0.0000}°, {point.Location.Longitude:0.0000}° · " +
                    $"heading {point.HeadingDegrees:0}° · boat {point.BoatSpeedKnots:0.0} kt · " +
                    $"{FormatApparentWind(point)}\n" +
                    $"true wind {point.TrueWindSpeedKnots:0.0} kt @ {point.TrueWindDirectionDegrees:0}° · " +
@@ -365,7 +384,9 @@ public partial class MainViewModel : ViewModelBase
 
     public string TimelineDisplay => SelectedTimelineUtc is null
         ? "Timeline unavailable"
-        : $"{SelectedTimelineUtc:yyyy-MM-dd HH:mm:ss} UTC";
+        : $"{(ActiveRouteModel is { } model ? $"{ModelShortName(model)} · " : string.Empty)}" +
+          $"{SelectedTimelineUtc:yyyy-MM-dd HH:mm:ss} UTC" +
+          $"{(_selectedStopoverLabel is null ? string.Empty : $" · {_selectedStopoverLabel}")}";
 
     public string ActiveWeatherDisplay => ActiveWeatherModel is null
         ? "No weather overlay"
@@ -375,11 +396,23 @@ public partial class MainViewModel : ViewModelBase
 
     public bool IsEcmwfWeatherActive => ActiveWeatherModel == ForecastModel.EcmwfIfs;
 
+    public bool IsNoaaRouteActive => ActiveRouteModel == ForecastModel.NoaaGfs;
+
+    public bool IsEcmwfRouteActive => ActiveRouteModel == ForecastModel.EcmwfIfs;
+
+    public bool HasNoaaRoutes => _visualizationLegs.Any(leg =>
+        leg.Key.Model == ForecastModel.NoaaGfs && leg.HasOptimizedGeometry);
+
+    public bool HasEcmwfRoutes => _visualizationLegs.Any(leg =>
+        leg.Key.Model == ForecastModel.EcmwfIfs && leg.HasOptimizedGeometry);
+
     public int WeatherCellCount => _mapLayers.WeatherCellCount;
 
     public int SuccessfulRouteCount => _mapLayers.Routes.Count;
 
     public IReadOnlyList<RouteResult> SuccessfulRoutes => _mapLayers.Routes;
+
+    public IReadOnlyList<RouteLegVisualization> VisualizedRouteLegs => _visualizationLegs;
 
     partial void OnWarningMessageChanged(string? value) =>
         OnPropertyChanged(nameof(HasWarning));
@@ -414,10 +447,14 @@ public partial class MainViewModel : ViewModelBase
     public void DisplayRoutes(IEnumerable<RouteResult> routes)
     {
         var successful = routes.ToArray();
-        _mapLayers.SetRoutes(successful);
+        _visualizationLegs = CreateTransientVisualizations(successful);
+        _mapLayers.SetRouteLegs(_visualizationLegs);
         _mapLayers.FitRoutes();
         OnPropertyChanged(nameof(SuccessfulRouteCount));
-        BuildTimeline(successful);
+        OnPropertyChanged(nameof(VisualizedRouteLegs));
+        NotifyRouteModelAvailability();
+        ActiveRouteModel = successful.FirstOrDefault()?.Model;
+        BuildTimeline(ActiveRouteModel);
         UpdateLandAvoidanceWarning(successful);
         StatusMessage = successful.Length == 0
             ? "No routes are currently displayed."
@@ -477,6 +514,25 @@ public partial class MainViewModel : ViewModelBase
     {
         ArgumentNullException.ThrowIfNull(worldPosition);
         var viewport = Map.Navigator.Viewport;
+        if (_mapLayers.RouteLegs.Count > 0)
+        {
+            return RouteHitTester.FindNearest(
+                _mapLayers.RouteLegs,
+                (RouteLegVisualization leg) => MapProjection
+                    .ToContinuousMapPointsNear(
+                        leg.Route!.Points.Select(point => point.Location),
+                        worldPosition.X)
+                    .Select(point =>
+                    {
+                        var projected = viewport.WorldToScreen(point);
+                        return new ScreenPoint(projected.X, projected.Y);
+                    })
+                    .ToArray(),
+                screenPosition,
+                RouteHitTolerancePixels,
+                RoutePointHitTolerancePixels);
+        }
+
         return RouteHitTester.FindNearest(
             _mapLayers.Routes,
             (RouteResult route) => MapProjection
@@ -517,18 +573,20 @@ public partial class MainViewModel : ViewModelBase
     public void SelectRoutePoint(RouteMapSelection selection, bool focus = true)
     {
         ArgumentNullException.ThrowIfNull(selection);
-        if (_timeline is not null)
+        if (selection.Leg is { } leg)
+        {
+            ActiveRouteModel = leg.Key.Model;
+            SelectLegGeometry(leg.Key);
+        }
+
+        if (_timeline is not null && _timeline.Model == selection.Route.Model)
         {
             SetTimelineUtc(selection.TimelineTimestamp);
         }
 
-        if (_acquisitions.ContainsKey(selection.Route.Model))
-        {
-            ActiveWeatherModel = selection.Route.Model;
-        }
-
         SelectedRoutePoint = selection;
-        ApplyTimelineSelection(selection.Route.Model);
+        _selectedStopoverLabel = null;
+        UpdateWeatherAvailability();
         if (focus)
         {
             FocusSelectedRoutePoint();
@@ -923,11 +981,22 @@ public partial class MainViewModel : ViewModelBase
             resolution = 10_000;
         }
 
-        Map.Navigator.CenterOnAndZoomTo(
-            MapProjection.ToContinuousMapPoints(
-                SelectedRoutePoint.Route.Points.Select(point => point.Location))[
-                SelectedRoutePoint.PointIndex],
-            Math.Min(resolution, 10_000));
+        var projected = SelectedRoutePoint.Key is { } key
+            ? _mapLayers.GetProjectedRoutePoint(key, SelectedRoutePoint.PointIndex)
+            : null;
+        projected ??= MapProjection.ToContinuousMapPoints(
+            SelectedRoutePoint.Route.Points.Select(point => point.Location))[
+            SelectedRoutePoint.PointIndex];
+        Map.Navigator.CenterOnAndZoomTo(projected, Math.Min(resolution, 10_000));
+    }
+
+    [RelayCommand]
+    private void FocusSelectedLeg()
+    {
+        if (SelectedRoutePoint?.Key is { } key)
+        {
+            _mapLayers.FitRouteLeg(key);
+        }
     }
 
     [RelayCommand(CanExecute = nameof(CanMovePrevious))]
@@ -970,6 +1039,12 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(HasEcmwfWeather))]
     private void ActivateEcmwfWeather() => ActiveWeatherModel = ForecastModel.EcmwfIfs;
 
+    [RelayCommand(CanExecute = nameof(HasNoaaRoutes))]
+    private void ActivateNoaaRoute() => ActiveRouteModel = ForecastModel.NoaaGfs;
+
+    [RelayCommand(CanExecute = nameof(HasEcmwfRoutes))]
+    private void ActivateEcmwfRoute() => ActiveRouteModel = ForecastModel.EcmwfIfs;
+
     partial void OnTimelinePositionChanged(double value)
     {
         if (_updatingTimelinePosition || _timeline is null)
@@ -995,8 +1070,34 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsNoaaWeatherActive));
         OnPropertyChanged(nameof(IsEcmwfWeatherActive));
         OnPropertyChanged(nameof(ActiveWeatherDisplay));
-        ApplyTimelineSelection(value);
         RequestWeatherRefreshFromViewport();
+    }
+
+    partial void OnActiveRouteModelChanged(ForecastModel? value)
+    {
+        var selectedLegId = SelectedLeg?.Key.LegId;
+        OnPropertyChanged(nameof(IsNoaaRouteActive));
+        OnPropertyChanged(nameof(IsEcmwfRouteActive));
+        BuildTimeline(value);
+        if (value is { } model)
+        {
+            var sameLeg = selectedLegId is { } legId
+                ? _visualizationLegs.FirstOrDefault(leg =>
+                    leg.Key.Model == model &&
+                    leg.Key.LegId == legId &&
+                    leg.HasOptimizedGeometry)
+                : null;
+            var target = sameLeg ?? _visualizationLegs.FirstOrDefault(leg =>
+                leg.Key.Model == model && leg.HasOptimizedGeometry);
+            if (target is not null)
+            {
+                SelectLegGeometry(target.Key);
+                SetTimelineUtc(target.Route!.Request.DepartureTime);
+                ApplyTimelineSelection();
+            }
+        }
+
+        UpdateWeatherAvailability();
     }
 
     private void ApplyPlanWorkflowResult(RoutePlanRoutingResult result)
@@ -1009,7 +1110,7 @@ public partial class MainViewModel : ViewModelBase
         {
             if (!outcome.Acquisitions.IsEmpty)
             {
-                _acquisitions[outcome.Model] = outcome.Acquisitions[^1];
+                _acquisitions[outcome.Model] = outcome.Acquisitions;
             }
 
             var legStatuses = outcome.Legs.Select((leg, index) =>
@@ -1036,24 +1137,9 @@ public partial class MainViewModel : ViewModelBase
             }
         }
 
-        HasNoaaWeather = _acquisitions.ContainsKey(ForecastModel.NoaaGfs);
-        HasEcmwfWeather = _acquisitions.ContainsKey(ForecastModel.EcmwfIfs);
-        ActiveWeatherModel = HasNoaaWeather
-            ? ForecastModel.NoaaGfs
-            : HasEcmwfWeather
-                ? ForecastModel.EcmwfIfs
-                : null;
-
-        var routes = result.Models
-            .SelectMany(outcome => outcome.Legs)
-            .Where(leg => leg.Route is not null)
-            .Select(leg => leg.Route!)
-            .ToImmutableArray();
-        _mapLayers.SetRoutes(routes);
+        DisplayPlanVisualization(result.Plan, fit: true);
+        var routes = _mapLayers.Routes;
         _displayedRoutePlanId = Itinerary.PlanId;
-        _mapLayers.FitRoutes();
-        OnPropertyChanged(nameof(SuccessfulRouteCount));
-        BuildTimeline(routes);
         ProgressFraction = 1;
         ErrorMessage = failures.Count == 0 ? null : string.Join(Environment.NewLine, failures);
         WarningMessage = warnings.Count == 0 ? null : string.Join(Environment.NewLine, warnings);
@@ -1068,7 +1154,7 @@ public partial class MainViewModel : ViewModelBase
             _ => "No model completed the itinerary."
         };
         OnPropertyChanged(nameof(SelectedRouteDetails));
-        RequestWeatherRefreshFromViewport();
+        UpdateWeatherAvailability();
     }
 
     partial void OnHasNoaaWeatherChanged(bool value) =>
@@ -1106,6 +1192,10 @@ public partial class MainViewModel : ViewModelBase
     {
         if (value is not null)
         {
+            if (value.Leg is not null)
+            {
+                SelectedLeg = value.Leg;
+            }
             StatusMessage = $"{ModelName(value.Route.Model)} route selected at " +
                             $"{value.TimelineTimestamp:HH:mm} UTC.";
         }
@@ -1113,6 +1203,13 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(SelectedRouteTitle));
         OnPropertyChanged(nameof(SelectedRouteDetails));
         RouteSelectionChanged?.Invoke(this, value);
+    }
+
+    partial void OnSelectedLegChanged(RouteLegVisualization? value)
+    {
+        OnPropertyChanged(nameof(SelectedRouteTitle));
+        OnPropertyChanged(nameof(SelectedRouteDetails));
+        Itinerary.SetSelectedLeg(value?.Key.LegId);
     }
 
     private bool TryCreateWorkflowRequest(
@@ -1213,7 +1310,7 @@ public partial class MainViewModel : ViewModelBase
         {
             if (outcome.Acquisition is not null)
             {
-                _acquisitions[outcome.Model] = outcome.Acquisition;
+                _acquisitions[outcome.Model] = [outcome.Acquisition];
             }
 
             if (outcome.Route is not null)
@@ -1279,14 +1376,6 @@ public partial class MainViewModel : ViewModelBase
             }
         }
 
-        HasNoaaWeather = _acquisitions.ContainsKey(ForecastModel.NoaaGfs);
-        HasEcmwfWeather = _acquisitions.ContainsKey(ForecastModel.EcmwfIfs);
-        ActiveWeatherModel = HasNoaaWeather
-            ? ForecastModel.NoaaGfs
-            : HasEcmwfWeather
-                ? ForecastModel.EcmwfIfs
-                : null;
-
         foreach (var outcome in result.Outcomes)
         {
             var reason = outcome.Route is not null
@@ -1314,11 +1403,16 @@ public partial class MainViewModel : ViewModelBase
         }
 
         var routes = recordedRoutes.ToImmutableArray();
-        _mapLayers.SetRoutes(routes);
+        if (Itinerary.CurrentPlan is { } plan)
+        {
+            DisplayPlanVisualization(plan, fit: true);
+            routes = _mapLayers.Routes.ToImmutableArray();
+        }
+        else
+        {
+            DisplayRoutes(routes);
+        }
         _displayedRoutePlanId = Itinerary.PlanId;
-        _mapLayers.FitRoutes();
-        OnPropertyChanged(nameof(SuccessfulRouteCount));
-        BuildTimeline(routes);
         ProgressFraction = 1;
         ErrorMessage = failures.Count == 0 ? null : string.Join(Environment.NewLine, failures);
         WarningMessage = warnings.Count == 0 ? null : string.Join(Environment.NewLine, warnings);
@@ -1335,8 +1429,188 @@ public partial class MainViewModel : ViewModelBase
             _ => "Both model routes are available."
         };
         OnPropertyChanged(nameof(SelectedRouteDetails));
-        RequestWeatherRefreshFromViewport();
+        UpdateWeatherAvailability();
     }
+
+    private void DisplayPlanVisualization(RoutePlan plan, bool fit)
+    {
+        var previousSelection = SelectedLeg?.Key;
+        _visualizationLegs = RoutePlanVisualization.Create(plan)
+            .Select(leg => IsVisualizationCurrent(leg)
+                ? leg
+                : leg with
+                {
+                    State = RouteLegOutcomeState.Invalidated,
+                    Reason = RouteLegOutcomeReason.WaypointCoordinateChanged,
+                    Route = null,
+                    Detail = "The edited waypoint boundaries no longer match this saved geometry."
+                })
+            .ToImmutableArray();
+        var successful = _visualizationLegs.Where(leg => leg.HasOptimizedGeometry).ToArray();
+        var reboundSelection = previousSelection is { } key
+            ? _visualizationLegs.FirstOrDefault(leg => leg.Key == key) ??
+              _visualizationLegs.FirstOrDefault(leg =>
+                  leg.Key.PlanId == key.PlanId &&
+                  leg.Key.LegId == key.LegId &&
+                  leg.Key.Model == key.Model)
+            : null;
+        SelectedLeg = reboundSelection;
+        var selectedKey = reboundSelection?.HasOptimizedGeometry is true
+            ? reboundSelection.Key
+            : (RouteVisualizationKey?)null;
+        _mapLayers.SetRouteLegs(successful, selectedKey);
+        if (fit)
+        {
+            _mapLayers.FitRoutes();
+        }
+
+        OnPropertyChanged(nameof(SuccessfulRouteCount));
+        OnPropertyChanged(nameof(VisualizedRouteLegs));
+        NotifyRouteModelAvailability();
+        var model = ActiveRouteModel is { } active &&
+                    successful.Any(leg => leg.Key.Model == active)
+            ? active
+            : successful.FirstOrDefault(leg => leg.Key.Model == ForecastModel.NoaaGfs)?.Key.Model ??
+              successful.FirstOrDefault()?.Key.Model;
+        if (ActiveRouteModel != model)
+        {
+            ActiveRouteModel = model;
+        }
+        else
+        {
+            BuildTimeline(model);
+        }
+
+        UpdateLandAvoidanceWarning(successful.Select(leg => leg.Route!));
+    }
+
+    private bool IsVisualizationCurrent(RouteLegVisualization leg)
+    {
+        if (leg.IsSailed)
+        {
+            return true;
+        }
+
+        if (leg.Route is not { } route ||
+            leg.LegIndex < 0 ||
+            leg.LegIndex + 1 >= Itinerary.Waypoints.Count ||
+            Itinerary.Waypoints[leg.LegIndex].Coordinate is not { } from ||
+            Itinerary.Waypoints[leg.LegIndex + 1].Coordinate is not { } to)
+        {
+            return leg.Route is null;
+        }
+
+        var validOrigin = route.Request.Origin.IsSameLocation(from) ||
+                          (Itinerary.CurrentPositionCoordinate is { } current &&
+                           route.Request.Origin.IsSameLocation(current));
+        return validOrigin && route.Request.Destination.IsSameLocation(to);
+    }
+
+    private ImmutableArray<RouteLegVisualization> CreateTransientVisualizations(
+        IEnumerable<RouteResult> routes)
+    {
+        var plan = Itinerary.CurrentPlan;
+        var fallbackFrom = new RouteWaypoint("Start", Start ?? new Coordinate(0, 0));
+        var fallbackTo = new RouteWaypoint("Finish", Destination ?? new Coordinate(0, 1));
+        var fallbackLeg = RouteLeg.Create(0, fallbackFrom, fallbackTo);
+        return routes.Select(route =>
+        {
+            var leg = plan?.Legs.FirstOrDefault(candidate =>
+                route.Request.Origin.IsSameLocation(
+                    plan.Waypoints.Single(waypoint => waypoint.Id == candidate.FromWaypointId).Coordinate) &&
+                route.Request.Destination.IsSameLocation(
+                    plan.Waypoints.Single(waypoint => waypoint.Id == candidate.ToWaypointId).Coordinate));
+            var from = leg is null
+                ? fallbackFrom
+                : plan!.Waypoints.Single(waypoint => waypoint.Id == leg.FromWaypointId);
+            var to = leg is null
+                ? fallbackTo
+                : plan!.Waypoints.Single(waypoint => waypoint.Id == leg.ToWaypointId);
+            var legId = leg?.Id ?? fallbackLeg.Id;
+            var sessionId = new RouteCalculationSessionId();
+            return new RouteLegVisualization(
+                new RouteVisualizationKey(
+                    plan?.Id ?? Itinerary.PlanId,
+                    legId,
+                    route.Model,
+                    sessionId,
+                    route.Request.RouteId),
+                leg?.Index ?? 0,
+                from,
+                to,
+                RouteLegOutcomeState.Succeeded,
+                route.IsForecastLimited
+                    ? RouteLegOutcomeReason.ForecastExhausted
+                    : RouteLegOutcomeReason.CalculationSucceeded,
+                route,
+                null,
+                plan?.SailedLegIds.Contains(legId) is true,
+                route.Request.DepartureTime,
+                route.ArrivalTime);
+        }).ToImmutableArray();
+    }
+
+    private void SelectLegGeometry(RouteVisualizationKey key)
+    {
+        var leg = _visualizationLegs.SingleOrDefault(item => item.Key == key);
+        if (leg is null)
+        {
+            return;
+        }
+
+        SelectedLeg = leg;
+        _mapLayers.SelectRouteLeg(leg.HasOptimizedGeometry ? key : null);
+        Itinerary.SetSelectedLeg(leg.Key.LegId);
+    }
+
+    private void NotifyRouteModelAvailability()
+    {
+        OnPropertyChanged(nameof(HasNoaaRoutes));
+        OnPropertyChanged(nameof(HasEcmwfRoutes));
+        ActivateNoaaRouteCommand.NotifyCanExecuteChanged();
+        ActivateEcmwfRouteCommand.NotifyCanExecuteChanged();
+    }
+
+    private string FormatSelectedLegDetails(RouteLegVisualization leg)
+    {
+        var state = VisualizationStatusName(leg);
+        var sailed = leg.IsSailed ? " · sailed history" : string.Empty;
+        var session = $"session {leg.Key.SessionId} · started {leg.SessionStartedAt:yyyy-MM-dd HH:mm} UTC" +
+                      $"{(leg.SessionCompletedAt is { } completed ? $" · saved {completed:yyyy-MM-dd HH:mm} UTC" : string.Empty)}";
+        var outcome = leg.Route is not { } route
+            ? $"{state}{sailed}{(string.IsNullOrWhiteSpace(leg.Detail) ? string.Empty : $" · {leg.Detail}")}"
+            : $"{state}{sailed} · depart {route.Request.DepartureTime:yyyy-MM-dd HH:mm} UTC · " +
+              $"{(route.IsForecastLimited ? "forecast endpoint" : "arrive")} {route.ArrivalTime:yyyy-MM-dd HH:mm} UTC · " +
+              $"{FormatDuration(route.ArrivalTime - route.Request.DepartureTime)} · " +
+              $"{route.Points[^1].CumulativeDistanceNauticalMiles:0.0} NM" +
+              $"{(route.LandAvoidance.HasWarning ? $" · warning: {route.LandAvoidance.Warning}" : string.Empty)}";
+        var comparison = _visualizationLegs
+            .Where(other => other.Key.LegId == leg.Key.LegId && other.Key.Model != leg.Key.Model)
+            .Select(other => $"{ModelShortName(other.Key.Model)} {VisualizationStatusName(other)}" +
+                (other.Route is null ? string.Empty : $" · arrival {other.Route.ArrivalTime:MMM d HH:mm} UTC"))
+            .ToArray();
+        return $"{leg.From.Name} ({FormatCoordinate(leg.From.Coordinate, "unknown")}) → " +
+               $"{leg.To.Name} ({FormatCoordinate(leg.To.Coordinate, "unknown")})\n" +
+               $"{outcome}\n{session}" +
+               $"{(comparison.Length == 0 ? string.Empty : $"\nComparison: {string.Join(" · ", comparison)}")}\n";
+    }
+
+    private static string VisualizationStatusName(RouteLegVisualization leg) =>
+        leg.IsSailed ? "sailed" : leg.State switch
+        {
+            RouteLegOutcomeState.Succeeded
+                when leg.Reason == RouteLegOutcomeReason.ForecastExhausted => "forecast-limited",
+            RouteLegOutcomeState.Succeeded => "complete",
+            RouteLegOutcomeState.Failed => "failed",
+            RouteLegOutcomeState.Cancelled => "cancelled",
+            RouteLegOutcomeState.Blocked => "blocked by prior failure",
+            RouteLegOutcomeState.OutsideForecastWindow => "outside forecast window",
+            RouteLegOutcomeState.Invalidated => "stale",
+            _ => "not calculated"
+        };
+
+    private static string FormatDuration(TimeSpan duration) =>
+        $"{(int)duration.TotalHours}h {duration.Minutes:00}m";
 
     private void UpdateLandAvoidanceWarning(IEnumerable<RouteResult> routes)
     {
@@ -1350,21 +1624,33 @@ public partial class MainViewModel : ViewModelBase
             : string.Join(Environment.NewLine, warnings);
     }
 
-    private void BuildTimeline(IReadOnlyCollection<RouteResult> routes)
+    private void BuildTimeline(ForecastModel? model)
     {
-        if (routes.Count == 0)
+        var legs = model is null
+            ? []
+            : _visualizationLegs
+                .Where(leg => leg.Key.Model == model && leg.HasOptimizedGeometry)
+                .ToArray();
+        if (legs.Length == 0)
         {
             _timeline = null;
             HasTimeline = false;
             SelectedTimelineUtc = null;
             SelectedRoutePoint = null;
+            if (SelectedLeg is { } selected &&
+                !_visualizationLegs.Any(leg => leg.Key == selected.Key))
+            {
+                SelectedLeg = null;
+            }
+            _selectedStopoverLabel = null;
+            OnPropertyChanged(nameof(TimelineDisplay));
             return;
         }
 
-        _timeline = SharedRouteTimeline.Create(routes);
+        _timeline = SharedRouteTimeline.Create(model!.Value, legs);
         HasTimeline = true;
         SetTimelineUtc(_timeline.Start);
-        ApplyTimelineSelection(ActiveWeatherModel ?? routes.First().Model);
+        ApplyTimelineSelection();
     }
 
     private void SetTimelineUtc(DateTimeOffset timestamp)
@@ -1384,30 +1670,28 @@ public partial class MainViewModel : ViewModelBase
         _updatingTimelinePosition = false;
     }
 
-    private void ApplyTimelineSelection(ForecastModel? preferredModel = null)
+    private void ApplyTimelineSelection()
     {
         if (_timeline is null || SelectedTimelineUtc is null)
         {
             return;
         }
 
-        var nearest = _timeline.NearestPoints(SelectedTimelineUtc.Value);
-        var model = preferredModel ??
-                    SelectedRoutePoint?.Route.Model ??
-                    ActiveWeatherModel ??
-                    nearest.Keys.First().Model;
-        var candidate = nearest.Values.FirstOrDefault(selection => selection.Route.Model == model) ??
-                        nearest.Values.First();
-        var route = _mapLayers.Routes.First(item =>
-            item.Request.RouteId == candidate.Route.RouteId &&
-            item.Model == candidate.Route.Model);
-        var pointIndex = route.Points.IndexOf(candidate.Point);
+        var candidate = _timeline.Select(SelectedTimelineUtc.Value);
+        var route = candidate.Leg.Route!;
+        var pointIndex = candidate.IsStopover
+            ? route.Points.Length - 1
+            : route.Points.IndexOf(candidate.Point);
+        _selectedStopoverLabel = candidate.StopoverLabel;
         SelectedRoutePoint = new RouteMapSelection(
-            route,
+            candidate.Leg,
             Math.Max(0, pointIndex),
             candidate.Point,
             RouteHitKind.RoutePoint,
             0);
+        SelectLegGeometry(candidate.Leg.Key);
+        OnPropertyChanged(nameof(TimelineDisplay));
+        UpdateWeatherAvailability();
         RequestWeatherRefreshFromViewport();
     }
 
@@ -1457,7 +1741,7 @@ public partial class MainViewModel : ViewModelBase
         if (_weatherSampler is null ||
             ActiveWeatherModel is not { } model ||
             SelectedTimelineUtc is not { } selected ||
-            !_acquisitions.TryGetValue(model, out var acquisition))
+            FindCompatibleAcquisition(SelectedRoutePoint?.Leg, model) is not { } acquisition)
         {
             if (generation == Volatile.Read(ref _weatherGeneration))
             {
@@ -1535,6 +1819,51 @@ public partial class MainViewModel : ViewModelBase
         cancellation?.Dispose();
         _mapLayers.ClearWeather();
         OnPropertyChanged(nameof(WeatherCellCount));
+    }
+
+    private ForecastAcquisition? FindCompatibleAcquisition(
+        RouteLegVisualization? leg,
+        ForecastModel model)
+    {
+        if (leg?.Route is not { } route ||
+            leg.Key.Model != model ||
+            !_acquisitions.TryGetValue(model, out var acquisitions))
+        {
+            return null;
+        }
+
+        return acquisitions
+            .Where(acquisition =>
+                acquisition.Request.Model == model &&
+                acquisition.Request.From <= route.Request.DepartureTime &&
+                acquisition.Request.Through >= route.ArrivalTime &&
+                acquisition.Request.Bounds.Contains(route.Request.Origin) &&
+                acquisition.Request.Bounds.Contains(route.Request.Destination))
+            .OrderByDescending(acquisition => acquisition.Request.From)
+            .FirstOrDefault();
+    }
+
+    private void UpdateWeatherAvailability()
+    {
+        var selectedLeg = SelectedRoutePoint?.Leg;
+        HasNoaaWeather = FindCompatibleAcquisition(selectedLeg, ForecastModel.NoaaGfs) is not null;
+        HasEcmwfWeather = FindCompatibleAcquisition(selectedLeg, ForecastModel.EcmwfIfs) is not null;
+        var selectedModel = selectedLeg?.Key.Model;
+        var compatible = selectedModel is { } model &&
+                         FindCompatibleAcquisition(selectedLeg, model) is not null;
+        ActiveWeatherModel = compatible ? selectedModel : null;
+        if (!compatible)
+        {
+            CancelWeather();
+            WeatherLayerError = selectedLeg is null
+                ? "Select a calculated leg to view weather."
+                : "Weather is unavailable for this saved leg/model. Route geometry and details remain available.";
+        }
+        else
+        {
+            WeatherLayerError = null;
+            RequestWeatherRefreshFromViewport();
+        }
     }
 
     private bool TryGetVisibleBounds(out GeographicBounds bounds)
@@ -1779,6 +2108,9 @@ public partial class MainViewModel : ViewModelBase
         _ => model.ToString()
     };
 
+    private static string ModelShortName(ForecastModel model) =>
+        model == ForecastModel.NoaaGfs ? "NOAA" : "ECMWF";
+
     private static string FormatApparentWind(RoutePoint point)
     {
         var signedAngle = point.ApparentWindAngleSignedDegrees;
@@ -1832,6 +2164,42 @@ public partial class MainViewModel : ViewModelBase
         NotifyInteractionChanged();
     }
 
+    private void OnLegSelected(object? sender, RouteLegId legId)
+    {
+        var candidates = _visualizationLegs.Where(leg => leg.Key.LegId == legId).ToArray();
+        if (candidates.Length == 0)
+        {
+            Itinerary.SetSelectedLeg(legId);
+            StatusMessage = "This leg has not been calculated by any forecast model.";
+            return;
+        }
+
+        var target = candidates.FirstOrDefault(leg => leg.Key.Model == ActiveRouteModel) ??
+                     candidates.FirstOrDefault(leg => leg.HasOptimizedGeometry) ??
+                     candidates[0];
+        if (target.Key.Model != ActiveRouteModel)
+        {
+            ActiveRouteModel = target.Key.Model;
+        }
+
+        SelectLegGeometry(target.Key);
+        if (target.Route is { } route)
+        {
+            SetTimelineUtc(route.Request.DepartureTime);
+            SelectedRoutePoint = new RouteMapSelection(
+                target,
+                0,
+                route.Points[0],
+                RouteHitKind.RoutePoint,
+                0);
+        }
+        else
+        {
+            SelectedRoutePoint = null;
+            UpdateWeatherAvailability();
+        }
+    }
+
     private void OnItineraryChanged(object? sender, EventArgs e)
     {
         if (IsCalculating &&
@@ -1863,23 +2231,31 @@ public partial class MainViewModel : ViewModelBase
             _interaction.SetDestination(finish);
         }
 
-        if (_mapLayers.Routes.Count > 0 &&
-            (_displayedRoutePlanId != Itinerary.PlanId ||
-             Itinerary.ResultsInvalidated ||
-             Start is null ||
-             Destination is null ||
-             _mapLayers.Routes.Any(route =>
-                 !route.Request.Origin.IsSameLocation(Start.Value) ||
-                 !route.Request.Destination.IsSameLocation(Destination.Value))))
+        if (Itinerary.CurrentPlan is { } plan)
         {
-            _mapLayers.SetRoutes([]);
+            if (_displayedRoutePlanId is { } displayedPlanId && displayedPlanId != plan.Id)
+            {
+                _acquisitions.Clear();
+            }
+
+            DisplayPlanVisualization(plan, fit: _displayedRoutePlanId != plan.Id);
+            _displayedRoutePlanId = plan.Id;
+            UpdateWeatherAvailability();
+        }
+        else if (_mapLayers.Routes.Count > 0 || !_visualizationLegs.IsEmpty)
+        {
+            _visualizationLegs = [];
+            _mapLayers.SetRouteLegs([]);
             _displayedRoutePlanId = null;
-            BuildTimeline([]);
+            BuildTimeline(null);
             _acquisitions.Clear();
             HasNoaaWeather = false;
             HasEcmwfWeather = false;
             ActiveWeatherModel = null;
+            SelectedLeg = null;
             OnPropertyChanged(nameof(SuccessfulRouteCount));
+            OnPropertyChanged(nameof(VisualizedRouteLegs));
+            NotifyRouteModelAvailability();
             LandAvoidanceWarning = null;
         }
 

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -993,9 +993,10 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void FocusSelectedLeg()
     {
-        if (SelectedRoutePoint?.Key is { } key)
+        var key = SelectedLeg?.Key ?? SelectedRoutePoint?.Key;
+        if (key is not null)
         {
-            _mapLayers.FitRouteLeg(key);
+            _mapLayers.FitRouteLeg(key.Value);
         }
     }
 

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -1607,6 +1607,7 @@ public partial class MainViewModel : ViewModelBase
             RouteLegOutcomeState.Blocked => "blocked by prior failure",
             RouteLegOutcomeState.OutsideForecastWindow => "outside forecast window",
             RouteLegOutcomeState.Invalidated => "stale",
+            RouteLegOutcomeState.Pending => "pending",
             _ => "not calculated"
         };
 

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -1559,6 +1559,11 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        if (ReferenceEquals(SelectedLeg, leg))
+        {
+            return;
+        }
+
         SelectedLeg = leg;
         _mapLayers.SelectRouteLeg(leg.HasOptimizedGeometry ? key : null);
         Itinerary.SetSelectedLeg(leg.Key.LegId);
@@ -1694,7 +1699,6 @@ public partial class MainViewModel : ViewModelBase
         SelectLegGeometry(candidate.Leg.Key);
         OnPropertyChanged(nameof(TimelineDisplay));
         UpdateWeatherAvailability();
-        RequestWeatherRefreshFromViewport();
     }
 
     private void RequestWeatherRefresh(
@@ -1853,7 +1857,9 @@ public partial class MainViewModel : ViewModelBase
         var selectedModel = selectedLeg?.Key.Model;
         var compatible = selectedModel is { } model &&
                          FindCompatibleAcquisition(selectedLeg, model) is not null;
-        ActiveWeatherModel = compatible ? selectedModel : null;
+        var nextWeatherModel = compatible ? selectedModel : null;
+        var weatherModelChanged = ActiveWeatherModel != nextWeatherModel;
+        ActiveWeatherModel = nextWeatherModel;
         if (!compatible)
         {
             CancelWeather();
@@ -1864,7 +1870,10 @@ public partial class MainViewModel : ViewModelBase
         else
         {
             WeatherLayerError = null;
-            RequestWeatherRefreshFromViewport();
+            if (!weatherModelChanged)
+            {
+                RequestWeatherRefreshFromViewport();
+            }
         }
     }
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -204,21 +204,28 @@
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="vm:RouteLegEditorItemViewModel">
                                             <Border Classes="subtle" Margin="0,0,0,6">
-                                                <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="5">
+                                                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto" ColumnSpacing="5">
                                                     <StackPanel>
                                                         <TextBlock Text="{Binding Label}" />
                                                         <TextBlock Text="{Binding StatusLabel}"
                                                                    Classes="muted" />
+                                                        <TextBlock Text="{Binding OutcomeStatus}"
+                                                                   Classes="muted"
+                                                                   TextWrapping="Wrap" />
                                                     </StackPanel>
                                                     <Button Grid.Column="1"
+                                                            Content="View"
+                                                            Command="{Binding SelectCommand}"
+                                                            ToolTip.Tip="Select this leg on the full-route map" />
+                                                    <Button Grid.Column="2"
                                                             Content="Sailed"
                                                             Command="{Binding MarkSailedCommand}"
                                                             ToolTip.Tip="Mark this leg as sailed/completed" />
-                                                    <Button Grid.Column="2"
+                                                    <Button Grid.Column="3"
                                                             Content="Unmark"
                                                             Command="{Binding UnmarkSailedCommand}"
                                                             ToolTip.Tip="Unmark this leg as sailed" />
-                                                    <Button Grid.Column="3"
+                                                    <Button Grid.Column="4"
                                                             Content="Active"
                                                             Command="{Binding MakeActiveCommand}"
                                                             ToolTip.Tip="Explicitly resume from this leg" />
@@ -556,7 +563,7 @@
                                        FontSize="20"
                                        FontWeight="SemiBold" />
                             <TextBlock Classes="muted"
-                                       Text="Selected point and shared UTC timeline." />
+                                       Text="Full-route context with a model-specific UTC timeline." />
                         </StackPanel>
 
                         <Border Classes="card">
@@ -567,10 +574,17 @@
                                 <TextBlock Text="{Binding SelectedRouteDetails}"
                                            Classes="muted"
                                            TextWrapping="Wrap" />
-                                <Button Command="{Binding FocusSelectedRoutePointCommand}"
-                                        Content="Focus on map"
-                                        HorizontalAlignment="Stretch"
-                                        ToolTip.Tip="Center the selected route point" />
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="7">
+                                    <Button Command="{Binding FocusSelectedLegCommand}"
+                                            Content="Fit selected leg"
+                                            HorizontalAlignment="Stretch"
+                                            ToolTip.Tip="Fit the selected leg without hiding route-wide context" />
+                                    <Button Grid.Column="1"
+                                            Command="{Binding FocusSelectedRoutePointCommand}"
+                                            Content="Focus point"
+                                            HorizontalAlignment="Stretch"
+                                            ToolTip.Tip="Center the selected route point" />
+                                </Grid>
                             </StackPanel>
                         </Border>
 
@@ -578,6 +592,16 @@
                             <StackPanel Spacing="9">
                                 <TextBlock Classes="section-title"
                                            Text="TIMELINE" />
+                                <StackPanel Orientation="Horizontal" Spacing="10">
+                                    <RadioButton Content="NOAA GFS"
+                                                 Command="{Binding ActivateNoaaRouteCommand}"
+                                                 IsChecked="{Binding IsNoaaRouteActive, Mode=OneWay}"
+                                                 IsVisible="{Binding HasNoaaRoutes}" />
+                                    <RadioButton Content="ECMWF experimental"
+                                                 Command="{Binding ActivateEcmwfRouteCommand}"
+                                                 IsChecked="{Binding IsEcmwfRouteActive, Mode=OneWay}"
+                                                 IsVisible="{Binding HasEcmwfRoutes}" />
+                                </StackPanel>
                                 <Grid ColumnDefinitions="44,44,*,Auto"
                                       ColumnSpacing="7">
                                     <Button x:Name="PreviousTimelineButton"

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -254,11 +254,12 @@
                                                                    Classes="muted"
                                                                    TextWrapping="Wrap" />
                                                     </StackPanel>
-                                                    <ToggleButton Grid.Column="1"
-                                                                  Content="View"
-                                                                  Command="{Binding SelectCommand}"
-                                                                  IsChecked="{Binding IsSelected, Mode=OneWay}"
-                                                                  ToolTip.Tip="Select this leg on the full-route map" />
+                                                    <RadioButton Grid.Column="1"
+                                                                 Content="View"
+                                                                 Command="{Binding SelectCommand}"
+                                                                 GroupName="RouteLegSelection"
+                                                                 IsChecked="{Binding IsSelected, Mode=OneWay}"
+                                                                 ToolTip.Tip="Select this leg on the full-route map" />
                                                     <Button Grid.Column="2"
                                                             Content="Sailed"
                                                             Command="{Binding MarkSailedCommand}"

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -254,10 +254,11 @@
                                                                    Classes="muted"
                                                                    TextWrapping="Wrap" />
                                                     </StackPanel>
-                                                    <Button Grid.Column="1"
-                                                            Content="View"
-                                                            Command="{Binding SelectCommand}"
-                                                            ToolTip.Tip="Select this leg on the full-route map" />
+                                                    <ToggleButton Grid.Column="1"
+                                                                  Content="View"
+                                                                  Command="{Binding SelectCommand}"
+                                                                  IsChecked="{Binding IsSelected, Mode=OneWay}"
+                                                                  ToolTip.Tip="Select this leg on the full-route map" />
                                                     <Button Grid.Column="2"
                                                             Content="Sailed"
                                                             Command="{Binding MarkSailedCommand}"

--- a/src/Navtool.Core/RouteVisualization.cs
+++ b/src/Navtool.Core/RouteVisualization.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+
+namespace Navtool.Core;
+
+public readonly record struct RouteVisualizationKey(
+    RoutePlanId PlanId,
+    RouteLegId LegId,
+    ForecastModel Model,
+    RouteCalculationSessionId SessionId,
+    string RouteId);
+
+public sealed record RouteLegVisualization(
+    RouteVisualizationKey Key,
+    int LegIndex,
+    RouteWaypoint From,
+    RouteWaypoint To,
+    RouteLegOutcomeState State,
+    RouteLegOutcomeReason Reason,
+    RouteResult? Route,
+    string? Detail,
+    bool IsSailed,
+    DateTimeOffset SessionStartedAt,
+    DateTimeOffset? SessionCompletedAt)
+{
+    public TimeSpan? StopoverAfter => To.Stopover;
+
+    public bool HasOptimizedGeometry =>
+        Route is not null &&
+        State == RouteLegOutcomeState.Succeeded;
+}
+
+public static class RoutePlanVisualization
+{
+    public static ImmutableArray<RouteLegVisualization> Create(RoutePlan plan)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        var legs = plan.Legs.ToDictionary(leg => leg.Id);
+        var waypoints = plan.Waypoints.ToDictionary(waypoint => waypoint.Id);
+        return plan.Results
+            .SelectMany(result => result.Legs.Select(outcome =>
+            {
+                var leg = legs[outcome.LegId];
+                return new RouteLegVisualization(
+                    new RouteVisualizationKey(
+                        plan.Id,
+                        leg.Id,
+                        result.Model,
+                        result.Session.Id,
+                        outcome.Route?.Request.RouteId ?? string.Empty),
+                    leg.Index,
+                    waypoints[leg.FromWaypointId],
+                    waypoints[leg.ToWaypointId],
+                    outcome.State,
+                    outcome.Reason,
+                    outcome.Route,
+                    outcome.Detail,
+                    plan.SailedLegIds.Contains(leg.Id),
+                    result.Session.StartedAt,
+                    result.Session.CompletedAt);
+            }))
+            .OrderBy(item => item.LegIndex)
+            .ThenBy(item => item.Key.Model)
+            .ToImmutableArray();
+    }
+}

--- a/src/Navtool.Core/SharedRouteTimeline.cs
+++ b/src/Navtool.Core/SharedRouteTimeline.cs
@@ -2,26 +2,30 @@ using System.Collections.Immutable;
 
 namespace Navtool.Core;
 
-public readonly record struct RouteKey(string RouteId, ForecastModel Model);
-
 public sealed record RoutePointSelection(
-    RouteKey Route,
+    RouteLegVisualization Leg,
     RoutePoint Point,
-    TimeSpan OffsetFromRequestedTime);
+    TimeSpan OffsetFromRequestedTime,
+    bool IsStopover,
+    string? StopoverLabel);
 
 public sealed class SharedRouteTimeline
 {
-    private readonly ImmutableArray<RouteResult> _routes;
+    private readonly ImmutableArray<RouteLegVisualization> _legs;
 
     private SharedRouteTimeline(
-        ImmutableArray<RouteResult> routes,
+        ForecastModel model,
+        ImmutableArray<RouteLegVisualization> legs,
         ImmutableArray<DateTimeOffset> timestamps)
     {
-        _routes = routes;
+        Model = model;
+        _legs = legs;
         Timestamps = timestamps;
-        Start = routes.Min(route => route.Request.DepartureTime);
-        End = routes.Max(route => route.ArrivalTime);
+        Start = legs.Min(leg => leg.Route!.Request.DepartureTime);
+        End = legs.Max(GetLegTimelineEnd);
     }
+
+    public ForecastModel Model { get; }
 
     public DateTimeOffset Start { get; }
 
@@ -29,46 +33,87 @@ public sealed class SharedRouteTimeline
 
     public ImmutableArray<DateTimeOffset> Timestamps { get; }
 
-    public static SharedRouteTimeline Create(IEnumerable<RouteResult> routes)
+    public static SharedRouteTimeline Create(
+        ForecastModel model,
+        IEnumerable<RouteLegVisualization> legs)
     {
-        ArgumentNullException.ThrowIfNull(routes);
-        var immutableRoutes = routes.ToImmutableArray();
-        if (immutableRoutes.IsEmpty)
+        ArgumentNullException.ThrowIfNull(legs);
+        var successfulLegs = legs
+            .Where(leg => leg.Key.Model == model && leg.HasOptimizedGeometry)
+            .OrderBy(leg => leg.Route!.Request.DepartureTime)
+            .ThenBy(leg => leg.LegIndex)
+            .ToImmutableArray();
+        if (successfulLegs.IsEmpty)
         {
-            throw new ArgumentException("At least one route is required.", nameof(routes));
+            throw new ArgumentException(
+                "At least one successful route leg is required for the selected model.",
+                nameof(legs));
         }
 
-        var duplicate = immutableRoutes
-            .GroupBy(route => new RouteKey(route.Request.RouteId, route.Model))
+        var duplicate = successfulLegs
+            .GroupBy(leg => leg.Key)
             .FirstOrDefault(group => group.Count() > 1);
         if (duplicate is not null)
         {
-            throw new ArgumentException($"Duplicate route '{duplicate.Key}'.", nameof(routes));
+            throw new ArgumentException($"Duplicate route leg '{duplicate.Key}'.", nameof(legs));
         }
 
-        var timestamps = immutableRoutes
-            .SelectMany(route => route.Points)
-            .Select(point => point.Timestamp)
+        var timestamps = successfulLegs
+            .SelectMany(leg => leg.Route!.Points
+                .Select(point => point.Timestamp)
+                .Append(GetLegTimelineEnd(leg)))
             .Distinct()
             .Order()
             .ToImmutableArray();
 
-        return new SharedRouteTimeline(immutableRoutes, timestamps);
+        return new SharedRouteTimeline(model, successfulLegs, timestamps);
     }
 
-    public ImmutableDictionary<RouteKey, RoutePointSelection> NearestPoints(DateTimeOffset timestamp)
+    public RoutePointSelection Select(DateTimeOffset timestamp)
     {
-        var utcTimestamp = timestamp.ToUniversalTime();
-        return _routes.ToImmutableDictionary(
-            route => new RouteKey(route.Request.RouteId, route.Model),
-            route =>
-            {
-                var point = FindNearest(route.Points, utcTimestamp);
-                return new RoutePointSelection(
-                    new RouteKey(route.Request.RouteId, route.Model),
-                    point,
-                    point.Timestamp - utcTimestamp);
-            });
+        var selected = Clamp(timestamp);
+        var active = _legs.LastOrDefault(leg =>
+            selected >= leg.Route!.Request.DepartureTime &&
+            selected <= leg.Route.ArrivalTime);
+        if (active is not null)
+        {
+            var point = FindNearest(active.Route!.Points, selected);
+            return new RoutePointSelection(active, point, point.Timestamp - selected, false, null);
+        }
+
+        var previous = _legs.LastOrDefault(leg => leg.Route!.ArrivalTime < selected);
+        if (previous is not null &&
+            GetStopover(previous) is { } stopover &&
+            selected <= previous.Route!.ArrivalTime + stopover)
+        {
+            var arrival = previous.Route.Points[^1];
+            var hold = new RoutePoint(
+                arrival.Location,
+                selected,
+                arrival.HeadingDegrees,
+                0,
+                arrival.TrueWindSpeedKnots,
+                arrival.TrueWindDirectionDegrees,
+                arrival.CumulativeDistanceNauticalMiles);
+            return new RoutePointSelection(
+                previous,
+                hold,
+                TimeSpan.Zero,
+                true,
+                $"Stopover at {previous.To.Name}");
+        }
+
+        var nearestLeg = _legs
+            .OrderBy(leg => DistanceFromInterval(selected, leg.Route!))
+            .ThenBy(leg => leg.LegIndex)
+            .First();
+        var nearestPoint = FindNearest(nearestLeg.Route!.Points, selected);
+        return new RoutePointSelection(
+            nearestLeg,
+            nearestPoint,
+            nearestPoint.Timestamp - selected,
+            false,
+            null);
     }
 
     public bool TryGetPreviousTimestamp(DateTimeOffset timestamp, out DateTimeOffset previous)
@@ -107,6 +152,27 @@ public sealed class SharedRouteTimeline
     {
         var utcTimestamp = timestamp.ToUniversalTime();
         return utcTimestamp < Start ? Start : utcTimestamp > End ? End : utcTimestamp;
+    }
+
+    private static DateTimeOffset GetLegTimelineEnd(RouteLegVisualization leg) =>
+        leg.Route!.ArrivalTime + (GetStopover(leg) ?? TimeSpan.Zero);
+
+    private static TimeSpan? GetStopover(RouteLegVisualization leg) =>
+        leg.Reason == RouteLegOutcomeReason.CalculationSucceeded &&
+        !leg.Route!.IsForecastLimited
+            ? leg.StopoverAfter
+            : null;
+
+    private static TimeSpan DistanceFromInterval(DateTimeOffset timestamp, RouteResult route)
+    {
+        if (timestamp < route.Request.DepartureTime)
+        {
+            return route.Request.DepartureTime - timestamp;
+        }
+
+        return timestamp > route.ArrivalTime
+            ? timestamp - route.ArrivalTime
+            : TimeSpan.Zero;
     }
 
     private static RoutePoint FindNearest(

--- a/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
+++ b/tests/Navtool.App.Tests/ItineraryEditorViewModelTests.cs
@@ -71,6 +71,7 @@ public sealed class ItineraryEditorViewModelTests
         var editor = new ItineraryEditorViewModel(repository);
         await editor.RefreshSavedPlansCommand.ExecuteAsync(null);
         await editor.OpenCommand.ExecuteAsync(null);
+        Assert.All(editor.Legs, leg => Assert.Equal("NOAA pending", leg.OutcomeStatus));
 
         editor.Waypoints[1].HasStopover = true;
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -191,6 +191,7 @@ public sealed class MainViewModelWorkflowTests
         await viewModel.CalculateRoutesAsync();
 
         Assert.Equal(0, viewModel.SuccessfulRouteCount);
+        Assert.Null(viewModel.SelectedLeg?.Route);
         Assert.Null(viewModel.LandAvoidanceWarning);
     }
 
@@ -305,10 +306,14 @@ public sealed class MainViewModelWorkflowTests
             (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
         var engine = new DelegateRouteEngine((request, forecast, _) =>
             ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        ForecastAcquisition? sampledAcquisition = null;
         var viewModel = CreateViewModel(
             new RoutingWorkflow(new[] { noaa }, engine),
-            new DelegateWeatherSampler((_, _, _, _, _, _) =>
-                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            new DelegateWeatherSampler((acquisition, _, _, _, _, _) =>
+            {
+                sampledAcquisition = acquisition;
+                return ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty);
+            }),
             routePlanRepository: repository);
         viewModel.Itinerary.AddWaypointCommand.Execute(null);
         var waypoint = viewModel.Itinerary.Waypoints[1];
@@ -329,15 +334,42 @@ public sealed class MainViewModelWorkflowTests
         Assert.Equal(36, waypoint.Coordinate!.Value.Latitude, 10);
         Assert.Equal(-58, waypoint.Coordinate.Value.Longitude, 10);
         Assert.Equal(2, viewModel.SuccessfulRouteCount);
+        Assert.Equal(2, viewModel.VisualizedRouteLegs.Count);
+        Assert.All(
+            viewModel.VisualizedRouteLegs,
+            leg => Assert.Equal(viewModel.Itinerary.PlanId, leg.Key.PlanId));
+        Assert.Single(viewModel.VisualizedRouteLegs.Select(leg => leg.Key.SessionId).Distinct());
+        Assert.Equal(2, viewModel.VisualizedRouteLegs.Select(leg => leg.Key.LegId).Distinct().Count());
         Assert.Contains("leg 1 complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("leg 2 complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
         Assert.Equal("All itinerary legs are complete.", viewModel.StatusMessage);
+        viewModel.TimelinePosition = 0.5;
+        Assert.Contains("Stopover at", viewModel.TimelineDisplay);
+        Assert.Contains("stationary hold", viewModel.SelectedRouteDetails);
+        viewModel.Itinerary.Legs[1].SelectCommand.Execute(null);
+        Assert.Equal(1, viewModel.SelectedLeg!.LegIndex);
+        await viewModel.RefreshWeatherAsync(noaa.Requests[1].Bounds, 2, 2);
+        Assert.Equal(noaa.Requests[1].From, sampledAcquisition!.Request.From);
 
         var loaded = await repository.OpenAsync(viewModel.Itinerary.PlanId);
         Assert.Equal(2, loaded.LatestResult(ForecastModel.NoaaGfs)!.Legs.Length);
         var json = await File.ReadAllTextAsync(
             Path.Combine(repository.RootDirectory, $"{loaded.Id}.route.json"));
         Assert.DoesNotContain("fake-forecast.grib2", json, StringComparison.OrdinalIgnoreCase);
+
+        var reopened = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
+        await reopened.Itinerary.RefreshSavedPlansCommand.ExecuteAsync(null);
+        reopened.Itinerary.SelectedSavedPlan = reopened.Itinerary.SavedPlans.Single();
+        await reopened.Itinerary.OpenCommand.ExecuteAsync(null);
+        Assert.Equal(2, reopened.SuccessfulRouteCount);
+        Assert.True(reopened.HasTimeline);
+        Assert.Null(reopened.ActiveWeatherModel);
+        Assert.Contains("unavailable", reopened.WeatherLayerError, StringComparison.OrdinalIgnoreCase);
+        Assert.All(reopened.Itinerary.Legs, leg => Assert.Contains("complete", leg.OutcomeStatus));
         Directory.Delete(root, recursive: true);
     }
 
@@ -393,6 +425,13 @@ public sealed class MainViewModelWorkflowTests
         Assert.Equal(firstLegRoute.RouteId, retainedFirstLeg.Route!.Request.RouteId);
         Assert.Equal(RouteLegOutcomeState.Succeeded, retainedFirstLeg.State);
         Assert.Equal(RouteLegOutcomeState.Succeeded, recalculatedResult.Legs[1].State);
+        Assert.True(viewModel.Itinerary.PlaceCurrentPosition(
+            new Coordinate(36.5, -57.5),
+            firstLegRoute.DepartureTime.AddHours(10),
+            out var placementError));
+        Assert.Null(placementError);
+        var sailedHistory = Assert.Single(viewModel.SuccessfulRoutes);
+        Assert.Equal(firstLegRoute.RouteId, sailedHistory.Request.RouteId);
         Directory.Delete(root, recursive: true);
     }
 
@@ -931,7 +970,7 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task TimelineCommandsAndRouteSelectionShareUtcState()
+    public async Task TimelineCommandsAndRouteSelectionUseOneActiveModel()
     {
         var providers = new[]
         {
@@ -956,12 +995,13 @@ public sealed class MainViewModelWorkflowTests
 
         var start = viewModel.SelectedTimelineUtc;
         viewModel.NextTimelineCommand.Execute(null);
-        Assert.Equal(start!.Value.AddHours(2), viewModel.SelectedTimelineUtc);
+        Assert.Equal(start!.Value.AddHours(3), viewModel.SelectedTimelineUtc);
 
-        var ecmwf = viewModel.SuccessfulRoutes.Single(
-            route => route.Model == ForecastModel.EcmwfIfs);
+        var ecmwfLeg = viewModel.VisualizedRouteLegs.Single(
+            leg => leg.Key.Model == ForecastModel.EcmwfIfs);
+        var ecmwf = ecmwfLeg.Route!;
         var selection = new RouteMapSelection(
-            ecmwf,
+            ecmwfLeg,
             2,
             ecmwf.Points[2],
             RouteHitKind.RoutePoint,
@@ -970,10 +1010,54 @@ public sealed class MainViewModelWorkflowTests
 
         Assert.Equal(ecmwf.Points[2].Timestamp, viewModel.SelectedTimelineUtc);
         Assert.Equal(ForecastModel.EcmwfIfs, viewModel.SelectedRoutePoint!.Route.Model);
+        Assert.Equal(ForecastModel.EcmwfIfs, viewModel.ActiveRouteModel);
         Assert.Equal(ForecastModel.EcmwfIfs, viewModel.ActiveWeatherModel);
 
         viewModel.PreviousTimelineCommand.Execute(null);
         Assert.True(viewModel.SelectedTimelineUtc < ecmwf.Points[2].Timestamp);
+    }
+
+    [Fact]
+    public async Task Switching_models_preserves_the_selected_stable_leg()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-model-leg-{Guid.NewGuid():N}");
+        var repository = new RoutePlanJsonRepository(root);
+        var providers = new[]
+        {
+            new DelegateForecastProvider(
+                ForecastModel.NoaaGfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request))),
+            new DelegateForecastProvider(
+                ForecastModel.EcmwfIfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request)))
+        };
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(
+                request,
+                forecast.Request.Model,
+                forecast.Request.Model == ForecastModel.NoaaGfs ? 3 : 2)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(providers, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            routePlanRepository: repository);
+        viewModel.Itinerary.AddWaypointCommand.Execute(null);
+        viewModel.Itinerary.Waypoints[1].SetOnMapCommand.Execute(null);
+        viewModel.HandleMapClick(
+            MapProjection.ToMapPoint(new Coordinate(36, -58)),
+            default);
+        viewModel.UseEcmwf = true;
+        await viewModel.CalculateRoutesAsync();
+
+        var secondLegId = viewModel.Itinerary.Legs[1].Id;
+        viewModel.Itinerary.Legs[1].SelectCommand.Execute(null);
+        Assert.Equal(ForecastModel.NoaaGfs, viewModel.SelectedLeg!.Key.Model);
+
+        viewModel.ActivateEcmwfRouteCommand.Execute(null);
+
+        Assert.Equal(secondLegId, viewModel.SelectedLeg!.Key.LegId);
+        Assert.Equal(ForecastModel.EcmwfIfs, viewModel.SelectedLeg.Key.Model);
+        Directory.Delete(root, recursive: true);
     }
 
     [Fact]

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -349,6 +349,7 @@ public sealed class MainViewModelWorkflowTests
         viewModel.Itinerary.Legs[1].SelectCommand.Execute(null);
         Assert.Equal(1, viewModel.SelectedLeg!.LegIndex);
         Assert.True(viewModel.Itinerary.Legs[1].IsSelected);
+        Assert.DoesNotContain("Stopover at", viewModel.TimelineDisplay);
         await viewModel.RefreshWeatherAsync(noaa.Requests[1].Bounds, 2, 2);
         Assert.Equal(noaa.Requests[1].From, sampledAcquisition!.Request.From);
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -348,6 +348,7 @@ public sealed class MainViewModelWorkflowTests
         Assert.Contains("stationary hold", viewModel.SelectedRouteDetails);
         viewModel.Itinerary.Legs[1].SelectCommand.Execute(null);
         Assert.Equal(1, viewModel.SelectedLeg!.LegIndex);
+        Assert.True(viewModel.Itinerary.Legs[1].IsSelected);
         await viewModel.RefreshWeatherAsync(noaa.Requests[1].Bounds, 2, 2);
         Assert.Equal(noaa.Requests[1].From, sampledAcquisition!.Request.From);
 

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -555,6 +555,47 @@ public sealed class MapRenderingTests
         Assert.True(nearWesternCopy.Average(point => point.X) < 0);
     }
 
+    [Fact]
+    public void Route_leg_features_keep_identity_and_selected_emphasis_across_antimeridian()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        var first = CreateVisualizationLeg(
+            ForecastModel.NoaaGfs,
+            0,
+            new Coordinate(10, 179),
+            new Coordinate(10, -179));
+        var second = CreateVisualizationLeg(
+            ForecastModel.NoaaGfs,
+            1,
+            new Coordinate(10, -179),
+            new Coordinate(11, -175));
+
+        layers.SetRouteLegs([first, second], second.Key);
+
+        var routeLayer = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS routes"));
+        var features = routeLayer.Features.Cast<GeometryFeature>().ToArray();
+        Assert.Equal(2, features.Length);
+        Assert.Equal(first.Key, Assert.IsType<RouteLegVisualization>(features[0].Data).Key);
+        Assert.Equal(second.Key, Assert.IsType<RouteLegVisualization>(features[1].Data).Key);
+        var subdued = Assert.IsType<VectorStyle>(Assert.Single(features[0].Styles));
+        var selected = Assert.IsType<VectorStyle>(Assert.Single(features[1].Styles));
+        Assert.Equal(0.3f, subdued.Opacity);
+        Assert.Equal(2.25, subdued.Line!.Width);
+        Assert.Equal(1f, selected.Opacity);
+        Assert.Equal(6, selected.Line!.Width);
+        var datelineLine = Assert.IsType<LineString>(features[0].Geometry);
+        var followingLine = Assert.IsType<LineString>(features[1].Geometry);
+        Assert.True(Math.Abs(datelineLine.Coordinates[1].X - datelineLine.Coordinates[0].X) < 500_000);
+        Assert.Equal(datelineLine.Coordinates[^1].X, followingLine.Coordinates[0].X, 6);
+        Assert.Equal(
+            followingLine.Coordinates[1].X,
+            layers.GetProjectedRoutePoint(second.Key, 1)!.X,
+            6);
+        Assert.Equal(second.Key, layers.SelectedRouteKey);
+    }
+
     private static MainViewModel CreateViewModel(bool tilesEnabled) =>
         new(
             null,
@@ -593,6 +634,46 @@ public sealed class MapRenderingTests
                     10)
             },
             new RouteDiagnostics(10, 20, 5, (int)(frontierTime.Hour + 1)));
+    }
+
+    private static RouteLegVisualization CreateVisualizationLeg(
+        ForecastModel model,
+        int index,
+        Coordinate fromCoordinate,
+        Coordinate toCoordinate)
+    {
+        var planId = new RoutePlanId();
+        var sessionId = new RouteCalculationSessionId();
+        var from = new RouteWaypoint($"From {index}", fromCoordinate);
+        var to = new RouteWaypoint($"To {index}", toCoordinate);
+        var legId = RouteLegId.FromEndpoints(from.Id, to.Id);
+        var departure = new DateTimeOffset(2026, 7, 15, index * 2, 0, 0, TimeSpan.Zero);
+        var request = new RouteRequest(
+            $"{planId}-leg-{index}-{sessionId}",
+            fromCoordinate,
+            toCoordinate,
+            departure,
+            departure.AddHours(4));
+        var route = new RouteResult(
+            request,
+            model,
+            [
+                new RoutePoint(fromCoordinate, departure, 90, 6, 15, 180, 0),
+                new RoutePoint(toCoordinate, departure.AddHours(2), 90, 6, 15, 180, 100)
+            ],
+            new RouteDiagnostics(10, 20, 5, 2));
+        return new RouteLegVisualization(
+            new RouteVisualizationKey(planId, legId, model, sessionId, request.RouteId),
+            index,
+            from,
+            to,
+            RouteLegOutcomeState.Succeeded,
+            RouteLegOutcomeReason.CalculationSucceeded,
+            route,
+            null,
+            false,
+            departure,
+            departure.AddHours(2));
     }
 
     private static Coordinate[] CreateDatelineFrontier(double longitudeOffset) =>

--- a/tests/Navtool.Core.Tests/SharedRouteTimelineTests.cs
+++ b/tests/Navtool.Core.Tests/SharedRouteTimelineTests.cs
@@ -3,94 +3,162 @@ namespace Navtool.Core.Tests;
 public sealed class SharedRouteTimelineTests
 {
     [Fact]
-    public void Timeline_spans_routes_and_navigates_union_timestamps()
+    public void Timeline_uses_full_identity_and_spans_only_the_active_model()
     {
+        var planId = new RoutePlanId();
+        var legId = new RouteLegId(Guid.NewGuid());
         var start = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
-        var first = CreateRoute(
-            "route-a",
+        var noaa = CreateLeg(
+            planId,
+            legId,
             ForecastModel.NoaaGfs,
+            new RouteCalculationSessionId(),
             start,
-            start.AddHours(4),
-            (start, 0),
-            (start.AddHours(1), 1_000),
-            (start.AddHours(4), 4_000));
-        var second = CreateRoute(
-            "route-a",
+            start.AddHours(4));
+        var revisedNoaa = CreateLeg(
+            planId,
+            legId,
+            ForecastModel.NoaaGfs,
+            new RouteCalculationSessionId(),
+            start.AddHours(1),
+            start.AddHours(5));
+        var ecmwf = CreateLeg(
+            planId,
+            legId,
             ForecastModel.EcmwfIfs,
-            start.AddHours(-1),
-            start.AddHours(3),
-            (start, 0),
-            (start.AddHours(2), 2_000),
-            (start.AddHours(3), 3_000));
+            new RouteCalculationSessionId(),
+            start.AddHours(8),
+            start.AddHours(12));
 
-        var timeline = SharedRouteTimeline.Create(new[] { first, second });
+        Assert.NotEqual(noaa.Key, revisedNoaa.Key);
+        var timeline = SharedRouteTimeline.Create(ForecastModel.NoaaGfs, [noaa]);
 
-        Assert.Equal(start.AddHours(-1), timeline.Start);
+        Assert.Equal(ForecastModel.NoaaGfs, timeline.Model);
+        Assert.Equal(start, timeline.Start);
         Assert.Equal(start.AddHours(4), timeline.End);
-        Assert.Equal(
-            new[] { start, start.AddHours(1), start.AddHours(2), start.AddHours(3), start.AddHours(4) },
-            timeline.Timestamps);
-        Assert.True(timeline.TryGetPreviousTimestamp(start.AddHours(2), out var previous));
-        Assert.Equal(start.AddHours(1), previous);
-        Assert.True(timeline.TryGetNextTimestamp(start.AddHours(2), out var next));
-        Assert.Equal(start.AddHours(3), next);
-        Assert.False(timeline.TryGetPreviousTimestamp(start, out _));
-        Assert.False(timeline.TryGetNextTimestamp(start.AddHours(4), out _));
+        Assert.DoesNotContain(ecmwf.Route!.Request.DepartureTime, timeline.Timestamps);
     }
 
     [Fact]
-    public void Timeline_selects_each_routes_nearest_point_and_prefers_earlier_on_ties()
+    public void Timeline_represents_stopover_as_stationary_hold_and_navigates_boundaries()
     {
+        var planId = new RoutePlanId();
+        var sessionId = new RouteCalculationSessionId();
         var start = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
-        var first = CreateRoute(
-            "route-a",
+        var first = CreateLeg(
+            planId,
+            new RouteLegId(Guid.NewGuid()),
             ForecastModel.NoaaGfs,
+            sessionId,
             start,
             start.AddHours(2),
-            (start, 0),
-            (start.AddHours(2), 2_000));
-        var second = CreateRoute(
-            "route-a",
-            ForecastModel.EcmwfIfs,
-            start,
-            start.AddHours(3),
-            (start.AddHours(1), 0),
-            (start.AddHours(3), 2_000));
+            TimeSpan.FromHours(2),
+            0);
+        var second = CreateLeg(
+            planId,
+            new RouteLegId(Guid.NewGuid()),
+            ForecastModel.NoaaGfs,
+            sessionId,
+            start.AddHours(4),
+            start.AddHours(6),
+            null,
+            1);
+        var timeline = SharedRouteTimeline.Create(ForecastModel.NoaaGfs, [first, second]);
 
-        var selections = SharedRouteTimeline
-            .Create(new[] { first, second })
-            .NearestPoints(start.AddHours(1));
+        var hold = timeline.Select(start.AddHours(3));
 
-        Assert.Equal(start, selections[new RouteKey("route-a", ForecastModel.NoaaGfs)].Point.Timestamp);
-        Assert.Equal(
-            start.AddHours(1),
-            selections[new RouteKey("route-a", ForecastModel.EcmwfIfs)].Point.Timestamp);
+        Assert.True(hold.IsStopover);
+        Assert.Equal("Stopover at Waypoint 1", hold.StopoverLabel);
+        Assert.Equal(first.Route!.Points[^1].Location, hold.Point.Location);
+        Assert.Equal(0, hold.Point.BoatSpeedKnots);
+        Assert.Equal(start.AddHours(3), hold.Point.Timestamp);
+        Assert.Contains(start.AddHours(4), timeline.Timestamps);
+        Assert.True(timeline.TryGetPreviousTimestamp(start.AddHours(4), out var previous));
+        Assert.Equal(start.AddHours(2), previous);
+        Assert.True(timeline.TryGetNextTimestamp(start.AddHours(4), out var next));
+        Assert.Equal(start.AddHours(6), next);
+        Assert.False(timeline.TryGetPreviousTimestamp(start, out _));
+        Assert.False(timeline.TryGetNextTimestamp(start.AddHours(6), out _));
     }
 
-    private static RouteResult CreateRoute(
-        string routeId,
-        ForecastModel model,
-        DateTimeOffset departure,
-        DateTimeOffset latestArrival,
-        params (DateTimeOffset Timestamp, double Distance)[] points)
+    [Fact]
+    public void Timeline_handles_missing_later_legs_without_inventing_geometry()
     {
+        var start = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var leg = CreateLeg(
+            new RoutePlanId(),
+            new RouteLegId(Guid.NewGuid()),
+            ForecastModel.NoaaGfs,
+            new RouteCalculationSessionId(),
+            start,
+            start.AddHours(2),
+            TimeSpan.FromHours(1));
+        var timeline = SharedRouteTimeline.Create(ForecastModel.NoaaGfs, [leg]);
+
+        Assert.Equal(start.AddHours(3), timeline.End);
+        Assert.True(timeline.Select(timeline.End).IsStopover);
+    }
+
+    [Fact]
+    public void Forecast_limited_leg_does_not_hold_at_unreached_stopover()
+    {
+        var start = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var leg = CreateLeg(
+            new RoutePlanId(),
+            new RouteLegId(Guid.NewGuid()),
+            ForecastModel.NoaaGfs,
+            new RouteCalculationSessionId(),
+            start,
+            start.AddHours(2),
+            TimeSpan.FromHours(4),
+            reason: RouteLegOutcomeReason.ForecastExhausted);
+        var timeline = SharedRouteTimeline.Create(ForecastModel.NoaaGfs, [leg]);
+
+        Assert.Equal(start.AddHours(2), timeline.End);
+        Assert.False(timeline.Select(timeline.End).IsStopover);
+    }
+
+    private static RouteLegVisualization CreateLeg(
+        RoutePlanId planId,
+        RouteLegId legId,
+        ForecastModel model,
+        RouteCalculationSessionId sessionId,
+        DateTimeOffset departure,
+        DateTimeOffset arrival,
+        TimeSpan? stopover = null,
+        int index = 0,
+        RouteLegOutcomeReason reason = RouteLegOutcomeReason.CalculationSucceeded)
+    {
+        var from = new RouteWaypoint($"Waypoint {index}", new Coordinate(40 + index, -70 + index));
+        var to = new RouteWaypoint(
+            $"Waypoint {index + 1}",
+            new Coordinate(41 + index, -69 + index),
+            stopover);
         var request = new RouteRequest(
-            routeId,
-            new Coordinate(40, -70),
-            new Coordinate(45, -50),
+            $"{planId}-leg-{index}-{sessionId}",
+            from.Coordinate,
+            to.Coordinate,
             departure,
-            latestArrival);
-        return new RouteResult(
+            arrival.AddHours(1));
+        var route = new RouteResult(
             request,
             model,
-            points.Select(point => new RoutePoint(
-                new Coordinate(40, -70 + point.Distance / 1_000),
-                point.Timestamp,
-                90,
-                6,
-                15,
-                180,
-                point.Distance)),
-            new RouteDiagnostics(10, 20, 5, points.Length, TimeSpan.FromSeconds(1)));
+            [
+                new RoutePoint(from.Coordinate, departure, 90, 6, 15, 180, 0),
+                new RoutePoint(to.Coordinate, arrival, 90, 6, 15, 180, 100)
+            ],
+            new RouteDiagnostics(10, 20, 5, 2));
+        return new RouteLegVisualization(
+            new RouteVisualizationKey(planId, legId, model, sessionId, request.RouteId),
+            index,
+            from,
+            to,
+            RouteLegOutcomeState.Succeeded,
+            reason,
+            route,
+            null,
+            false,
+            departure,
+            arrival);
     }
 }


### PR DESCRIPTION
## Summary
- render saved successful legs across the full itinerary with plan/leg/model/session identity, selected emphasis, antimeridian-safe shared projection, list/map selection, and selected-leg fitting
- add an active-model route-wide UTC timeline with explicit stationary stopovers, divergent model timing, cross-model leg details, and persisted sailed/history status
- scope weather overlays to compatible selected leg/model acquisitions, clear stale async weather deterministically, and reopen saved geometry without forecast binaries
- document saved multi-point routes, rolling sessions, full-route visualization, and weather/safety limitations

## Stack
- #39 sequential multi-leg routing
- #41 rolling route resume
- this PR: full-route visualization

## Tests
- `dotnet test Navtool.sln --no-restore --verbosity minimal`
- `dotnet format Navtool.sln --no-restore --verify-no-changes --verbosity minimal`

Base: `frye-rolling-route-resume`