### PR TITLE
Persist and reuse tiled NOAA forecast cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,25 @@ status, and the model-specific timeline. Weather overlays are not restored from
 route JSON.
 
 NOAA data is downloaded from the operational NOMADS GFS filter. Navtool derives
-an antimeridian-safe buffered passage area, requests every available forecast
-step needed for the selected duration, and shows the expected part count before
-calculation. Requests remain sequential and include only 10 m U/V wind.
-Completed parts are cached atomically, so cancellation or a transient NOMADS
-failure can resume without downloading valid parts again. NOMADS is not a
-bulk-download service and may be unavailable or throttle excessive usage.
+an antimeridian-safe buffered passage area, divides it into stable 10-degree
+cache tiles, requests every available forecast step needed for the selected
+duration, and shows the expected part count before calculation. Requests remain
+sequential and include only 10 m U/V wind.
+
+Each immutable run/hour/tile is promoted atomically beneath the persistent
+forecast cache. Route-specific GRIB files are assembled locally from those
+tiles, so restarting Navtool or shifting a departure by a few minutes reuses
+overlapping data and downloads only newly required edge hours or tiles. Cache
+entries do not expire by age; least-recently-used data is removed only when the
+configured size or entry limits require space. Interrupted downloads leave
+completed tiles available for the next attempt.
+
+By default, route calculation uses the newest cached GFS run that fully covers
+the requested area and time window. If NOAA has published a newer covering run,
+Navtool displays a warning. Enable **Use newest weather data** before calculating
+to select that newest run; tiles already cached for it are still reused rather
+than downloaded again. NOMADS is not a bulk-download service and may be
+unavailable or throttle excessive usage.
 
 ## Existing GRIB files
 

--- a/src/Navtool.App/Services/AppComposition.cs
+++ b/src/Navtool.App/Services/AppComposition.cs
@@ -32,8 +32,9 @@ public static class AppComposition
             client.Timeout = TimeSpan.FromMinutes(10);
         });
 
-        services.AddSingleton(_ => new AtomicFileCache(
-            new AtomicFileCacheOptions(ResolveCacheRoot())));
+        services.AddSingleton(provider => new AtomicFileCache(
+            new AtomicFileCacheOptions(ResolveCacheRoot()),
+            provider.GetRequiredService<ILogger<AtomicFileCache>>()));
         services.AddSingleton<IRoutePlanSchemaMigrator, RoutePlanSchemaMigrator>();
         services.AddSingleton<IRoutePlanRepository>(provider => new RoutePlanJsonRepository(
             ResolveAppDataRoot(),

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -99,6 +99,9 @@ public partial class MainViewModel : ViewModelBase
     private bool _useEcmwf;
 
     [ObservableProperty]
+    private bool _useNewestWeatherData;
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CalculateCommand))]
     [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
     private bool _isCalculating;
@@ -656,7 +659,8 @@ public partial class MainViewModel : ViewModelBase
                 sequentialPlan,
                 departureTime,
                 request!.Route.LatestArrivalTime,
-                request.Selections);
+                request.Selections,
+                request.RefreshPolicy);
         }
 
         try
@@ -1136,6 +1140,8 @@ public partial class MainViewModel : ViewModelBase
                 _acquisitions[outcome.Model] = outcome.Acquisitions;
             }
 
+            AddNewerRunWarning(warnings, outcome.Model, outcome.Acquisitions);
+
             var legStatuses = outcome.Legs.Select((leg, index) =>
                 $"leg {index + 1} {LegStatusName(leg, result.Plan.SailedLegIds.Contains(leg.LegId))}");
             var modelStatus =
@@ -1318,7 +1324,10 @@ public partial class MainViewModel : ViewModelBase
         request = new RoutingWorkflowRequest(
             route,
             selections,
-            ForecastCorridor.Create(route.Origin, route.Destination));
+            ForecastCorridor.Create(route.Origin, route.Destination),
+            UseNewestWeatherData
+                ? ForecastRefreshPolicy.LatestAvailable
+                : ForecastRefreshPolicy.PreferCache);
         error = null;
         return true;
     }
@@ -1334,6 +1343,7 @@ public partial class MainViewModel : ViewModelBase
             if (outcome.Acquisition is not null)
             {
                 _acquisitions[outcome.Model] = [outcome.Acquisition];
+                AddNewerRunWarning(warnings, outcome.Model, [outcome.Acquisition]);
             }
 
             if (outcome.Route is not null)
@@ -2108,6 +2118,27 @@ public partial class MainViewModel : ViewModelBase
             RouteLegOutcomeState.Invalidated => "invalidated",
             _ => "not calculated"
         };
+    }
+
+    private static void AddNewerRunWarning(
+        ICollection<string> warnings,
+        ForecastModel model,
+        IEnumerable<ForecastAcquisition> acquisitions)
+    {
+        var usage = acquisitions
+            .Select(acquisition => acquisition.CacheUsage)
+            .Where(item => item?.IsNewerRunAvailable == true)
+            .OrderByDescending(item => item!.LatestPublishedRun)
+            .FirstOrDefault();
+        if (usage is null)
+        {
+            return;
+        }
+
+        warnings.Add(
+            $"{ModelName(model)} cached run {usage.SelectedRun:yyyy-MM-dd HH:mm} UTC was used. " +
+            $"Run {usage.LatestPublishedRun:yyyy-MM-dd HH:mm} UTC is available; enable " +
+            "Use newest weather data before calculating to update it.");
     }
 
     private static string ProgressStageName(RoutingProgressStage stage) => stage switch

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -372,6 +372,11 @@
                                                        TextWrapping="Wrap" />
                                         </StackPanel>
                                     </CheckBox>
+                                    <CheckBox IsChecked="{Binding UseNewestWeatherData}"
+                                              Content="Use newest weather data" />
+                                    <TextBlock Classes="muted"
+                                               Text="Normally Navtool reuses a covering cached run. Enable this only when newer published weather is required."
+                                               TextWrapping="Wrap" />
                                 </StackPanel>
                                 <StackPanel IsVisible="{Binding IsLocalForecast}"
                                             Spacing="7">

--- a/src/Navtool.Core/Forecasts.cs
+++ b/src/Navtool.Core/Forecasts.cs
@@ -27,6 +27,12 @@ public enum ForecastSelectionKind
     LocalFile
 }
 
+public enum ForecastRefreshPolicy
+{
+    PreferCache,
+    LatestAvailable
+}
+
 public enum ForecastProgressStage
 {
     Queued,
@@ -77,9 +83,15 @@ public sealed record ForecastRequest
         ForecastModel model,
         GeographicBounds bounds,
         DateTimeOffset from,
-        DateTimeOffset through)
+        DateTimeOffset through,
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
     {
         _ = model.Provider();
+        if (!Enum.IsDefined(refreshPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(refreshPolicy));
+        }
+
         var utcFrom = from.ToUniversalTime();
         var utcThrough = through.ToUniversalTime();
         if (utcThrough < utcFrom)
@@ -91,6 +103,7 @@ public sealed record ForecastRequest
         Bounds = bounds;
         From = utcFrom;
         Through = utcThrough;
+        RefreshPolicy = refreshPolicy;
     }
 
     public ForecastProvider Provider => Model.Provider();
@@ -102,6 +115,8 @@ public sealed record ForecastRequest
     public DateTimeOffset From { get; }
 
     public DateTimeOffset Through { get; }
+
+    public ForecastRefreshPolicy RefreshPolicy { get; }
 }
 
 public sealed record ForecastProgress
@@ -359,7 +374,8 @@ public sealed record ForecastAcquisition
         ForecastRun run,
         LocalGribArtifact artifact,
         ForecastAcquisitionSource source,
-        CacheMetadata? cache = null)
+        CacheMetadata? cache = null,
+        ForecastCacheUsage? cacheUsage = null)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(run);
@@ -374,6 +390,7 @@ public sealed record ForecastAcquisition
         Artifact = artifact;
         Source = source;
         Cache = cache;
+        CacheUsage = cacheUsage;
     }
 
     public ForecastRequest Request { get; }
