### PR TITLE
Roll past route starts forward

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ It targets macOS, Windows, and Linux.
 - Open on a Salish Sea chart view and use resizable edge drawers plus
   right-click, long-press, or keyboard radial map actions to place endpoints,
   inspect routes, and start calculation without obscuring the chart.
-- Choose a local departure date/time, converted to UTC with DST validation.
+- Choose a local departure date/time, converted to UTC with DST validation; when calculation
+  starts with a past active-leg departure, Navtool rolls it forward to the current time and warns
+  without changing sailed-leg history.
 - Set the expected passage duration so only the required forecast times are
   acquired, up to the ten-day planning limit.
 - Download geographically subsetted NOAA GFS 0.25-degree 10 m wind fields, or

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -87,6 +87,52 @@
         <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
         <Setter Property="BorderThickness" Value="2" />
     </Style>
+    <Style Selector="TextBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="TextBox:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
+    <Style Selector="ComboBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+    </Style>
+    <Style Selector="ComboBox:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
+    <Style Selector="DatePicker">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+    </Style>
+    <Style Selector="DatePicker:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
+    <Style Selector="TimePicker">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+    </Style>
+    <Style Selector="TimePicker:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
+    <Style Selector="NumericUpDown">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+    </Style>
+    <Style Selector="NumericUpDown:disabled">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
     <Style Selector="ToggleButton.map-tool">
         <Setter Property="MinHeight" Value="44" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -333,6 +333,29 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         return applied;
     }
 
+    internal bool UpdateCurrentPositionDeparture(
+        DateTimeOffset departureTimeUtc,
+        TimeZoneInfo localTimeZone,
+        out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(localTimeZone);
+        if (CurrentPositionCoordinate is not { } coordinate)
+        {
+            error = "Set the current position before updating its departure time.";
+            return false;
+        }
+
+        if (!PlaceCurrentPosition(coordinate, departureTimeUtc, out error))
+        {
+            return false;
+        }
+
+        var localDeparture = TimeZoneInfo.ConvertTime(departureTimeUtc, localTimeZone);
+        CurrentPositionDepartureDate = localDeparture;
+        CurrentPositionDepartureTimeOfDay = localDeparture.TimeOfDay;
+        return true;
+    }
+
     /// <summary>
     /// Places the current position using the local <see cref="CurrentPositionDepartureDate"/>/
     /// <see cref="CurrentPositionDepartureTimeOfDay"/> fields, converted to UTC via

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -703,7 +703,11 @@ public partial class MainViewModel : ViewModelBase
             }
         }
 
-        if (!TryCreateWorkflowRequest(out var request, out var validationError))
+        if (!TryCreateWorkflowRequest(
+                out var request,
+                out var validationError,
+                out var departureWarning,
+                out var rollCurrentPositionDeparture))
         {
             ErrorMessage = validationError;
             return;
@@ -736,16 +740,6 @@ public partial class MainViewModel : ViewModelBase
                 ErrorMessage = validationError;
                 return;
             }
-
-            // The explicit current-position departure time (never wall clock/GPS) takes priority
-            // over the itinerary-start departure fields once a current position has been placed.
-            var departureTime = sequentialPlan!.CurrentPosition?.DepartureTime ?? request.Route.DepartureTime;
-            planRequest = new RoutePlanRoutingRequest(
-                sequentialPlan,
-                departureTime,
-                request.Route.LatestArrivalTime,
-                request.Selections,
-                request.RefreshPolicy);
         }
 
         try
@@ -788,6 +782,40 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
+        if (departureWarning is not null)
+        {
+            if (rollCurrentPositionDeparture)
+            {
+                if (!Itinerary.UpdateCurrentPositionDeparture(
+                        request.Route.DepartureTime,
+                        _localTimeZone,
+                        out validationError) ||
+                    !Itinerary.TryBuildPlan(out sequentialPlan, out validationError))
+                {
+                    ErrorMessage = validationError;
+                    return;
+                }
+            }
+            else
+            {
+                var localDeparture = TimeZoneInfo.ConvertTime(
+                    request.Route.DepartureTime,
+                    _localTimeZone);
+                DepartureDate = localDeparture;
+                DepartureTime = localDeparture.TimeOfDay;
+            }
+        }
+
+        if (useSequentialWorkflow)
+        {
+            planRequest = new RoutePlanRoutingRequest(
+                sequentialPlan!,
+                request.Route.DepartureTime,
+                request.Route.LatestArrivalTime,
+                request.Selections,
+                request.RefreshPolicy);
+        }
+
         var generation = Interlocked.Increment(ref _calculationGeneration);
         var calculationPlanId = Itinerary.PlanId;
         var calculationRevision = Itinerary.CalculationRevision;
