### PR TITLE
Fix router launch regression guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# Navtool agent launch rules
+
+- On macOS and Linux, launch the app and capture screenshots only with `./scripts/run.sh`.
+- On Windows, launch the app and capture screenshots only with `.\scripts\run.ps1`.
+- Never use raw `dotnet run`, `dotnet exec`, or direct `Navtool.App.dll` execution for a functional launch or smoke test.
+- Build native artifacts only in the current worktree. Never use a router bridge from another checkout.
+- Use `scripts/build-native.sh` or `scripts/build-native.ps1` for native-only validation.
+- Use `scripts/publish.sh` or `scripts/publish.ps1` for distributable artifacts.
+- Before reporting a successful launch, verify the bridge preflight succeeds and the app does not show `Routing engine unavailable`.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ discoverable by CMake and the application.
 
 ## Build and run
 
-Build the native bridge and run the app with one command:
+Source checkout launches must use the platform launcher, which builds and tests
+the current worktree's native bridge before starting the app:
 
 ```sh
 ./scripts/run.sh
@@ -62,6 +63,11 @@ On Windows:
 ```powershell
 .\scripts\run.ps1
 ```
+
+Raw `dotnet run`, `dotnet exec`, and direct `Navtool.App.dll` execution are not
+supported for functional source checkout launches. Native build outputs are
+gitignored and local to each worktree, so a managed build alone does not provide
+the bridge and a bridge from another checkout must not be reused.
 
 In GitHub Copilot App or VS Code, select the **Navtool** run configuration and
 press the play button (or press `F5`). To launch without the debugger, run the
@@ -78,10 +84,12 @@ dotnet build Navtool.sln
 dotnet test Navtool.sln
 ```
 
-The application discovers the development bridge automatically. For a custom
-location, set `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its
-directory. Native builds fetch and compile the immutable `router-lib` revision
-`v0.3.0` by default. Set
+Use `scripts/build-native.sh` or `scripts/build-native.ps1` for native-only
+validation, and use `scripts/publish.sh` or `scripts/publish.ps1` for
+distributable artifacts. For a custom bridge location, set
+`NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its directory. Packaged
+applications discover their bridge under `runtimes/<RID>/native`. Native builds
+fetch and compile the immutable `router-lib` revision `v0.3.0` by default. Set
 `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when testing other
 revisions.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ On Windows:
 
 Raw `dotnet run`, `dotnet exec`, and direct `Navtool.App.dll` execution are not
 supported for functional source checkout launches. Native build outputs are
-gitignored and local to each worktree, so a managed build alone does not provide
+git-ignored and local to each worktree, so a managed build alone does not provide
 the bridge and a bridge from another checkout must not be reused.
 
 In GitHub Copilot App or VS Code, select the **Navtool** run configuration and

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -527,6 +527,28 @@ public partial class MainViewModel : ViewModelBase
                     "Route calculation is blocked to prevent unchecked land crossings.");
             }
         }
+        catch (NativeBridgeUnavailableException exception)
+            when (exception.InnerException is DllNotFoundException)
+        {
+            _logger.LogError(exception, "Native routing preflight failed");
+            var sourceLauncher = OperatingSystem.IsWindows()
+                ? @".\scripts\run.ps1"
+                : "./scripts/run.sh";
+            ErrorMessage =
+                $"Routing engine unavailable: {exception.Message}{Environment.NewLine}" +
+                $"For a source checkout, relaunch with {sourceLauncher}. " +
+                "For a packaged app, verify the bridge under runtimes/<RID>/native " +
+                "or configure NAVTOOL_ROUTER_BRIDGE_PATH.";
+            StatusMessage = "No forecast was downloaded.";
+            return;
+        }
+        catch (NativeBridgeUnavailableException exception)
+        {
+            _logger.LogError(exception, "Native routing preflight failed");
+            ErrorMessage = $"Routing engine unavailable: {exception.Message}";
+            StatusMessage = "No forecast was downloaded.";
+            return;
+        }
         catch (Exception exception)
         {
             _logger.LogError(exception, "Native routing preflight failed");

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -343,7 +343,7 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task NativePreflightFailureHappensBeforeForecastAcquisition()
+    public async Task MissingNativeBridgePreservesDegradedModeAndProvidesRecoveryGuidance()
     {
         var noaa = new DelegateForecastProvider(
             ForecastModel.NoaaGfs,
@@ -364,7 +364,43 @@ public sealed class MainViewModelWorkflowTests
 
         Assert.Equal(1, preflight.CallCount);
         Assert.Equal(0, noaa.CallCount);
+        Assert.False(viewModel.IsCalculating);
+        Assert.Equal(0, viewModel.SuccessfulRouteCount);
         Assert.Contains("Routing engine unavailable", viewModel.ErrorMessage);
+        Assert.Contains(
+            OperatingSystem.IsWindows() ? @".\scripts\run.ps1" : "./scripts/run.sh",
+            viewModel.ErrorMessage);
+        Assert.Contains("runtimes/<RID>/native", viewModel.ErrorMessage);
+        Assert.Contains("NAVTOOL_ROUTER_BRIDGE_PATH", viewModel.ErrorMessage);
+        Assert.Equal("No forecast was downloaded.", viewModel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task GenericNativePreflightFailureDoesNotSuggestMissingBridgeRecovery()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var preflight = new DelegateNativeRoutingPreflight(
+            new InvalidOperationException("Preflight failed generically."));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            nativeRoutingPreflight: preflight);
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(1, preflight.CallCount);
+        Assert.Equal(0, noaa.CallCount);
+        Assert.False(viewModel.IsCalculating);
+        Assert.Equal(0, viewModel.SuccessfulRouteCount);
+        Assert.Contains("Preflight failed generically.", viewModel.ErrorMessage);
+        Assert.DoesNotContain("./scripts/run.sh", viewModel.ErrorMessage);
+        Assert.DoesNotContain(@".\scripts\run.ps1", viewModel.ErrorMessage);
+        Assert.DoesNotContain("runtimes/<RID>/native", viewModel.ErrorMessage);
         Assert.Equal("No forecast was downloaded.", viewModel.StatusMessage);
     }
 


### PR DESCRIPTION
## Summary
- document the mandatory supported launch contract for agents and source worktrees
- explain worktree-local native outputs and supported custom/published bridge locations
- add actionable missing-library recovery guidance while preserving distinct ABI, architecture, land-capability, and generic preflight errors
- cover missing-library and generic preflight behavior before forecast acquisition

## Validation
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --filter FullyQualifiedName~MainViewModelWorkflowTests --no-restore --verbosity quiet`
- `dotnet test Navtool.sln --no-restore --verbosity quiet`
- `./scripts/build-native.sh`
- `NAVTOOL_ROUTER_BRIDGE_PATH="$PWD/native/Navtool.RouterBridge/build" dotnet test tests/Navtool.Infrastructure.Tests/Navtool.Infrastructure.Tests.csproj --no-restore --filter 'FullyQualifiedName~ConstructingNativeRouterBridge_DoesNotThrow_WhenBridgeIsAvailable'`
- smoke-launched only through `./scripts/run.sh`; it rebuilt and passed `navtool_router_bridge_tests`, then kept the worktree-local `Navtool.App` process running. GUI state was not machine-read, so bridge health is evidenced by the successful managed bridge-construction preflight plus ABI/capability exports from this worktree's arm64 dylib.