@@ -387,6 +404,43 @@ public sealed record ForecastAcquisition
     public ForecastAcquisitionSource Source { get; }
 
     public CacheMetadata? Cache { get; }
+
+    public ForecastCacheUsage? CacheUsage { get; }
+}
+
+public sealed record ForecastCacheUsage
+{
+    public ForecastCacheUsage(
+        int reusedPartCount,
+        int downloadedPartCount,
+        DateTimeOffset selectedRun,
+        DateTimeOffset latestPublishedRun)
+    {
+        if (reusedPartCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(reusedPartCount));
+        }
+
+        if (downloadedPartCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(downloadedPartCount));
+        }
+
+        ReusedPartCount = reusedPartCount;
+        DownloadedPartCount = downloadedPartCount;
+        SelectedRun = selectedRun.ToUniversalTime();
+        LatestPublishedRun = latestPublishedRun.ToUniversalTime();
+    }
+
+    public int ReusedPartCount { get; }
+
+    public int DownloadedPartCount { get; }
+
+    public DateTimeOffset SelectedRun { get; }
+
+    public DateTimeOffset LatestPublishedRun { get; }
+
+    public bool IsNewerRunAvailable => LatestPublishedRun > SelectedRun;
 }
 
 public interface IForecastProvider

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -10,10 +10,16 @@ public sealed record RoutePlanRoutingRequest
         RoutePlan plan,
         DateTimeOffset departureTime,
         DateTimeOffset forecastCutoff,
-        IEnumerable<ForecastSelection> selections)
+        IEnumerable<ForecastSelection> selections,
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(selections);
+        if (!Enum.IsDefined(refreshPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(refreshPolicy));
+        }
+
         var immutableSelections = selections.ToImmutableArray();
         if (immutableSelections.Length is < 1 or > 2 ||
             immutableSelections.Select(selection => selection.Model).Distinct().Count() !=
@@ -45,6 +51,7 @@ public sealed record RoutePlanRoutingRequest
         ForecastCutoff = cutoffUtc;
         Selections = immutableSelections;
         Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
+        RefreshPolicy = refreshPolicy;
         StartLegIndex = plan.ActiveLegIndex;
         StartOrigin = plan.CurrentPosition?.Coordinate ??
             plan.Waypoints[StartLegIndex].Coordinate;
@@ -59,6 +66,8 @@ public sealed record RoutePlanRoutingRequest
     public ImmutableArray<ForecastSelection> Selections { get; }
 
     public ImmutableArray<ForecastModel> Models { get; }
+
+    public ForecastRefreshPolicy RefreshPolicy { get; }
 
     /// <summary>
     /// The index of the leg routing should resume from: <see cref="RoutePlan.ActiveLegIndex"/> at
@@ -240,7 +249,8 @@ public sealed class RoutePlanRoutingWorkflow
                     var workflowRequest = new RoutingWorkflowRequest(
                         route,
                         [modelState.Selection],
-                        ForecastCorridor.Create(route.Origin, route.Destination));
+                        ForecastCorridor.Create(route.Origin, route.Destination),
+                        request.RefreshPolicy);
                     var legProgress = new InlineProgress<RoutingProgress>(value =>
                         progressState.Report(
                             value.Model,

--- a/src/Navtool.Core/RoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutingWorkflow.cs
@@ -7,21 +7,29 @@ public sealed record RoutingWorkflowRequest
     public RoutingWorkflowRequest(
         RouteRequest route,
         IEnumerable<ForecastModel> models,
-        GeographicBounds? forecastBounds = null)
+        GeographicBounds? forecastBounds = null,
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
         : this(
             route,
             CreateDownloadSelections(models),
-            forecastBounds)
+            forecastBounds,
+            refreshPolicy)
     {
     }
 
     public RoutingWorkflowRequest(
         RouteRequest route,
         IEnumerable<ForecastSelection> selections,
-        GeographicBounds? forecastBounds = null)
+        GeographicBounds? forecastBounds = null,
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
     {
         ArgumentNullException.ThrowIfNull(route);
         ArgumentNullException.ThrowIfNull(selections);
+        if (!Enum.IsDefined(refreshPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(refreshPolicy));
+        }
+
         var immutableSelections = selections.ToImmutableArray();
         if (immutableSelections.Length is < 1 or > 2 ||
             immutableSelections.Select(selection => selection.Model).Distinct().Count() !=
@@ -52,6 +60,7 @@ public sealed record RoutingWorkflowRequest
         Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
         ForecastBounds = forecastBounds ?? GeographicBounds.FromCoordinates(
             new[] { route.Origin, route.Destination });
+        RefreshPolicy = refreshPolicy;
     }
 
     public RouteRequest Route { get; }
@@ -61,6 +70,8 @@ public sealed record RoutingWorkflowRequest
     public ImmutableArray<ForecastSelection> Selections { get; }
 
     public GeographicBounds ForecastBounds { get; }
+
+    public ForecastRefreshPolicy RefreshPolicy { get; }
 
     private static IEnumerable<ForecastSelection> CreateDownloadSelections(
         IEnumerable<ForecastModel> models)
@@ -279,7 +290,8 @@ public sealed class RoutingWorkflow
                 model,
                 request.ForecastBounds,
                 request.Route.DepartureTime,
-                request.Route.LatestArrivalTime);
+                request.Route.LatestArrivalTime,
+                request.RefreshPolicy);
             var forecastProgress = new SynchronousProgress<ForecastProgress>(value =>
                 Report(
                     progress,

--- a/src/Navtool.Infrastructure/AtomicFileCache.cs
+++ b/src/Navtool.Infrastructure/AtomicFileCache.cs
@@ -1,6 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Navtool.Core;
 
 namespace Navtool.Infrastructure;
@@ -10,7 +12,7 @@ public sealed record AtomicFileCacheOptions
     public AtomicFileCacheOptions(
         string rootDirectory,
         long maximumBytes = 2L * 1024 * 1024 * 1024,
-        int maximumEntries = 64)
+        int maximumEntries = 4096)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(rootDirectory);
         if (maximumBytes <= 0)
@@ -46,13 +48,18 @@ public sealed class AtomicFileCache
     private const string ArtifactExtension = ".grib2";
     private const string MetadataExtension = ".metadata.json";
     private readonly AtomicFileCacheOptions _options;
+    private readonly ILogger<AtomicFileCache> _logger;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
-    public AtomicFileCache(AtomicFileCacheOptions options)
+    public AtomicFileCache(
+        AtomicFileCacheOptions options,
+        ILogger<AtomicFileCache>? logger = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         _options = options;
+        _logger = logger ?? NullLogger<AtomicFileCache>.Instance;
         Directory.CreateDirectory(_options.RootDirectory);
+        SweepOrphanedPartials();
     }
 
     public string RootDirectory => _options.RootDirectory;
@@ -84,7 +91,20 @@ public sealed class AtomicFileCache
     public async ValueTask<AtomicCacheEntry?> TryGetFreshAsync(
         string key,
         DateTimeOffset now,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        await TryGetAsync(key, now, requireFresh: true, cancellationToken).ConfigureAwait(false);
+
+    public async ValueTask<AtomicCacheEntry?> TryGetAsync(
+        string key,
+        DateTimeOffset accessedAt,
+        CancellationToken cancellationToken = default) =>
+        await TryGetAsync(key, accessedAt, requireFresh: false, cancellationToken).ConfigureAwait(false);
+
+    private async ValueTask<AtomicCacheEntry?> TryGetAsync(
+        string key,
+        DateTimeOffset accessedAt,
+        bool requireFresh,
+        CancellationToken cancellationToken)
     {
         ValidateKey(key);
         cancellationToken.ThrowIfCancellationRequested();
@@ -108,9 +128,23 @@ public sealed class AtomicFileCache
             }
 
             var metadata = new CacheMetadata(stored.Key, stored.CreatedAt, stored.ExpiresAt);
-            if (!metadata.IsFreshAt(now))
+            if (requireFresh && !metadata.IsFreshAt(accessedAt))
             {
                 return null;
+            }
+
+            var touched = stored with { LastAccessedAt = accessedAt.ToUniversalTime() };
+            try
+            {
+                await WriteMetadataAtomicallyAsync(metadataPath, touched, cancellationToken).ConfigureAwait(false);
+            }
+            catch (IOException exception)
+            {
+                _logger.LogWarning(exception, "Could not update cache access time for {CacheKey}", key);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                _logger.LogWarning(exception, "Could not update cache access time for {CacheKey}", key);
             }
 
             return new AtomicCacheEntry(key, artifactPath, file.Length, metadata);
@@ -163,20 +197,9 @@ public sealed class AtomicFileCache
                 key,
                 metadata.CreatedAt,
                 metadata.ExpiresAt,
-                length);
-            await using (var output = new FileStream(
-                             metadataTemp,
-                             FileMode.CreateNew,
-                             FileAccess.Write,
-                             FileShare.None,
-                             16 * 1024,
-                             FileOptions.Asynchronous | FileOptions.WriteThrough))
-            {
-                await JsonSerializer.SerializeAsync(output, stored, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-                await output.FlushAsync(cancellationToken).ConfigureAwait(false);
-                output.Flush(true);
-            }
+                length,
+                metadata.CreatedAt);
+            await WriteMetadataFileAsync(metadataTemp, stored, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
             var artifactPath = GetArtifactPath(key);
@@ -244,7 +267,7 @@ public sealed class AtomicFileCache
         foreach (var entry in entries
                      .Where(entry => !string.Equals(entry.Metadata.Key, protectedKey, StringComparison.Ordinal))
                      .OrderBy(entry => entry.Metadata.ExpiresAt > now)
-                     .ThenBy(entry => entry.Metadata.CreatedAt)
+                     .ThenBy(entry => entry.Metadata.LastAccessedAt ?? entry.Metadata.CreatedAt)
                      .ThenBy(entry => entry.Metadata.Key, StringComparer.Ordinal))
         {
             if (count <= _options.MaximumEntries && bytes <= _options.MaximumBytes)
@@ -288,9 +311,45 @@ public sealed class AtomicFileCache
                        .ConfigureAwait(false) ??
                    throw new InvalidDataException($"Cache metadata '{path}' is empty.");
         }
+
         catch (JsonException exception)
         {
             throw new InvalidDataException($"Cache metadata '{path}' is invalid JSON.", exception);
+        }
+    }
+
+    private static async ValueTask WriteMetadataFileAsync(
+        string path,
+        StoredCacheMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        await using var output = new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.Write,
+            FileShare.None,
+            16 * 1024,
+            FileOptions.Asynchronous | FileOptions.WriteThrough);
+        await JsonSerializer.SerializeAsync(output, metadata, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+        output.Flush(true);
+    }
+
+    private static async ValueTask WriteMetadataAtomicallyAsync(
+        string path,
+        StoredCacheMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        var temp = $"{path}.{Guid.NewGuid():N}.partial";
+        try
+        {
+            await WriteMetadataFileAsync(temp, metadata, cancellationToken).ConfigureAwait(false);
+            File.Move(temp, path, true);
+        }
+        finally
+        {
+            DeleteIfPresent(temp);
         }
     }
 
@@ -370,11 +429,23 @@ public sealed class AtomicFileCache
         }
     }
 
