### PR TITLE
Fix routing with tiled NOAA forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ validation.
 - Fixed route calculation for NOAA forecasts assembled from multiple spatial
   cache tiles, including corridors that cross tile latitude or longitude
   boundaries.
-  ([router-lib#22](https://github.com/frye/router-lib/pull/22))
+  ([router-lib v0.3.1](https://github.com/frye/router-lib/releases/tag/v0.3.1))
 - Fixed historical isochrone styles inheriting an opaque fill in CI and
   restored .NET 9 compatibility for radial-action placement.
   ([#35](https://github.com/frye/navtool/pull/35),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ validation.
 
 ### Fixed
 
+- Fixed route calculation for NOAA forecasts assembled from multiple spatial
+  cache tiles, including corridors that cross tile latitude or longitude
+  boundaries.
+  ([router-lib#22](https://github.com/frye/router-lib/pull/22))
 - Fixed historical isochrone styles inheriting an opaque fill in CI and
   restored .NET 9 compatibility for radial-action placement.
   ([#35](https://github.com/frye/navtool/pull/35),

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ validation, and use `scripts/publish.sh` or `scripts/publish.ps1` for
 distributable artifacts. For a custom bridge location, set
 `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its directory. Packaged
 applications discover their bridge under `runtimes/<RID>/native`. Native builds
-fetch and compile the immutable `router-lib` revision `v0.3.0` by default. Set
+fetch and compile the immutable `router-lib` revision
+`f41fdd7352763b0173a47aae9b938da6dc5854b6` by default. Set
 `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when testing other
 revisions.
 
@@ -202,7 +203,7 @@ also be installed or packaged according to the target platform.
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
 | `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
-| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.3.0`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `f41fdd7352763b0173a47aae9b938da6dc5854b6`) |
 | `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ validation, and use `scripts/publish.sh` or `scripts/publish.ps1` for
 distributable artifacts. For a custom bridge location, set
 `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its directory. Packaged
 applications discover their bridge under `runtimes/<RID>/native`. Native builds
-fetch and compile the immutable `router-lib` revision
-`f41fdd7352763b0173a47aae9b938da6dc5854b6` by default. Set
+fetch and compile the immutable `router-lib` release `v0.3.1` by default. Set
 `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when testing other
 revisions.
 
@@ -203,7 +202,7 @@ also be installed or packaged according to the target platform.
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
 | `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
-| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `f41fdd7352763b0173a47aae9b938da6dc5854b6`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.3.1`) |
 | `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -15,7 +15,7 @@ set(
     "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
 set(
     NAVTOOL_ROUTER_LIB_RELEASE_TAG
-    "v0.3.0"
+    "f41fdd7352763b0173a47aae9b938da6dc5854b6"
     CACHE STRING
     "Immutable router-lib revision used when SAILROUTE_SOURCE_DIR is unset")
 set(_navtool_router_effective_source_dir "")

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -15,7 +15,7 @@ set(
     "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
 set(
     NAVTOOL_ROUTER_LIB_RELEASE_TAG
-    "f41fdd7352763b0173a47aae9b938da6dc5854b6"
+    "v0.3.1"
     CACHE STRING
     "Immutable router-lib revision used when SAILROUTE_SOURCE_DIR is unset")
 set(_navtool_router_effective_source_dir "")

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -30,6 +30,13 @@ void require_ok(navtool_router_status_v1 status, const char* operation) {
     }
 }
 
+void require_codes_ok(int status, const char* operation) {
+    if (status != CODES_SUCCESS) {
+        throw std::runtime_error(
+            std::string{operation} + ": " + codes_get_error_message(status));
+    }
+}
+
 struct ProgressCapture {
     size_t count{};
     int64_t previous_time{};
@@ -372,6 +379,143 @@ std::filesystem::path create_grib_through_step(long maximum_step) {
         std::filesystem::remove(output_path);
         throw std::runtime_error("could not create short GRIB fixture");
     }
+    return output_path;
+}
+
+std::filesystem::path create_tiled_grib() {
+    const auto output_path =
+        std::filesystem::temp_directory_path() /
+        ("navtool-tiled-" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()) +
+         ".grib");
+    constexpr long tile_point_count = 41L;
+    constexpr double grid_step = 0.25;
+    const double latitude_bands[][2] = {
+        {50.0, 40.0},
+        {60.0, 50.0},
+    };
+    const double longitude_bands[][2] = {
+        {220.0, 230.0},
+        {230.0, 240.0},
+        {240.0, 250.0},
+    };
+    bool first_message = true;
+
+    try {
+        for (const auto& latitude_band : latitude_bands) {
+            for (const auto& longitude_band : longitude_bands) {
+                for (const auto* short_name : {"10u", "10v"}) {
+                    codes_handle* handle =
+                        codes_grib_handle_new_from_samples(
+                            nullptr,
+                            "regular_ll_sfc_grib2");
+                    if (handle == nullptr) {
+                        throw std::runtime_error(
+                            "unable to create tiled ecCodes GRIB sample");
+                    }
+
+                    try {
+                        require_codes_ok(
+                            codes_set_long(handle, "Ni", tile_point_count),
+                            "set tiled Ni");
+                        require_codes_ok(
+                            codes_set_long(handle, "Nj", tile_point_count),
+                            "set tiled Nj");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "latitudeOfFirstGridPointInDegrees",
+                                latitude_band[0]),
+                            "set tiled first latitude");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "latitudeOfLastGridPointInDegrees",
+                                latitude_band[1]),
+                            "set tiled last latitude");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "longitudeOfFirstGridPointInDegrees",
+                                longitude_band[0]),
+                            "set tiled first longitude");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "longitudeOfLastGridPointInDegrees",
+                                longitude_band[1]),
+                            "set tiled last longitude");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "iDirectionIncrementInDegrees",
+                                grid_step),
+                            "set tiled longitude increment");
+                        require_codes_ok(
+                            codes_set_double(
+                                handle,
+                                "jDirectionIncrementInDegrees",
+                                grid_step),
+                            "set tiled latitude increment");
+                        require_codes_ok(
+                            codes_set_long(handle, "iScansNegatively", 0),
+                            "set tiled i scan");
+                        require_codes_ok(
+                            codes_set_long(handle, "jScansPositively", 0),
+                            "set tiled j scan");
+                        require_codes_ok(
+                            codes_set_long(handle, "dataDate", 20260803),
+                            "set tiled date");
+                        require_codes_ok(
+                            codes_set_long(handle, "dataTime", 1800),
+                            "set tiled time");
+                        require_codes_ok(
+                            codes_set_long(handle, "forecastTime", 7),
+                            "set tiled forecast time");
+                        std::size_t short_name_size =
+                            std::char_traits<char>::length(short_name);
+                        require_codes_ok(
+                            codes_set_string(
+                                handle,
+                                "shortName",
+                                short_name,
+                                &short_name_size),
+                            "set tiled wind component");
+                        require_codes_ok(
+                            codes_set_long(handle, "level", 10),
+                            "set tiled wind level");
+                        const std::vector<double> values(
+                            static_cast<std::size_t>(
+                                tile_point_count * tile_point_count),
+                            std::string{short_name} == "10u" ? 12.0 : 4.0);
+                        require_codes_ok(
+                            codes_set_double_array(
+                                handle,
+                                "values",
+                                values.data(),
+                                values.size()),
+                            "set tiled values");
+                        require_codes_ok(
+                            codes_write_message(
+                                handle,
+                                output_path.string().c_str(),
+                                first_message ? "w" : "a"),
+                            "write tiled GRIB message");
+                        first_message = false;
+                    } catch (...) {
+                        codes_handle_delete(handle);
+                        throw;
+                    }
+                    codes_handle_delete(handle);
+                }
+            }
+        }
+    } catch (...) {
+        std::filesystem::remove(output_path);
+        throw;
+    }
+
     return output_path;
 }
 