@@ -800,6 +828,7 @@ public partial class MainViewModel : ViewModelBase
         CancelWeather();
 
         InitializeCalculationPresentation(request, planRequest);
+        WarningMessage = departureWarning;
         IsCalculating = true;
         ProgressFraction = 0;
         StatusMessage = "Starting forecast acquisition and route calculations…";
@@ -902,7 +931,7 @@ public partial class MainViewModel : ViewModelBase
                     return;
                 }
 
-                ApplyPlanWorkflowResult(planResult);
+                ApplyPlanWorkflowResult(planResult, departureWarning);
                 return;
             }
 
@@ -919,7 +948,7 @@ public partial class MainViewModel : ViewModelBase
                 return;
             }
 
-            ApplyWorkflowResult(result);
+            ApplyWorkflowResult(result, departureWarning);
         }
         catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
         {
@@ -1231,12 +1260,15 @@ public partial class MainViewModel : ViewModelBase
         UpdateWeatherAvailability();
     }
 
-    private void ApplyPlanWorkflowResult(RoutePlanRoutingResult result)
+    private void ApplyPlanWorkflowResult(
+        RoutePlanRoutingResult result,
+        string? calculationWarning)
     {
         Itinerary.AcceptCalculationResult(result.Plan);
         _acquisitions.Clear();
         var failures = new List<string>();
         var warnings = new List<string>();
+        AddCalculationWarning(warnings, calculationWarning);
         foreach (var outcome in result.Models)
         {
             if (!outcome.Acquisitions.IsEmpty)
@@ -1347,16 +1379,20 @@ public partial class MainViewModel : ViewModelBase
 
     private bool TryCreateWorkflowRequest(
         [NotNullWhen(true)] out RoutingWorkflowRequest? request,
-        out string? error)
+        out string? error,
+        out string? warning,
+        out bool rollCurrentPositionDeparture)
     {
         request = null;
+        warning = null;
+        rollCurrentPositionDeparture = false;
         if (Start is null || Destination is null)
         {
             error = "Set both endpoints before calculating.";
             return false;
         }
 
-        if (!Itinerary.TryBuildPlan(out _, out error))
+        if (!Itinerary.TryBuildPlan(out var plan, out error))
         {
             return false;
         }
@@ -1406,15 +1442,27 @@ public partial class MainViewModel : ViewModelBase
             return false;
         }
 
+        var utcNow = _timeProvider.GetUtcNow();
+        var departureWasCurrentPosition = plan!.CurrentPosition is not null;
+        var effectiveDepartureUtc = plan.CurrentPosition?.DepartureTime ?? departureUtc;
+        if (effectiveDepartureUtc < utcNow)
+        {
+            effectiveDepartureUtc = utcNow;
+            rollCurrentPositionDeparture = departureWasCurrentPosition;
+            warning =
+                $"The current leg start time was in the past and was rolled forward to " +
+                $"{effectiveDepartureUtc:yyyy-MM-dd HH:mm:ss} UTC. Calculation started anyway.";
+        }
+
         var route = new RouteRequest(
             $"route-{Guid.NewGuid():N}",
             Start.Value,
             Destination.Value,
-            departureUtc,
-            departureUtc + passageDuration);
+            effectiveDepartureUtc,
+            effectiveDepartureUtc + passageDuration);
         var validation = new RouteRequestValidator().Validate(
             route,
-            _timeProvider.GetUtcNow(),
+            utcNow,
             new RouteValidationOptions(
                 maximumDepartureLeadTime: MaximumDepartureLeadTime,
                 maximumRouteDuration: MaximumRouteWindow,
@@ -1436,11 +1484,14 @@ public partial class MainViewModel : ViewModelBase
         return true;
     }
 
-    private void ApplyWorkflowResult(RoutingWorkflowResult result)
+    private void ApplyWorkflowResult(
+        RoutingWorkflowResult result,
+        string? calculationWarning)
     {
         _acquisitions.Clear();
         var failures = new List<string>();
         var warnings = new List<string>();
+        AddCalculationWarning(warnings, calculationWarning);
         var recordedRoutes = new List<RouteResult>();
         foreach (var outcome in result.Outcomes)
         {
@@ -1567,6 +1618,14 @@ public partial class MainViewModel : ViewModelBase
         };
         OnPropertyChanged(nameof(SelectedRouteDetails));
         UpdateWeatherAvailability();
+    }
+
+    private static void AddCalculationWarning(List<string> warnings, string? warning)
+    {
+        if (!string.IsNullOrWhiteSpace(warning))
+        {
+            warnings.Add(warning);
+        }
     }
 
     private void DisplayPlanVisualization(RoutePlan plan, bool fit)

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -1450,7 +1450,7 @@ public partial class MainViewModel : ViewModelBase
             effectiveDepartureUtc = utcNow;
             rollCurrentPositionDeparture = departureWasCurrentPosition;
             warning =
-                $"The current leg start time was in the past and was rolled forward to " +
+                $"The active leg departure was in the past and was rolled forward to " +
                 $"{effectiveDepartureUtc:yyyy-MM-dd HH:mm:ss} UTC. Calculation started anyway.";
         }
 