+    private void SweepOrphanedPartials()
+    {
+        foreach (var path in Directory.EnumerateFiles(
+                     _options.RootDirectory,
+                     "*.partial",
+                     SearchOption.TopDirectoryOnly))
+        {
+            DeleteIfPresent(path);
+        }
+    }
+
     private sealed record StoredCacheMetadata(
         string Key,
         DateTimeOffset CreatedAt,
         DateTimeOffset ExpiresAt,
-        long LengthBytes);
+        long LengthBytes,
+        DateTimeOffset? LastAccessedAt = null);
 
     private sealed record StoredEntry(
         StoredCacheMetadata Metadata,

--- a/src/Navtool.Infrastructure/AtomicFileCache.cs
+++ b/src/Navtool.Infrastructure/AtomicFileCache.cs
@@ -436,7 +436,28 @@ public sealed class AtomicFileCache
                      "*.partial",
                      SearchOption.TopDirectoryOnly))
         {
-            DeleteIfPresent(path);
+            try
+            {
+                using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                }
+
+                File.Delete(path);
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (IOException)
+            {
+                // Another process still owns this partial; its atomic promotion must finish.
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                _logger.LogWarning(exception, "Could not inspect orphaned cache partial {Path}", path);
+            }
         }
     }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -14,7 +14,7 @@ public sealed record NoaaGfsOptions
 
     public TimeSpan PublicationDelay { get; init; } = TimeSpan.FromHours(5);
 
-    public TimeSpan CacheFreshness { get; init; } = TimeSpan.FromHours(6);
+    public double CacheTileSizeDegrees { get; init; } = 10;
 
     public TimeSpan ForecastHorizon { get; init; } = TimeSpan.FromHours(384);
 
@@ -79,6 +79,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly Dictionary<string, AcquisitionGate> _acquisitionGates =
         new(StringComparer.Ordinal);
     private readonly object _acquisitionGatesLock = new();