@@ -795,6 +939,61 @@ int main() {
         require_ok(
             navtool_router_forecast_destroy_v1(&forecast),
             "destroy bounded forecast");
+
+        const auto tiled_grib = create_tiled_grib();
+        try {
+            require_ok(
+                navtool_router_forecast_load_bounded_v1(
+                    tiled_grib.string().c_str(),
+                    43.0,
+                    -134.0,
+                    54.0,
+                    -114.25,
+                    &forecast),
+                "load Port Townsend-Ucluelet tiled forecast");
+            require_ok(
+                navtool_router_forecast_get_metadata_v1(
+                    forecast,
+                    &metadata,
+                    &source,
+                    &source_length),
+                "read tiled forecast metadata");
+            require(
+                metadata.latitude_count == 45U,
+                "tiled latitude mosaic was not cropped to the requested bounds");
+            require(
+                metadata.longitude_count == 80U,
+                "tiled longitude mosaic was not cropped to the requested bounds");
+            navtool_router_bridge_free_v1(source);
+
+            navtool_router_wind_sample_v1 tiled_sample{};
+            require_ok(
+                navtool_router_sample_grid_v1(
+                    forecast,
+                    48.5,
+                    -123.0,
+                    48.5,
+                    -123.0,
+                    1U,
+                    1U,
+                    metadata.first_valid_utc_epoch_seconds,
+                    &tiled_sample,
+                    1U),
+                "sample tiled forecast");
+            require(
+                tiled_sample.valid == 1U &&
+                    std::abs(tiled_sample.east_mps - 12.0) < 1e-9 &&
+                    std::abs(tiled_sample.north_mps - 4.0) < 1e-9,
+                "tiled forecast interpolation returned unexpected wind");
+            require_ok(
+                navtool_router_forecast_destroy_v1(&forecast),
+                "destroy tiled forecast");
+            std::filesystem::remove(tiled_grib);
+        } catch (...) {
+            navtool_router_forecast_destroy_v1(&forecast);
+            std::filesystem::remove(tiled_grib);
+            throw;
+        }
 
         // ---- GRIB inspection API ----
 

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -10,7 +10,7 @@ if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 if ([string]::IsNullOrWhiteSpace($RouterRevision)) {
-    $RouterRevision = "f41fdd7352763b0173a47aae9b938da6dc5854b6"
+    $RouterRevision = "v0.3.1"
 }
 
 if ([string]::IsNullOrWhiteSpace($RouterSource)) {

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -10,7 +10,7 @@ if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 if ([string]::IsNullOrWhiteSpace($RouterRevision)) {
-    $RouterRevision = "v0.3.0"
+    $RouterRevision = "f41fdd7352763b0173a47aae9b938da6dc5854b6"
 }
 
 if ([string]::IsNullOrWhiteSpace($RouterSource)) {

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -3,7 +3,7 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
-router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"f41fdd7352763b0173a47aae9b938da6dc5854b6"}
+router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"v0.3.1"}
 
 if [ -n "${SAILROUTE_SOURCE_DIR:-}" ]; then
   router_source=$SAILROUTE_SOURCE_DIR

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -3,7 +3,7 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
-router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"v0.3.0"}
+router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"f41fdd7352763b0173a47aae9b938da6dc5854b6"}
 
 if [ -n "${SAILROUTE_SOURCE_DIR:-}" ]; then
   router_source=$SAILROUTE_SOURCE_DIR


### PR DESCRIPTION
NOAA forecasts are cached as reusable spatial tiles, but the previous router-lib release treated each tile as a complete weather field. Route corridors spanning tile boundaries therefore failed while loading the forecast before optimization began.

This updates Navtool to router-lib `v0.3.1`, which mosaics compatible spatial GRIB fields before applying route bounds and accounts for per-tile GRIB packing precision at shared edges. It also adds a native bridge regression using the Port Townsend-to-Ucluelet bounds that originally failed, verifying the tiled forecast is cropped and interpolated correctly.

## Validation

- Native bridge build and tests pass against router-lib `v0.3.1`
- Exact cached NOAA artifact loads with the original bounds as a 45x80 grid
- Port Townsend-to-Ucluelet route reaches the destination using that artifact
- Managed test suite passes