--- a/tests/Navtool.App.Tests/AppThemeTests.cs
+++ b/tests/Navtool.App.Tests/AppThemeTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Avalonia.Threading;
@@ -132,9 +133,11 @@ public sealed class AppThemeTests
             foreach (var option in AppThemeService.AvailableThemes)
             {
                 service.SelectTheme(option.Theme);
-                var expectedForeground = FindColorResource("TextPrimaryColor");
-                var expectedBackground = FindColorResource("SurfaceRaisedColor");
-                var inputs = window.GetVisualDescendants()
+                var enabledForeground = FindColorResource("TextPrimaryColor");
+                var enabledBackground = FindColorResource("SurfaceRaisedColor");
+                var disabledForeground = FindColorResource("DisabledTextColor");
+                var disabledBackground = FindColorResource("DisabledBackgroundColor");
+                var inputs = window.GetLogicalDescendants()
                     .OfType<TemplatedControl>()
                     .Where(control =>
                         control is TextBox or ComboBox or DatePicker or TimePicker or NumericUpDown)
@@ -148,6 +151,12 @@ public sealed class AppThemeTests
                 Assert.Contains(inputs, control => control is NumericUpDown);
                 Assert.All(inputs, input =>
                 {
+                    var expectedForeground = input.IsEffectivelyEnabled
+                        ? enabledForeground
+                        : disabledForeground;
+                    var expectedBackground = input.IsEffectivelyEnabled
+                        ? enabledBackground
+                        : disabledBackground;
                     Assert.Equal(
                         expectedForeground,
                         Assert.IsAssignableFrom<ISolidColorBrush>(input.Foreground).Color);

--- a/tests/Navtool.App.Tests/AppThemeTests.cs
+++ b/tests/Navtool.App.Tests/AppThemeTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 using Avalonia.Styling;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Navtool.App.Models;
 using Navtool.App.Services;
@@ -126,6 +127,7 @@ public sealed class AppThemeTests
         {
             window.Show();
             window.SetPlanningDrawerOpen(true);
+            Dispatcher.UIThread.RunJobs();
 
             foreach (var option in AppThemeService.AvailableThemes)
             {

--- a/tests/Navtool.App.Tests/AppThemeTests.cs
+++ b/tests/Navtool.App.Tests/AppThemeTests.cs
@@ -94,6 +94,7 @@ public sealed class AppThemeTests
             AssertContrast("AccentTextColor", "AccentHoverColor", 4.5);
             AssertContrast("AccentTextColor", "AccentPressedColor", 4.5);
             AssertContrast("ActiveToolTextColor", "ActiveToolBackgroundColor", 4.5);
+            AssertContrast("TextPrimaryColor", "SurfaceRaisedColor", 4.5);
 
             foreach (var key in new[]
                      {
@@ -108,6 +109,55 @@ public sealed class AppThemeTests
             {
                 Assert.IsType<Color>(FindResource(key));
             }
+        }
+    }
+
+    [AvaloniaFact]
+    public void PlanningInputsUseSemanticColorsInEveryTheme()
+    {
+        var service = AppThemeService.CreateTransient();
+        service.Initialize(Application.Current!);
+        var window = new MainWindow(service)
+        {
+            DataContext = CreateViewModel()
+        };
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+
+            foreach (var option in AppThemeService.AvailableThemes)
+            {
+                service.SelectTheme(option.Theme);
+                var expectedForeground = FindColorResource("TextPrimaryColor");
+                var expectedBackground = FindColorResource("SurfaceRaisedColor");
+                var inputs = window.GetVisualDescendants()
+                    .OfType<TemplatedControl>()
+                    .Where(control =>
+                        control is TextBox or ComboBox or DatePicker or TimePicker or NumericUpDown)
+                    .ToArray();
+
+                Assert.NotEmpty(inputs);
+                Assert.Contains(inputs, control => control is TextBox);
+                Assert.Contains(inputs, control => control is ComboBox);
+                Assert.Contains(inputs, control => control is DatePicker);
+                Assert.Contains(inputs, control => control is TimePicker);
+                Assert.Contains(inputs, control => control is NumericUpDown);
+                Assert.All(inputs, input =>
+                {
+                    Assert.Equal(
+                        expectedForeground,
+                        Assert.IsAssignableFrom<ISolidColorBrush>(input.Foreground).Color);
+                    Assert.Equal(
+                        expectedBackground,
+                        Assert.IsAssignableFrom<ISolidColorBrush>(input.Background).Color);
+                });
+            }
+        }
+        finally
+        {
+            window.Close();
         }
     }
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -344,6 +344,45 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Past_departure_rolls_forward_and_calculates_with_the_requested_duration()
+    {
+        var selectedRun = Now.AddHours(-6);
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(
+                request,
+                new ForecastCacheUsage(3, 0, selectedRun, selectedRun.AddHours(6)))));
+        RouteRequest? routed = null;
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routed = request;
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        var pastDeparture = Now.AddHours(-2);
+        viewModel.DepartureDate = pastDeparture;
+        viewModel.DepartureTime = pastDeparture.TimeOfDay;
+        viewModel.PassageDays = 2;
+        viewModel.PassageHours = 5;
+
+        await viewModel.CalculateRoutesAsync();
+
+        Assert.NotNull(routed);
+        Assert.Equal(Now, routed.DepartureTime);
+        Assert.Equal(TimeSpan.FromHours(53), routed.LatestArrivalTime - routed.DepartureTime);
+        Assert.Equal(Now.Date, viewModel.DepartureDate!.Value.Date);
+        Assert.Equal(Now.TimeOfDay, viewModel.DepartureTime);
+        Assert.Null(viewModel.ErrorMessage);
+        Assert.Contains("rolled forward", viewModel.WarningMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Calculation started anyway", viewModel.WarningMessage, StringComparison.Ordinal);
+        Assert.Contains("cached run", viewModel.WarningMessage, StringComparison.OrdinalIgnoreCase);
+        Assert.Single(noaa.Requests);
+    }
+
+    [Fact]
     public async Task Intermediate_waypoint_routes_sequentially_and_persists_results()
     {
         var root = Path.Combine(Path.GetTempPath(), $"navtool-multi-leg-{Guid.NewGuid():N}");
@@ -562,6 +601,70 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Past_current_leg_start_rolls_forward_without_changing_sailed_history()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"navtool-roll-current-leg-{Guid.NewGuid():N}");
+        try
+        {
+            var repository = new RoutePlanJsonRepository(root);
+            var noaa = new DelegateForecastProvider(
+                ForecastModel.NoaaGfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+            var routeRequests = new List<RouteRequest>();
+            var engine = new DelegateRouteEngine((request, forecast, _) =>
+            {
+                routeRequests.Add(request);
+                return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+            });
+            var viewModel = CreateViewModel(
+                new RoutingWorkflow(new[] { noaa }, engine),
+                new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                    ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+                routePlanRepository: repository);
+            viewModel.Itinerary.AddWaypointCommand.Execute(null);
+            var intermediate = viewModel.Itinerary.Waypoints[1];
+            intermediate.SetOnMapCommand.Execute(null);
+            viewModel.HandleMapClick(
+                MapProjection.ToMapPoint(new Coordinate(36, -58)),
+                default);
+
+            await viewModel.CalculateRoutesAsync();
+
+            var firstLeg = routeRequests[0];
+            var firstLegId = viewModel.Itinerary.Legs[0].Id;
+            viewModel.Itinerary.Legs[0].MarkSailedCommand.Execute(null);
+            var currentPosition = new Coordinate(36.5, -57.5);
+            Assert.True(viewModel.Itinerary.PlaceCurrentPosition(
+                currentPosition,
+                Now.AddHours(-3),
+                out var placementError));
+            Assert.Null(placementError);
+            routeRequests.Clear();
+
+            await viewModel.CalculateRoutesAsync();
+
+            var activeRoute = Assert.Single(routeRequests);
+            Assert.Equal(currentPosition, activeRoute.Origin);
+            Assert.Equal(Now, activeRoute.DepartureTime);
+            Assert.Equal(Now, viewModel.Itinerary.CurrentPositionDepartureTimeUtc);
+            Assert.Equal(Now.Date, viewModel.Itinerary.CurrentPositionDepartureDate!.Value.Date);
+            Assert.Equal(Now.TimeOfDay, viewModel.Itinerary.CurrentPositionDepartureTimeOfDay);
+            Assert.Contains("rolled forward", viewModel.WarningMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Null(viewModel.ErrorMessage);
+
+            var reopened = await repository.OpenAsync(viewModel.Itinerary.PlanId);
+            Assert.Contains(firstLegId, reopened.SailedLegIds);
+            var retainedFirstLeg = reopened.LatestResult(ForecastModel.NoaaGfs)!.Legs[0];
+            Assert.Equal(firstLeg.RouteId, retainedFirstLeg.Route!.Request.RouteId);
+            Assert.Equal(RouteLegOutcomeState.Succeeded, retainedFirstLeg.State);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Cancelling_a_multi_leg_calculation_preserves_the_completed_leg()
     {
         var noaa = new DelegateForecastProvider(
@@ -669,6 +772,9 @@ public sealed class MainViewModelWorkflowTests
             new DelegateWeatherSampler((_, _, _, _, _, _) =>
                 ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
             nativeRoutingPreflight: preflight);
+        var pastDeparture = Now.AddHours(-2);
+        viewModel.DepartureDate = pastDeparture;
+        viewModel.DepartureTime = pastDeparture.TimeOfDay;
 
         await viewModel.CalculateRoutesAsync();
 
@@ -683,6 +789,9 @@ public sealed class MainViewModelWorkflowTests
         Assert.Contains("runtimes/<RID>/native", viewModel.ErrorMessage);
         Assert.Contains("NAVTOOL_ROUTER_BRIDGE_PATH", viewModel.ErrorMessage);
         Assert.Equal("No forecast was downloaded.", viewModel.StatusMessage);
+        Assert.Null(viewModel.WarningMessage);
+        Assert.Equal(pastDeparture.Date, viewModel.DepartureDate!.Value.Date);
+        Assert.Equal(pastDeparture.TimeOfDay, viewModel.DepartureTime);
     }
 
     [Fact]


### PR DESCRIPTION
Past active-leg departures currently stop route calculation with a validation error. This change rolls the effective start forward to the current time, updates the visible fields, and continues calculation with a warning so users do not have to manually correct stale departure values.

## Summary

- Roll ordinary and current-position active-leg starts forward while preserving the requested passage duration.
- Keep sailed and completed leg history unchanged when recalculating the current leg.
- Preserve the roll-forward notice alongside forecast and cache warnings through calculation completion.
- Apply semantic foreground, background, and border colors to all planning inputs across Light, Dark, and Kind of Blue themes.
- Document the adjusted departure behavior.

## Validation

- Added workflow coverage for ordinary and current-position roll-forward behavior, warning merging, field updates, duration preservation, preflight failures, and sailed-history preservation.
- Added headless theme coverage for input colors and contrast in every supported theme.
- Ran the full managed test suite with the native bridge configured.
- Launched through `./scripts/run.sh`; native bridge build and preflight tests passed.