+    private readonly Dictionary<string, int> _activePartPaths;
+    private readonly object _activePartPathsLock = new();
 
     public NoaaGfsForecastProvider(
         HttpClient httpClient,
@@ -94,6 +96,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         _timeProvider = timeProvider ?? TimeProvider.System;
         _options = options ?? new NoaaGfsOptions();
         _logger = logger ?? NullLogger<NoaaGfsForecastProvider>.Instance;
+        _activePartPaths = new Dictionary<string, int>(
+            OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         ValidateOptions(_options);
     }
 
@@ -125,8 +129,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var runTime = SelectRun(request, _timeProvider.GetUtcNow());
         var steps = GetRequiredForecastHours(runTime, request.From, request.Through);
         var bounds = AlignBoundsToGrid(request.Bounds);
-        var regions = GetNomadsLongitudeWindows(bounds);
-        return new NoaaGfsDownloadEstimate(runTime, bounds, steps.Length, regions.Length);
+        var tiles = GetCacheTiles(bounds, _options.CacheTileSizeDegrees);
+        return new NoaaGfsDownloadEstimate(runTime, bounds, steps.Length, tiles.Length);
     }
 
     public async ValueTask<ForecastAcquisition> AcquireAsync(
@@ -145,7 +149,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         // (including the definitive cache key) is computed ONCE here and threaded into the
         // core so the gate and the download/store always agree on the same key, even if
         // the clock advances across a run-publish boundary while queued behind the gate.
-        var plan = CreateAcquisitionPlan(request);
+        var plan = await SelectAcquisitionPlanAsync(request, cancellationToken).ConfigureAwait(false);
         var gate = RentGate(plan.CacheKey);
 
         try
@@ -208,22 +212,85 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     // for a request against a single captured "now". Computing this once (rather than
     // recomputing inside the gated core) is what keeps the acquisition gate key and the
     // stored artifact key identical.
-    private AcquisitionPlan CreateAcquisitionPlan(ForecastRequest request)
+    private AcquisitionPlan CreateAcquisitionPlan(
+        ForecastRequest request,
+        DateTimeOffset now,
+        DateTimeOffset runTime)
     {
-        var now = _timeProvider.GetUtcNow();
-        var runTime = SelectRun(request, now);
         var steps = GetRequiredForecastHours(runTime, request.From, request.Through);
         var downloadBounds = AlignBoundsToGrid(request.Bounds);
-        var cacheKey = CreateCacheKey(downloadBounds, runTime, steps);
-        return new AcquisitionPlan(now, runTime, steps, downloadBounds, cacheKey);
+        var tiles = GetCacheTiles(downloadBounds, _options.CacheTileSizeDegrees);
+        var manifest = BuildTiledPartManifest(runTime, steps, tiles);
+        var cacheKey = CreateAssemblyCacheKey(runTime, manifest);
+        var legacyCacheKey = CreateLegacyCacheKey(downloadBounds, runTime, steps);
+        return new AcquisitionPlan(
+            now,
+            runTime,
+            SelectRun(request, now),
+            steps,
+            downloadBounds,
+            manifest,
+            cacheKey,
+            legacyCacheKey);
     }
 
     private readonly record struct AcquisitionPlan(
         DateTimeOffset Now,
         DateTimeOffset RunTime,
+        DateTimeOffset LatestPublishedRun,
         ImmutableArray<int> Steps,
         GeographicBounds DownloadBounds,
-        string CacheKey);
+        ImmutableArray<GribPartDescriptor> Manifest,
+        string CacheKey,
+        string LegacyCacheKey);
+
+    private async ValueTask<AcquisitionPlan> SelectAcquisitionPlanAsync(
+        ForecastRequest request,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        var latestRun = SelectRun(request, now);
+        var latestPlan = CreateAcquisitionPlan(request, now, latestRun);
+        if (request.RefreshPolicy == ForecastRefreshPolicy.LatestAvailable)
+        {
+            return latestPlan;
+        }
+
+        for (var index = 0; index <= _options.MaximumRunLookbackCycles; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var candidate = latestRun.AddHours(-6d * index);
+            if (candidate > request.From ||
+                request.Through > candidate + _options.ForecastHorizon)
+            {
+                continue;
+            }
+
+            var plan = index == 0
+                ? latestPlan
+                : CreateAcquisitionPlan(request, now, candidate);
+            if (await IsPlanFullyCachedAsync(plan, cancellationToken).ConfigureAwait(false))
+            {
+                return plan;
+            }
+        }
+
+        return latestPlan;
+    }
+
+    private async ValueTask<bool> IsPlanFullyCachedAsync(
+        AcquisitionPlan plan,
+        CancellationToken cancellationToken)
+    {
+        if (await _cache.TryGetAsync(plan.CacheKey, plan.Now, cancellationToken).ConfigureAwait(false) is not null ||
+            await _cache.TryGetAsync(plan.LegacyCacheKey, plan.Now, cancellationToken).ConfigureAwait(false) is not null)
+        {
+            return true;
+        }
+
+        var partsDirectory = GetPartsDirectory();
+        return plan.Manifest.All(part => File.Exists(Path.Combine(partsDirectory, part.PartKey + ".grib2")));
+    }
 
     private async ValueTask<ForecastAcquisition> AcquireCoreAsync(
         ForecastRequest request,
@@ -237,21 +304,23 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var runTime = plan.RunTime;
         var steps = plan.Steps;
         var downloadBounds = plan.DownloadBounds;
-        var regions = GetNomadsLongitudeWindows(downloadBounds);
         var cacheKey = plan.CacheKey;
+        var manifest = plan.Manifest;
         _logger.LogInformation(
-            "Selected NOAA GFS run {RunTime} with {StepCount} steps, {RegionCount} regions, download bounds " +
+            "Selected NOAA GFS run {RunTime} with {StepCount} steps, {PartCount} tiled parts, download bounds " +
             "south={South}, north={North}, west={West}, east={East}, and cache key {CacheKey}",
             runTime,
             steps.Length,
-            regions.Length,
+            manifest.Length,
             downloadBounds.South,
             downloadBounds.North,
             downloadBounds.West,
             downloadBounds.East,
             cacheKey);
 
-        var cached = await _cache.TryGetFreshAsync(cacheKey, now, cancellationToken)
+        var cached = await _cache.TryGetAsync(cacheKey, now, cancellationToken)
+            .ConfigureAwait(false);
+        cached ??= await _cache.TryGetAsync(plan.LegacyCacheKey, now, cancellationToken)
             .ConfigureAwait(false);
         if (cached is not null)
         {
@@ -262,23 +331,20 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                 request,
                 runTime,
                 cached,
-                ForecastAcquisitionSource.Cache);
+                ForecastAcquisitionSource.Cache,
+                new ForecastCacheUsage(
+                    manifest.Length,
+                    0,
+                    runTime,
+                    plan.LatestPublishedRun));
         }
 
         _logger.LogInformation("NOAA GFS cache miss for {CacheKey}", cacheKey);
 
-        // Build deterministic download manifest: forecast_hour ascending, then region index ascending.
-        var manifest = BuildPartManifest(runTime, steps, regions, downloadBounds);
-        // Isolate this cache key's resumable parts in their own subdirectory. Acquisitions
-        // for a given cache key are serialized by the keyed gate, so each subdirectory has a
-        // single writer at a time; acquisitions for different cache keys use different
-        // subdirectories. Pruning and orphan sweeping therefore only ever touch the current
-        // key's own parts, so a concurrent acquisition for another key can never have its
-        // freshly downloaded parts deleted as "stale," and file enumeration cannot race a
-        // delete from another acquisition. The cache key is a "<category>-<sha256-hex>"
-        // token (see AtomicFileCache.CreateKey), which is always a filesystem-safe segment.
-        var partsDirectory = Path.Combine(_cache.RootDirectory, "noaa-gfs-parts", cacheKey);
+        var partsDirectory = GetPartsDirectory();
         Directory.CreateDirectory(partsDirectory);
+        MigrateLegacyParts(partsDirectory);
+        using var partProtection = ProtectParts(partsDirectory, manifest);
         PrunePartCache(partsDirectory, manifest);
 
         var totalParts = manifest.Length;
@@ -291,40 +357,56 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             var part = manifest[index];
             var partFile = Path.Combine(partsDirectory, part.PartKey + ".grib2");
 
-            if (File.Exists(partFile))
+            var partGate = RentGate(part.PartKey);
+            var partGateAcquired = false;
+            try
             {
-                _logger.LogInformation(
-                    "Resuming cached part {PartIndex}/{Total} f{ForecastHour:000} region {RegionIndex}",
-                    index + 1, totalParts, part.ForecastHour, part.RegionIndex);
+                await partGate.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                partGateAcquired = true;
+                if (File.Exists(partFile))
+                {
+                    File.SetLastWriteTimeUtc(partFile, now.UtcDateTime);
+                    _logger.LogInformation(
+                        "Reusing cached tile {PartIndex}/{Total} f{ForecastHour:000} tile {RegionIndex}",
+                        index + 1, totalParts, part.ForecastHour, part.RegionIndex);
+                    Report(
+                        progress,
+                        ForecastProgressStage.Downloading,
+                        (index + 1) / (double)totalParts,
+                        $"Resumed cached f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
+                    continue;
+                }
+
+                if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+                {
+                    await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
+                }
+
+                Report(
+                    progress,
+                    ForecastProgressStage.Downloading,
+                    index / (double)totalParts,
+                    $"Downloading GFS f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
+
+                await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
+                downloadedParts++;
+                PrunePartCache(partsDirectory, manifest);
+
                 Report(
                     progress,
                     ForecastProgressStage.Downloading,
                     (index + 1) / (double)totalParts,
-                    $"Resumed cached f{part.ForecastHour:000} (part {index + 1}/{totalParts})");
-                continue;
+                    $"Downloaded {index + 1}/{totalParts} GFS tiles ({downloadedParts} new this run)");
             }
-
-            // Apply pacing before each HTTP request except the very first.
-            if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+            finally
             {
-                await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
+                if (partGateAcquired)
+                {
+                    partGate.Semaphore.Release();
+                }
+
+                ReturnGate(part.PartKey, partGate);
             }
-
-            Report(
-                progress,
-                ForecastProgressStage.Downloading,
-                index / (double)totalParts,
-                $"Downloading GFS f{part.ForecastHour:000} (part {index + 1}/{totalParts})");
-
-            await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
-            downloadedParts++;
-            PrunePartCache(partsDirectory, manifest);
-
-            Report(
-                progress,
-                ForecastProgressStage.Downloading,
-                (index + 1) / (double)totalParts,
-                $"Downloaded {index + 1}/{totalParts} GFS parts ({downloadedParts} new this run)");
         }
 
         // Concatenate all parts in manifest order into the final cached artifact.
@@ -339,7 +421,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var stored = await _cache.StoreAsync(
                 cacheKey,
                 cacheNow,
-                cacheNow + _options.CacheFreshness,
+                DateTimeOffset.MaxValue,
                 async (output, token) =>
                 {
                     foreach (var part in manifest)
@@ -365,18 +447,21 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             "Stored NOAA GFS artifact {CacheKey} with {LengthBytes} bytes",
             cacheKey,
             stored.LengthBytes);
-        foreach (var part in manifest)
-        {
-            TryDeletePart(
-                Path.Combine(partsDirectory, part.PartKey + ".grib2"),
-                "assembled NOAA part");
-        }
-
-        // The parts subdirectory is now empty on success; remove it so per-key subdirectories
-        // do not accumulate across the many distinct cache keys a long-lived session requests.
-        TryDeleteDirectoryIfEmpty(partsDirectory);
-
-        return CreateAcquisition(request, runTime, stored, ForecastAcquisitionSource.Remote);
+        partProtection.Dispose();
+        PrunePartCache(partsDirectory, [], includeAssemblyCache: true);
+        var source = downloadedParts == 0
+            ? ForecastAcquisitionSource.Cache
+            : ForecastAcquisitionSource.Remote;
+        return CreateAcquisition(
+            request,
+            runTime,
+            stored,
+            source,
+            new ForecastCacheUsage(
+                totalParts - downloadedParts,
+                downloadedParts,
+                runTime,
+                plan.LatestPublishedRun));
     }
 
     public DateTimeOffset SelectRun(ForecastRequest request, DateTimeOffset now)
@@ -534,6 +619,98 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                 var partKey = CreatePartKey(downloadBounds, runTime, forecastHour, regionIndex);
                 var uri = BuildNomadsUri(runTime, forecastHour, downloadBounds, region);
                 builder.Add(new GribPartDescriptor(forecastHour, regionIndex, region, downloadBounds, partKey, uri));
+            }
+        }
+
+        return builder.MoveToImmutable();
+    }
+
+    internal ImmutableArray<GeographicBounds> GetCacheTiles(GeographicBounds bounds) =>
+        GetCacheTiles(bounds, _options.CacheTileSizeDegrees);
+
+    internal static ImmutableArray<GeographicBounds> GetCacheTiles(
+        GeographicBounds bounds,
+        double tileSizeDegrees)
+    {
+        if (!double.IsFinite(tileSizeDegrees) ||
+            tileSizeDegrees < 0.25 ||
+            tileSizeDegrees > 180 ||
+            tileSizeDegrees % 0.25 != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(tileSizeDegrees),
+                "The cache tile size must be a 0.25-degree multiple between 0.25 and 180.");
+        }
+
+        var south = Math.Max(-90, Math.Floor(bounds.South / tileSizeDegrees) * tileSizeDegrees);
+        var north = Math.Min(90, Math.Ceiling(bounds.North / tileSizeDegrees) * tileSizeDegrees);
+        if (north <= south)
+        {
+            north = Math.Min(90, south + tileSizeDegrees);
+            if (north <= south)
+            {
+                south = Math.Max(-90, north - tileSizeDegrees);
+            }
+        }
+
+        var longitudeSegments = bounds.CrossesAntimeridian
+            ? new[] { (bounds.West, 180d), (-180d, bounds.East) }
+            : new[] { (bounds.West, bounds.East) };
+        var builder = ImmutableArray.CreateBuilder<GeographicBounds>();
+        for (var latitude = south; latitude < north; latitude += tileSizeDegrees)
+        {
+            var tileNorth = Math.Min(90, latitude + tileSizeDegrees);
+            foreach (var (segmentWest, segmentEast) in longitudeSegments)
+            {
+                if (segmentEast <= segmentWest)
+                {
+                    continue;
+                }
+
+                var west = Math.Max(-180, Math.Floor(segmentWest / tileSizeDegrees) * tileSizeDegrees);
+                var east = Math.Min(180, Math.Ceiling(segmentEast / tileSizeDegrees) * tileSizeDegrees);
+                if (east <= west)
+                {
+                    east = Math.Min(180, west + tileSizeDegrees);
+                }
+
+                for (var longitude = west; longitude < east; longitude += tileSizeDegrees)
+                {
+                    builder.Add(new GeographicBounds(
+                        latitude,
+                        tileNorth,
+                        longitude,
+                        Math.Min(180, longitude + tileSizeDegrees)));
+                }
+            }
+        }
+
+        return builder
+            .Distinct()
+            .OrderBy(tile => tile.South)
+            .ThenBy(tile => Normalize360(tile.West))
+            .ToImmutableArray();
+    }
+
+    private ImmutableArray<GribPartDescriptor> BuildTiledPartManifest(
+        DateTimeOffset runTime,
+        ImmutableArray<int> steps,
+        ImmutableArray<GeographicBounds> tiles)
+    {
+        var builder = ImmutableArray.CreateBuilder<GribPartDescriptor>(steps.Length * tiles.Length);
+        foreach (var forecastHour in steps)
+        {
+            for (var tileIndex = 0; tileIndex < tiles.Length; tileIndex++)
+            {
+                var tile = tiles[tileIndex];
+                var longitudeWindow = GetNomadsLongitudeWindows(tile).Single();
+                builder.Add(new GribPartDescriptor(
+                    forecastHour,
+                    tileIndex,
+                    longitudeWindow,
+                    tile,
+                    CreatePartKey(tile, runTime, forecastHour, 0),
+                    BuildNomadsUri(runTime, forecastHour, tile, longitudeWindow)));
             }
         }
 
@@ -841,7 +1018,8 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         ForecastRequest request,
         DateTimeOffset runTime,
         AtomicCacheEntry entry,
-        ForecastAcquisitionSource source)
+        ForecastAcquisitionSource source,
+        ForecastCacheUsage? cacheUsage = null)
     {
         var file = new FileInfo(entry.Path);
         return new ForecastAcquisition(
@@ -849,10 +1027,11 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             new ForecastRun(ForecastProvider.Noaa, ForecastModel.NoaaGfs, runTime),
             new LocalGribArtifact(entry.Path, file.Length, file.LastWriteTimeUtc),
             source,
-            entry.Metadata);
+            entry.Metadata,
+            cacheUsage);
     }
 
-    private static string CreateCacheKey(
+    private static string CreateLegacyCacheKey(
         GeographicBounds bounds,
         DateTimeOffset runTime,
         ImmutableArray<int> steps) =>
@@ -864,6 +1043,14 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             Format(bounds.West),
             Format(bounds.East),
             string.Join(",", steps));
+
+    private static string CreateAssemblyCacheKey(
+        DateTimeOffset runTime,
+        ImmutableArray<GribPartDescriptor> manifest) =>
+        AtomicFileCache.CreateKey(
+            "noaa-gfs-assembly-v2",
+            runTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+            string.Join(",", manifest.Select(part => part.PartKey)));
 
     private static string CreatePartKey(
         GeographicBounds bounds,
@@ -915,9 +1102,90 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         string message) =>
         progress?.Report(new ForecastProgress(Provider, Model, stage, fraction, message));
 
+    private string GetPartsDirectory() =>
+        Path.Combine(_cache.RootDirectory, "noaa-gfs-parts");
+
+    private void MigrateLegacyParts(string partsDirectory)
+    {
+        foreach (var legacyDirectory in Directory.EnumerateDirectories(
+                     partsDirectory,
+                     "*",
+                     SearchOption.TopDirectoryOnly))
+        {
+            foreach (var source in Directory.EnumerateFiles(
+                         legacyDirectory,
+                         "*.grib2",
+                         SearchOption.TopDirectoryOnly))
+            {
+                var destination = Path.Combine(partsDirectory, Path.GetFileName(source));
+                if (File.Exists(destination))
+                {
+                    TryDeletePart(source, "duplicate legacy NOAA part");
+                    continue;
+                }
+
+                try
+                {
+                    File.Move(source, destination);
+                }
+                catch (IOException exception)
+                {
+                    _logger.LogWarning(
+                        exception,
+                        "Could not migrate legacy NOAA part {Source} to {Destination}",
+                        source,
+                        destination);
+                }
+            }
+
+            TryDeleteDirectoryIfEmpty(legacyDirectory);
+        }
+    }
+
+    private IDisposable ProtectParts(
+        string partsDirectory,
+        ImmutableArray<GribPartDescriptor> manifest)
+    {
+        var paths = manifest
+            .Select(part => Path.Combine(partsDirectory, part.PartKey + ".grib2"))
+            .Distinct(OperatingSystem.IsWindows()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
+            .ToArray();
+        lock (_activePartPathsLock)
+        {
+            foreach (var path in paths)
+            {
+                _activePartPaths[path] = _activePartPaths.GetValueOrDefault(path) + 1;
+            }
+        }
+
+        return new PartProtection(this, paths);
+    }
+
+    private void ReleasePartProtection(IEnumerable<string> paths)
+    {
+        lock (_activePartPathsLock)
+        {
+            foreach (var path in paths)
+            {
+                var count = _activePartPaths[path] - 1;
+                if (count == 0)
+                {
+                    _activePartPaths.Remove(path);
+                }
+                else
+                {
+                    _activePartPaths[path] = count;
+                }
+            }
+        }
+    }
+
     private void PrunePartCache(
         string partsDirectory,
-        ImmutableArray<GribPartDescriptor> protectedManifest)
+        ImmutableArray<GribPartDescriptor> protectedManifest,
+        bool includeAssemblyCache = false)
     {
         SweepOrphanedPartials(partsDirectory);
 
@@ -927,11 +1195,23 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var protectedPaths = protectedManifest
             .Select(part => Path.Combine(partsDirectory, part.PartKey + ".grib2"))
             .ToHashSet(comparer);
+        lock (_activePartPathsLock)
+        {
+            protectedPaths.UnionWith(_activePartPaths.Keys);
+        }
+
         var files = Directory
             .EnumerateFiles(partsDirectory, "*.grib2", SearchOption.TopDirectoryOnly)
             .Select(path => new FileInfo(path))
             .ToList();
-        var maximumEntries = Math.Max(_cache.MaximumEntries, protectedManifest.Length);
+        var assemblyFiles = includeAssemblyCache
+            ? Directory.EnumerateFiles(_cache.RootDirectory, "*.grib2", SearchOption.TopDirectoryOnly)
+                .Select(path => new FileInfo(path))
+                .ToArray()
+            : [];
+        var availableBytes = Math.Max(0, _cache.MaximumBytes - assemblyFiles.Sum(file => file.Length));
+        var availableEntries = Math.Max(0, _cache.MaximumEntries - assemblyFiles.Length);
+        var maximumEntries = Math.Max(availableEntries, protectedPaths.Count);
         var bytes = files.Sum(file => file.Length);
         var count = files.Count;
 
@@ -940,7 +1220,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                      .OrderBy(file => file.LastWriteTimeUtc)
                      .ThenBy(file => file.Name, StringComparer.Ordinal))
         {
-            if (count <= maximumEntries && bytes <= _cache.MaximumBytes)
+            if (count <= maximumEntries && bytes <= availableBytes)
             {
                 break;
             }
@@ -953,19 +1233,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             }
         }
 
-        if (count > maximumEntries || bytes > _cache.MaximumBytes)
+        if (count > maximumEntries || bytes > availableBytes)
         {
-            throw new IOException(
-                "The resumable NOAA parts for the current request exceed the configured cache bounds.");
+            _logger.LogWarning(
+                "Active NOAA tiles temporarily exceed the shared cache bounds: {Count} entries, {Bytes} bytes",
+                count,
+                bytes);
         }
     }
 
-    // Deletes ".partial" temp files left behind by a prior process that was terminated
-    // mid-download. The parts subdirectory is isolated per cache key and acquisitions for a
-    // given key are serialized, so at every prune point the current acquisition holds no
-    // in-flight partial of its own: any ".partial" here is therefore an orphan from an
-    // earlier interrupted run of the same key. A completed download is atomically moved to
-    // its ".grib2" name, so a lingering ".partial" is always incomplete and safe to delete.
+    // Completed downloads are atomically promoted to ".grib2", so partials encountered
+    // before an acquisition starts are remnants of an interrupted process.
     private void SweepOrphanedPartials(string partsDirectory)
     {
         foreach (var path in Directory.EnumerateFiles(
@@ -1021,11 +1299,14 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
     private static void ValidateOptions(NoaaGfsOptions options)
     {
-        if (options.FilterEndpoint is null ||
-            !options.FilterEndpoint.IsAbsoluteUri ||
-            options.PublicationDelay < TimeSpan.Zero ||
-            options.CacheFreshness <= TimeSpan.Zero ||
-            options.ForecastHorizon <= TimeSpan.Zero ||
+        if (        options.FilterEndpoint is null ||
+        !options.FilterEndpoint.IsAbsoluteUri ||
+        options.PublicationDelay < TimeSpan.Zero ||
+        !double.IsFinite(options.CacheTileSizeDegrees) ||
+        options.CacheTileSizeDegrees < 0.25 ||
+        options.CacheTileSizeDegrees > 180 ||
+        options.CacheTileSizeDegrees % 0.25 != 0 ||
+        options.ForecastHorizon <= TimeSpan.Zero ||
             options.ForecastHorizon > TimeSpan.FromHours(384) ||
             options.MaximumRunLookbackCycles < 0 ||
             options.MaximumResponseBytes <= 0 ||
@@ -1044,6 +1325,21 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         : ForecastDownloadException(message)
     {
         public TimeSpan? RetryAfter { get; } = retryAfter;
+    }
+
+    private sealed class PartProtection(
+        NoaaGfsForecastProvider owner,
+        string[] paths) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
+            {
+                owner.ReleasePartProtection(paths);
+            }
+        }
     }
 }
 

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -1251,7 +1251,28 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             "*.partial",
             SearchOption.TopDirectoryOnly))
         {
-            TryDeletePart(path, "orphaned NOAA temporary part");
+            try
+            {
+                using (new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+                {
+                }
+
+                File.Delete(path);
+            }
+            catch (FileNotFoundException)
+            {
+            }
+            catch (DirectoryNotFoundException)
+            {
+            }
+            catch (IOException)
+            {
+                // A concurrent acquisition still owns this partial download.
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                _logger.LogWarning(exception, "Could not inspect orphaned NOAA partial {Path}", path);
+            }
         }
     }
 
@@ -1299,14 +1320,14 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
     private static void ValidateOptions(NoaaGfsOptions options)
     {
-        if (        options.FilterEndpoint is null ||
-        !options.FilterEndpoint.IsAbsoluteUri ||
-        options.PublicationDelay < TimeSpan.Zero ||
-        !double.IsFinite(options.CacheTileSizeDegrees) ||
-        options.CacheTileSizeDegrees < 0.25 ||
-        options.CacheTileSizeDegrees > 180 ||
-        options.CacheTileSizeDegrees % 0.25 != 0 ||
-        options.ForecastHorizon <= TimeSpan.Zero ||
+        if (options.FilterEndpoint is null ||
+            !options.FilterEndpoint.IsAbsoluteUri ||
+            options.PublicationDelay < TimeSpan.Zero ||
+            !double.IsFinite(options.CacheTileSizeDegrees) ||
+            options.CacheTileSizeDegrees < 0.25 ||
+            options.CacheTileSizeDegrees > 180 ||
+            options.CacheTileSizeDegrees % 0.25 != 0 ||
+            options.ForecastHorizon <= TimeSpan.Zero ||
             options.ForecastHorizon > TimeSpan.FromHours(384) ||
             options.MaximumRunLookbackCycles < 0 ||
             options.MaximumResponseBytes <= 0 ||

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -119,6 +119,53 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Newest_weather_control_propagates_refresh_policy()
+    {
+        ForecastRefreshPolicy? observedPolicy = null;
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) =>
+            {
+                observedPolicy = request.RefreshPolicy;
+                return ValueTask.FromResult(CreateAcquisition(request));
+            });
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        viewModel.UseNewestWeatherData = true;
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Equal(ForecastRefreshPolicy.LatestAvailable, observedPolicy);
+    }
+
+    [Fact]
+    public async Task Covering_cached_run_warns_when_newer_weather_is_available()
+    {
+        var selectedRun = new DateTimeOffset(2026, 7, 14, 6, 0, 0, TimeSpan.Zero);
+        var latestRun = selectedRun.AddHours(6);
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(
+                request,
+                new ForecastCacheUsage(3, 0, selectedRun, latestRun))));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.Contains("cached run", viewModel.WarningMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Use newest weather data", viewModel.WarningMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ArrivalBeyondRequestedDurationSucceedsWithOverDurationNote()
     {
         var noaa = new DelegateForecastProvider(
@@ -1245,13 +1292,16 @@ public sealed class MainViewModelWorkflowTests
         return viewModel;
     }
 
-    private static ForecastAcquisition CreateAcquisition(ForecastRequest request) =>
+    private static ForecastAcquisition CreateAcquisition(
+        ForecastRequest request,
+        ForecastCacheUsage? cacheUsage = null) =>
         new(
             request,
             new ForecastRun(request.Provider, request.Model, request.From.AddHours(-6)),
             new LocalGribArtifact(Path.GetFullPath("fake-forecast.grib2")),
             ForecastAcquisitionSource.Cache,
-            new CacheMetadata("fake", request.From.AddHours(-1), request.Through.AddHours(1)));
+            new CacheMetadata("fake", request.From.AddHours(-1), request.Through.AddHours(1)),
+            cacheUsage);
 
     private static RouteResult CreateRoute(
         RouteRequest request,

--- a/tests/Navtool.Infrastructure.Tests/AtomicFileCacheTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/AtomicFileCacheTests.cs
@@ -108,4 +108,24 @@ public sealed class AtomicFileCacheTests
         Assert.Null(await restarted.TryGetAsync(second, now.AddHours(2)));
         Assert.NotNull(await restarted.TryGetAsync(third, now.AddHours(2)));
     }
+
+    [Fact]
+    public void Startup_sweep_does_not_delete_partial_owned_by_another_writer()
+    {
+        using var directory = new TestDirectory();
+        var partial = Path.Combine(directory.Path, ".cache.inflight.partial");
+        using (var writer = new FileStream(
+                   partial,
+                   FileMode.CreateNew,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            writer.WriteByte(1);
+            _ = new AtomicFileCache(new AtomicFileCacheOptions(directory.Path));
+            Assert.True(File.Exists(partial));
+        }
+
+        _ = new AtomicFileCache(new AtomicFileCacheOptions(directory.Path));
+        Assert.False(File.Exists(partial));
+    }
 }

--- a/tests/Navtool.Infrastructure.Tests/AtomicFileCacheTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/AtomicFileCacheTests.cs
@@ -85,4 +85,27 @@ public sealed class AtomicFileCacheTests
         Assert.NotNull(await cache.TryGetFreshAsync(third, now.AddMinutes(3)));
         Assert.Equal(2, Directory.EnumerateFiles(directory.Path, "*.grib2").Count());
     }
+
+    [Fact]
+    public async Task Nonexpiring_lookup_survives_restart_and_touches_entry_for_lru()
+    {
+        using var directory = new TestDirectory();
+        var now = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+        var first = AtomicFileCache.CreateKey("test", "first");
+        var second = AtomicFileCache.CreateKey("test", "second");
+        var third = AtomicFileCache.CreateKey("test", "third");
+        var options = new AtomicFileCacheOptions(directory.Path, maximumBytes: 32, maximumEntries: 2);
+
+        var writer = new AtomicFileCache(options);
+        await writer.StoreAsync(first, now, now.AddMinutes(1), "first"u8.ToArray());
+        await writer.StoreAsync(second, now.AddMinutes(1), now.AddMinutes(2), "second"u8.ToArray());
+
+        var restarted = new AtomicFileCache(options);
+        Assert.NotNull(await restarted.TryGetAsync(first, now.AddHours(2)));
+        await restarted.StoreAsync(third, now.AddHours(2), DateTimeOffset.MaxValue, "third"u8.ToArray());
+
+        Assert.NotNull(await restarted.TryGetAsync(first, now.AddHours(2)));
+        Assert.Null(await restarted.TryGetAsync(second, now.AddHours(2)));
+        Assert.NotNull(await restarted.TryGetAsync(third, now.AddHours(2)));
+    }
 }

--- a/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NoaaGfsForecastProviderTests.cs
@@ -74,7 +74,7 @@ public sealed class NoaaGfsForecastProviderTests
         Assert.Equal(ForecastAcquisitionSource.Remote, acquired.Source);
         Assert.Equal(ForecastAcquisitionSource.Cache, cached.Source);
         Assert.Equal(new DateTimeOffset(2026, 7, 14, 6, 0, 0, TimeSpan.Zero), acquired.Run.InitializedAt);
-        Assert.Equal(3, handler.RequestCount);
+        Assert.Equal(6, handler.RequestCount);
         Assert.Equal(1, handler.MaximumConcurrency);
         Assert.All(handler.Requests, uri =>
         {
@@ -82,14 +82,80 @@ public sealed class NoaaGfsForecastProviderTests
             Assert.Contains("lev_10_m_above_ground=on", query);
             Assert.Contains("var_UGRD=on", query);
             Assert.Contains("var_VGRD=on", query);
-            Assert.Contains("leftlon=170", query);
-            Assert.Contains("rightlon=190", query);
-            Assert.Contains("toplat=45", query);
+            Assert.True(
+                query.Contains("leftlon=170", StringComparison.Ordinal) ||
+                query.Contains("leftlon=180", StringComparison.Ordinal));
+            Assert.True(
+                query.Contains("rightlon=180", StringComparison.Ordinal) ||
+                query.Contains("rightlon=190", StringComparison.Ordinal));
+            Assert.Contains("toplat=50", query);
             Assert.Contains("bottomlat=40", query);
         });
-        Assert.Equal(3 * "GRIBpayload7777"u8.Length, new FileInfo(acquired.Artifact.Path).Length);
+        Assert.Equal(6 * "GRIBpayload7777"u8.Length, new FileInfo(acquired.Artifact.Path).Length);
         Assert.Contains(progress, item => item.Stage == ForecastProgressStage.Downloading);
         Assert.Equal(ForecastProgressStage.Completed, progress[^1].Stage);
+    }
+
+    [Fact]
+    public async Task Shifted_window_reuses_overlapping_tiles_and_downloads_only_new_edge_hour()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var first = CreateRequest();
+        var shifted = new ForecastRequest(
+            ForecastModel.NoaaGfs,
+            first.Bounds,
+            first.From.AddMinutes(10),
+            first.Through.AddMinutes(10));
+
+        await provider.AcquireAsync(first, null, CancellationToken.None);
+        var originalRequestCount = handler.RequestCount;
+        var acquisition = await provider.AcquireAsync(shifted, null, CancellationToken.None);
+
+        Assert.Equal(1, handler.RequestCount - originalRequestCount);
+        Assert.Equal(3, acquisition.CacheUsage!.ReusedPartCount);
+        Assert.Equal(1, acquisition.CacheUsage.DownloadedPartCount);
+    }
+
+    [Fact]
+    public async Task Prefer_cache_uses_covering_older_run_until_latest_is_forced()
+    {
+        using var directory = new TestDirectory();
+        var handler = new RecordingHttpHandler((_, _, _) =>
+            Task.FromResult(RecordingHttpHandler.GribResponse()));
+        using var client = new HttpClient(handler);
+        var clock = new MutableTimeProvider(Now);
+        var provider = new NoaaGfsForecastProvider(
+            client,
+            new AtomicFileCache(new AtomicFileCacheOptions(directory.Path)),
+            clock,
+            TestOptions());
+        var cachedRequest = new ForecastRequest(
+            ForecastModel.NoaaGfs,
+            new GeographicBounds(40, 45, -70, -60),
+            new DateTimeOffset(2026, 7, 14, 14, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 7, 14, 16, 0, 0, TimeSpan.Zero));
+
+        var initial = await provider.AcquireAsync(cachedRequest, null, CancellationToken.None);
+        var initialRequests = handler.RequestCount;
+        clock.UtcNow = Now.AddHours(6);
+        var reused = await provider.AcquireAsync(cachedRequest, null, CancellationToken.None);
+        var forcedRequest = new ForecastRequest(
+            cachedRequest.Model,
+            cachedRequest.Bounds,
+            cachedRequest.From,
+            cachedRequest.Through,
+            ForecastRefreshPolicy.LatestAvailable);
+        var forced = await provider.AcquireAsync(forcedRequest, null, CancellationToken.None);
+
+        Assert.Equal(initial.Run.InitializedAt, reused.Run.InitializedAt);
+        Assert.True(reused.CacheUsage!.IsNewerRunAvailable);
+        Assert.Equal(initialRequests, handler.RequestCount - forced.CacheUsage!.DownloadedPartCount);
+        Assert.Equal(new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero), forced.Run.InitializedAt);
+        Assert.False(forced.CacheUsage.IsNewerRunAvailable);
     }
 
     [Fact]
@@ -354,8 +420,7 @@ public sealed class NoaaGfsForecastProviderTests
     {
         using var directory = new TestDirectory();
 
-        // A first attempt fails mid-run, leaving this cache key's isolated parts
-        // subdirectory behind.
+        // A first attempt fails mid-run, leaving a completed shared tile behind.
         var failingHandler = new RecordingHttpHandler((_, count, _) =>
             count == 1
                 ? Task.FromResult(RecordingHttpHandler.GribResponse())
@@ -365,11 +430,10 @@ public sealed class NoaaGfsForecastProviderTests
             await CreateProvider(directory.Path, failingClient)
                 .AcquireAsync(CreateRequest(), null, CancellationToken.None));
 
-        // Simulate a process killed mid-download by dropping a stray ".partial" into that
-        // subdirectory.
-        var partsSubdirectory = Directory.EnumerateDirectories(
-            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
-        var orphan = Path.Combine(partsSubdirectory, "f000-r0.grib2.deadbeefcafe.partial");
+        // Simulate a process killed mid-download by dropping a stray ".partial" into the
+        // shared tile directory.
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
+        var orphan = Path.Combine(partsDirectory, "f000-r0.grib2.deadbeefcafe.partial");
         await File.WriteAllTextAsync(orphan, "incomplete download from a killed process");
 
         // Resuming the same request sweeps the orphan before assembling.
@@ -474,8 +538,7 @@ public sealed class NoaaGfsForecastProviderTests
         });
         using var client = new HttpClient(handler);
         var provider = CreateProvider(directory.Path, client);
-        // 2 steps (f002, f003) × 2 regions (straddles Greenwich) = 4 parts.
-        // Expected manifest order: (f002, r0), (f002, r1), (f003, r0), (f003, r1).
+        // 2 steps (f002, f003) × 4 stable tiles = 8 parts.
         var request = new ForecastRequest(
             ForecastModel.NoaaGfs,
             new GeographicBounds(-5.11, 5.11, -5.11, 5.11),
@@ -484,16 +547,19 @@ public sealed class NoaaGfsForecastProviderTests
 
         var acquisition = await provider.AcquireAsync(request, null, CancellationToken.None);
 
-        Assert.Equal(4, handler.RequestCount);
+        Assert.Equal(8, handler.RequestCount);
         var expected = System.Text.Encoding.ASCII
-            .GetBytes("GRIB00017777GRIB00027777GRIB00037777GRIB00047777");
+            .GetBytes(
+                "GRIB00017777GRIB00027777GRIB00037777GRIB00047777" +
+                "GRIB00057777GRIB00067777GRIB00077777GRIB00087777");
         var actual = await File.ReadAllBytesAsync(acquisition.Artifact.Path);
         Assert.Equal(expected, actual);
-        Assert.Empty(
+        Assert.Equal(
+            8,
             Directory.EnumerateFiles(
                 Path.Combine(directory.Path, "noaa-gfs-parts"),
                 "*.grib2",
-                SearchOption.AllDirectories));
+                SearchOption.AllDirectories).Count());
     }
 
     [Fact]
@@ -574,8 +640,7 @@ public sealed class NoaaGfsForecastProviderTests
     {
         using var directory = new TestDirectory();
 
-        // A first attempt fails mid-run so this cache key's isolated parts subdirectory
-        // exists with one completed part.
+        // A first attempt fails mid-run so the shared tile directory exists with one part.
         var seedHandler = new RecordingHttpHandler((_, count, _) =>
             count == 1
                 ? Task.FromResult(RecordingHttpHandler.GribResponse())
@@ -584,10 +649,9 @@ public sealed class NoaaGfsForecastProviderTests
         await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
             await CreateProvider(directory.Path, seedClient)
                 .AcquireAsync(CreateRequest(), null, CancellationToken.None));
-        var partsDirectory = Directory.EnumerateDirectories(
-            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
 
-        // Seed abandoned parts beyond the cache bounds into that subdirectory.
+        // Seed abandoned parts beyond the cache bounds into the shared directory.
         for (var index = 0; index < 8; index++)
         {
             await File.WriteAllBytesAsync(
@@ -617,7 +681,7 @@ public sealed class NoaaGfsForecastProviderTests
     }
 
     [Fact]
-    public async Task Acquire_does_not_prune_parts_belonging_to_a_different_cache_key()
+    public async Task Acquire_retains_recent_tiles_for_a_different_route_within_cache_bounds()
     {
         using var directory = new TestDirectory();
 
@@ -631,13 +695,11 @@ public sealed class NoaaGfsForecastProviderTests
         await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
             await CreateProvider(directory.Path, failingClient)
                 .AcquireAsync(requestA, null, CancellationToken.None));
-        var subdirectoryA = Directory.EnumerateDirectories(
-            Path.Combine(directory.Path, "noaa-gfs-parts")).Single();
-        var partsA = Directory.EnumerateFiles(subdirectoryA, "*.grib2").ToList();
+        var partsDirectory = Path.Combine(directory.Path, "noaa-gfs-parts");
+        var partsA = Directory.EnumerateFiles(partsDirectory, "*.grib2").ToList();
         Assert.NotEmpty(partsA);
 
-        // A full acquisition for a different cache key B, under cache bounds its parts
-        // exceed, must not touch key A's isolated subdirectory.
+        // A full acquisition for route B remains within the shared cache bounds and keeps A.
         var requestB = CreateRequest(new GeographicBounds(10, 15, 20, 30));
         var handler = new RecordingHttpHandler((_, _, _) =>
             Task.FromResult(RecordingHttpHandler.GribResponse()));
@@ -648,7 +710,7 @@ public sealed class NoaaGfsForecastProviderTests
             cacheOptions: new AtomicFileCacheOptions(
                 directory.Path,
                 maximumBytes: 1_024,
-                maximumEntries: 1));
+                maximumEntries: 16));
 
         await provider.AcquireAsync(requestB, null, CancellationToken.None);
 

--- a/tests/Navtool.Infrastructure.Tests/TestSupport.cs
+++ b/tests/Navtool.Infrastructure.Tests/TestSupport.cs
@@ -29,6 +29,13 @@ internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
     public override DateTimeOffset GetUtcNow() => utcNow;
 }
 
+internal sealed class MutableTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+    public override DateTimeOffset GetUtcNow() => UtcNow;
+}
+
 // Returns a strictly increasing "now" on every read and records how many reads
 // happened. Used to prove AcquireAsync captures the clock exactly once, so its gate
 // key and the stored artifact key cannot diverge across a run-publish boundary.


### PR DESCRIPTION
Repeated route calculations could redownload the same NOAA data after restart or after small time-window changes because cache identity was tied to an exact request and elapsed freshness. This change makes immutable forecast data persistently reusable while retaining an explicit path to newer weather when needed.

## What changed

- Cache NOAA data as stable run/hour/10-degree geographic tiles and assemble route-specific GRIB files locally.
- Reuse overlapping tiles across restarts and shifted route windows, downloading only missing edge hours or tiles.
- Prefer the newest fully covering cached run during normal calculation, even when a newer publication exists.
- Add **Use newest weather data** to target the newest published run while still reusing tiles already cached for that run.
- Warn when routing uses an older cached run and identify the newer run available for refresh.
- Make cache artifacts age-independent and bounded with persistent LRU metadata, shared tile/assembly accounting, atomic recovery, and active-tile protection during concurrent assembly.
- Preserve exact legacy cache hits and migrate resumable legacy parts where possible.

## Validation

- Core tests: 66 passed
- Infrastructure tests: 85 passed
- App tests: 113 passed
- Native bridge build and CTest: passed

The scripted GUI launch built and validated the native bridge, but the current macOS automation session could not open Avalonia because its native render timer returned error `-6661`.