### PR TITLE
Automatically calculate routes on endpoint changes

### DIFF
--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -63,6 +63,11 @@
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryColor}" />
     </Style>
+    <Style Selector="Button.instrument-cancel">
+        <Setter Property="MinHeight" Value="26" />
+        <Setter Property="Padding" Value="9,2" />
+        <Setter Property="FontSize" Value="11" />
+    </Style>
     <Style Selector="Grid.compact-action-row">
         <Setter Property="ColumnSpacing" Value="8" />
     </Style>

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -64,6 +64,7 @@
         <Setter Property="Foreground" Value="{DynamicResource TextSecondaryColor}" />
     </Style>
     <Style Selector="Button.instrument-cancel">
+        <Setter Property="Width" Value="58" />
         <Setter Property="MinHeight" Value="26" />
         <Setter Property="Padding" Value="9,2" />
         <Setter Property="FontSize" Value="11" />

--- a/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
+++ b/src/Navtool.App/ViewModels/ItineraryEditorViewModel.cs
@@ -181,6 +181,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
     private readonly IRoutePlanRepository? _repository;
     private RoutePlan? _plan;
     private bool _suppressChanges;
+    private bool _suppressEndpointChanged;
 
     public ItineraryEditorViewModel(IRoutePlanRepository? repository = null)
     {
@@ -233,6 +234,8 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
 
     public event EventHandler? ItineraryChanged;
 
+    public event EventHandler? EndpointChanged;
+
     public event EventHandler<WaypointEditorItemViewModel>? MapPlacementStarted;
 
     public event EventHandler? CurrentPositionPlacementStarted;
@@ -268,8 +271,16 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
 
     public void SetEndpoints(Coordinate start, Coordinate finish)
     {
-        Waypoints[0].Coordinate = start;
-        Waypoints[^1].Coordinate = finish;
+        _suppressEndpointChanged = true;
+        try
+        {
+            Waypoints[0].Coordinate = start;
+            Waypoints[^1].Coordinate = finish;
+        }
+        finally
+        {
+            _suppressEndpointChanged = false;
+        }
     }
 
     public void BeginMapPlacement(WaypointEditorItemViewModel waypoint)
@@ -748,6 +759,7 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
             return;
         }
 
+        var isEndpoint = waypoint.IsStart || waypoint.IsFinish;
         if (coordinate is not null && _plan is not null)
         {
             if (_plan.Waypoints.Any(existing => existing.Id == waypoint.Id))
@@ -774,6 +786,10 @@ public sealed partial class ItineraryEditorViewModel : ViewModelBase
         CalculationRevision++;
         MarkChanged();
         AddWaypointCommand.NotifyCanExecuteChanged();
+        if (isEndpoint && !_suppressEndpointChanged)
+        {
+            EndpointChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     internal void ChangeStopover(WaypointEditorItemViewModel waypoint)

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -92,6 +92,7 @@ public partial class MainViewModel : ViewModelBase
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CalculateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ForceRecalculateCommand))]
     [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
     private bool _isInspectingLocalGrib;
 
@@ -115,6 +116,7 @@ public partial class MainViewModel : ViewModelBase
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(CalculateCommand))]
+    [NotifyCanExecuteChangedFor(nameof(ForceRecalculateCommand))]
     [NotifyCanExecuteChangedFor(nameof(CancelCommand))]
     private bool _isCalculating;
 
@@ -306,8 +308,12 @@ public partial class MainViewModel : ViewModelBase
         _timeProvider = timeProvider;
         _localTimeZone = localTimeZone;
         _logger = logger ?? NullLogger<MainViewModel>.Instance;
+        var localNow = TimeZoneInfo.ConvertTime(_timeProvider.GetUtcNow(), _localTimeZone);
+        _departureDate = new DateTimeOffset(localNow.Date, localNow.Offset);
+        _departureTime = localNow.TimeOfDay;
         Itinerary = new ItineraryEditorViewModel(routePlanRepository);
         Itinerary.ItineraryChanged += OnItineraryChanged;
+        Itinerary.EndpointChanged += OnEndpointChanged;
         Itinerary.MapPlacementStarted += OnMapPlacementStarted;
         Itinerary.CurrentPositionPlacementStarted += OnCurrentPositionPlacementStarted;
         Itinerary.LegSelected += OnLegSelected;
@@ -1064,10 +1070,41 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanCalculate))]
     private Task Calculate() => CalculateRoutesAsync();
 
+    [RelayCommand(CanExecute = nameof(CanCalculate))]
+    private Task ForceRecalculate()
+    {
+        RefreshExpiredDeparture();
+        return CalculateRoutesAsync();
+    }
+
     private bool CanCalculate() =>
         !IsCalculating &&
         !IsInspectingLocalGrib &&
         (ForecastInputMode == ForecastInputMode.Download || LocalForecast is not null);
+
+    private void RefreshExpiredDeparture()
+    {
+        if (Itinerary.HasCurrentPosition ||
+            !LocalDepartureConverter.TryConvertToUtc(
+                DepartureDate,
+                DepartureTime,
+                _localTimeZone,
+                out var departureUtc,
+                out _))
+        {
+            return;
+        }
+
+        var nowUtc = _timeProvider.GetUtcNow();
+        if (departureUtc >= nowUtc)
+        {
+            return;
+        }
+
+        var localNow = TimeZoneInfo.ConvertTime(nowUtc, _localTimeZone);
+        DepartureDate = new DateTimeOffset(localNow.Date, localNow.Offset);
+        DepartureTime = localNow.TimeOfDay;
+    }
 
     [RelayCommand]
     private void SelectDownloadSource() => ForecastInputMode = ForecastInputMode.Download;
@@ -1311,6 +1348,7 @@ public partial class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsDownloadForecast));
         OnPropertyChanged(nameof(IsLocalForecast));
         CalculateCommand.NotifyCanExecuteChanged();
+        ForceRecalculateCommand.NotifyCanExecuteChanged();
         UpdateForecastAreaSummary();
     }
 
@@ -1318,6 +1356,7 @@ public partial class MainViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(LocalGribDisplay));
         CalculateCommand.NotifyCanExecuteChanged();
+        ForceRecalculateCommand.NotifyCanExecuteChanged();
         UpdateForecastAreaSummary();
     }
 
@@ -2486,6 +2525,29 @@ public partial class MainViewModel : ViewModelBase
         }
 
         NotifyInteractionChanged();
+    }
+
+    private async void OnEndpointChanged(object? sender, EventArgs e)
+    {
+        var revision = Itinerary.CalculationRevision;
+        await Task.Yield();
+        if (_workflow is null ||
+            revision != Itinerary.CalculationRevision ||
+            Itinerary.HasPendingWaypoint ||
+            !CanCalculate())
+        {
+            return;
+        }
+
+        try
+        {
+            await CalculateRoutesAsync();
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Automatic route calculation failed");
+            ErrorMessage = $"Automatic route calculation failed: {exception.Message}";
+        }
     }
 
     private void UpdateWaypointLayers() =>

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -613,6 +613,11 @@
                                    FontWeight="SemiBold"
                                    TextAlignment="Center"
                                    VerticalAlignment="Center" />
+                        <Button x:Name="InstrumentRailCancelButton"
+                                Classes="instrument-cancel"
+                                Command="{Binding CancelCommand}"
+                                Content="Cancel"
+                                AutomationProperties.Name="Cancel route calculation" />
                     </StackPanel>
 
                     <ProgressBar x:Name="InstrumentRailProgressBar"
@@ -677,9 +682,9 @@
                 </Button>
                 <Button x:Name="CalculateRadialButton"
                         Classes="radial-action primary-radial"
-                        Command="{Binding CalculateCommand}"
+                        Command="{Binding ForceRecalculateCommand}"
                         Click="OnCalculateRadialClicked"
-                        ToolTip.Tip="Calculate route using the current passage plan"
+                        ToolTip.Tip="Recalculate route using the current passage plan"
                         AutomationProperties.Name="Calculate route">
                     <TextBlock Text="Calculate&#x0a;route"
                                TextAlignment="Center"

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -511,17 +511,18 @@
                 </StackPanel>
             </Border>
 
-            <Border x:Name="InstrumentRail"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Top"
-                    Margin="16"
-                    MaxWidth="720"
-                    Classes="map-overlay"
-                    CornerRadius="18"
-                    Padding="0"
-                    ClipToBounds="True"
-                    IsHitTestVisible="False">
-                <Grid>
+            <Grid x:Name="InstrumentRailHost"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Top"
+                  Margin="16"
+                  MaxWidth="720">
+                <Border x:Name="InstrumentRail"
+                        Classes="map-overlay"
+                        CornerRadius="18"
+                        Padding="0"
+                        ClipToBounds="True"
+                        IsHitTestVisible="False">
+                    <Grid>
                     <StackPanel x:Name="InstrumentRailIdleRow"
                                 Margin="14,7"
                                 Orientation="Horizontal"
@@ -613,11 +614,8 @@
                                    FontWeight="SemiBold"
                                    TextAlignment="Center"
                                    VerticalAlignment="Center" />
-                        <Button x:Name="InstrumentRailCancelButton"
-                                Classes="instrument-cancel"
-                                Command="{Binding CancelCommand}"
-                                Content="Cancel"
-                                AutomationProperties.Name="Cancel route calculation" />
+                        <Border Width="58"
+                                Height="26" />
                     </StackPanel>
 
                     <ProgressBar x:Name="InstrumentRailProgressBar"
@@ -629,8 +627,18 @@
                                  IsVisible="{Binding IsCalculating}"
                                  AutomationProperties.Name="Route calculation progress"
                                  AutomationProperties.HelpText="{Binding CalculationStageLabel}" />
-                </Grid>
-            </Border>
+                    </Grid>
+                </Border>
+                <Button x:Name="InstrumentRailCancelButton"
+                        Classes="instrument-cancel"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Top"
+                        Margin="0,7,14,0"
+                        IsVisible="{Binding IsCalculating}"
+                        Command="{Binding CancelCommand}"
+                        Content="Cancel"
+                        AutomationProperties.Name="Cancel route calculation" />
+            </Grid>
 
             <Border x:Name="MapInstructionOverlay"
                     HorizontalAlignment="Center"

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -643,7 +643,7 @@
             <Border x:Name="MapInstructionOverlay"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Top"
-                    Margin="14,60,14,0"
+                    Margin="14,68,14,0"
                     Classes="map-overlay"
                     CornerRadius="14"
                     Padding="12,7"

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1382,18 +1382,24 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task Itinerary_change_discards_late_result_and_clears_displayed_route()
+    public async Task Itinerary_change_discards_late_result_and_recalculates_updated_route()
     {
         var started = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var release = new TaskCompletionSource<ForecastAcquisition>(
             TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
         var provider = new DelegateForecastProvider(
             ForecastModel.NoaaGfs,
-            async (_, _) =>
+            async (request, _) =>
             {
-                started.SetResult();
-                return await release.Task;
+                if (Interlocked.Increment(ref calls) == 1)
+                {
+                    started.SetResult();
+                    return await release.Task;
+                }
+
+                return CreateAcquisition(request);
             });
         var engine = new DelegateRouteEngine((request, forecast, _) =>
             ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
@@ -1404,12 +1410,16 @@ public sealed class MainViewModelWorkflowTests
 
         var calculation = viewModel.CalculateRoutesAsync();
         await started.Task;
-        viewModel.SetDestinationAt(new Coordinate(40, -50));
+        var replacement = new Coordinate(40, -50);
+        viewModel.SetDestinationAt(replacement);
         release.SetResult(CreateAcquisition(provider.LastRequest!));
         await calculation;
+        await WaitForAsync(() => !viewModel.IsCalculating);
 
-        Assert.Equal(0, viewModel.SuccessfulRouteCount);
-        Assert.False(viewModel.HasTimeline);
+        Assert.Equal(2, calls);
+        Assert.Equal(1, viewModel.SuccessfulRouteCount);
+        Assert.Equal(replacement, viewModel.SelectedRoutePoint!.Route.Request.Destination);
+        Assert.True(viewModel.HasTimeline);
         Assert.False(viewModel.IsCalculating);
     }
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -61,6 +61,126 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task Placing_final_endpoint_starts_route_calculation_automatically()
+    {
+        var routeRequests = new List<RouteRequest>();
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routeRequests.Add(request);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = new MainViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            new FixedTimeProvider(Now),
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+        var departure = Now.AddHours(1);
+        viewModel.DepartureDate = departure;
+        viewModel.DepartureTime = departure.TimeOfDay;
+
+        viewModel.SetStartAt(new Coordinate(34, -64));
+        await Task.Yield();
+        Assert.Empty(routeRequests);
+
+        viewModel.SetDestinationAt(new Coordinate(39, -52));
+        await WaitForAsync(() => viewModel.SuccessfulRouteCount == 1);
+
+        var request = Assert.Single(routeRequests);
+        Assert.Equal(new Coordinate(34, -64), request.Origin);
+        Assert.Equal(new Coordinate(39, -52), request.Destination);
+    }
+
+    [Fact]
+    public async Task Replacing_endpoint_cancels_stale_calculation_and_routes_new_coordinate()
+    {
+        var firstStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstCancelled = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var callCount = 0;
+        Coordinate? completedDestination = null;
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new StreamingRouteEngine(async (request, forecast, _, cancellationToken) =>
+        {
+            if (Interlocked.Increment(ref callCount) == 1)
+            {
+                firstStarted.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    firstCancelled.SetResult();
+                    throw;
+                }
+            }
+
+            completedDestination = request.Destination;
+            return CreateRoute(request, forecast.Request.Model);
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+
+        viewModel.SetDestinationAt(new Coordinate(40, -51));
+        await firstStarted.Task;
+
+        var replacement = new Coordinate(41, -49);
+        viewModel.SetDestinationAt(replacement);
+        await firstCancelled.Task;
+        await WaitForAsync(() => viewModel.SuccessfulRouteCount == 1);
+
+        Assert.Equal(2, callCount);
+        Assert.Equal(replacement, completedDestination);
+    }
+
+    [Fact]
+    public async Task Forced_recalculation_refreshes_only_expired_normal_departure()
+    {
+        var routeRequests = new List<RouteRequest>();
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+        {
+            routeRequests.Add(request);
+            return ValueTask.FromResult(CreateRoute(request, forecast.Request.Model));
+        });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(new[] { noaa }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)));
+        var expired = Now.AddHours(-1);
+        viewModel.DepartureDate = expired;
+        viewModel.DepartureTime = expired.TimeOfDay;
+
+        await viewModel.ForceRecalculateCommand.ExecuteAsync(null);
+
+        Assert.Equal(Now, routeRequests[0].DepartureTime);
+        Assert.Equal(Now.Date, viewModel.DepartureDate!.Value.Date);
+        Assert.Equal(Now.TimeOfDay, viewModel.DepartureTime);
+
+        var future = Now.AddHours(3);
+        viewModel.DepartureDate = future;
+        viewModel.DepartureTime = future.TimeOfDay;
+
+        await viewModel.ForceRecalculateCommand.ExecuteAsync(null);
+
+        Assert.Equal(future, routeRequests[1].DepartureTime);
+        Assert.Equal(future.Date, viewModel.DepartureDate!.Value.Date);
+        Assert.Equal(future.TimeOfDay, viewModel.DepartureTime);
+    }
+
+    [Fact]
     public void LocalDepartureConversionHandlesUtcAndDstEdgeCases()
     {
         Assert.True(LocalDepartureConverter.TryConvertToUtc(

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -213,7 +213,7 @@ public sealed class MainWindowLayoutTests
                 Assert.Equal(VerticalAlignment.Center, button.VerticalContentAlignment);
             });
             var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
-            Assert.Same(viewModel.CalculateCommand, buttons[2].Command);
+            Assert.Same(viewModel.ForceRecalculateCommand, buttons[2].Command);
             Assert.True(buttons[2].IsEffectivelyEnabled);
             Assert.False(buttons[3].IsEnabled);
             viewModel.ForecastInputMode = ForecastInputMode.LocalFile;
@@ -400,7 +400,7 @@ public sealed class MainWindowLayoutTests
             Assert.True(idleRow.IsVisible);
             Assert.False(progressRow.IsVisible);
             Assert.False(progress.IsVisible);
-            Assert.False(cancel.IsVisible);
+            Assert.False(cancel.IsEffectivelyVisible);
             Assert.Contains(mapShell, rail.GetLogicalAncestors());
 
             viewModel.ProgressFraction = 0.64;
@@ -410,7 +410,7 @@ public sealed class MainWindowLayoutTests
             Assert.False(idleRow.IsVisible);
             Assert.True(progressRow.IsVisible);
             Assert.True(progress.IsVisible);
-            Assert.True(cancel.IsVisible);
+            Assert.True(cancel.IsEffectivelyVisible);
             Assert.True(cancel.IsEnabled);
             Assert.Same(viewModel.CancelCommand, cancel.Command);
             Assert.Equal(0.64, progress.Value);

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -394,10 +394,13 @@ public sealed class MainWindowLayoutTests
                 window.FindControl<StackPanel>("InstrumentRailProgressRow"));
             var progress = Assert.IsType<ProgressBar>(
                 window.FindControl<ProgressBar>("InstrumentRailProgressBar"));
+            var cancel = Assert.IsType<Button>(
+                window.FindControl<Button>("InstrumentRailCancelButton"));
 
             Assert.True(idleRow.IsVisible);
             Assert.False(progressRow.IsVisible);
             Assert.False(progress.IsVisible);
+            Assert.False(cancel.IsVisible);
             Assert.Contains(mapShell, rail.GetLogicalAncestors());
 
             viewModel.ProgressFraction = 0.64;
@@ -407,6 +410,9 @@ public sealed class MainWindowLayoutTests
             Assert.False(idleRow.IsVisible);
             Assert.True(progressRow.IsVisible);
             Assert.True(progress.IsVisible);
+            Assert.True(cancel.IsVisible);
+            Assert.True(cancel.IsEnabled);
+            Assert.Same(viewModel.CancelCommand, cancel.Command);
             Assert.Equal(0.64, progress.Value);
             Assert.Equal("Route calculation progress", AutomationProperties.GetName(progress));
             Assert.Equal(
@@ -426,8 +432,9 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(instructionTop);
             Assert.True(railBottom.Value.Y <= instructionTop.Value.Y);
 
-            viewModel.IsCalculating = false;
+            cancel.Command!.Execute(null);
             Dispatcher.UIThread.RunJobs();
+            Assert.False(viewModel.IsCalculating);
             Assert.True(idleRow.IsVisible);
             Assert.False(progressRow.IsVisible);
             Assert.False(progress.IsVisible);

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -402,6 +402,9 @@ public sealed class MainWindowLayoutTests
             Assert.False(progress.IsVisible);
             Assert.False(cancel.IsEffectivelyVisible);
             Assert.Contains(mapShell, rail.GetLogicalAncestors());
+            Assert.DoesNotContain(rail, cancel.GetLogicalAncestors());
+            Assert.False(rail.IsHitTestVisible);
+            Assert.True(cancel.IsHitTestVisible);
 
             viewModel.ProgressFraction = 0.64;
             viewModel.IsCalculating = true;

--- a/tests/Navtool.App.Tests/MapInputRoutingTests.cs
+++ b/tests/Navtool.App.Tests/MapInputRoutingTests.cs
@@ -128,7 +128,7 @@ public sealed class MapInputRoutingTests
             window.MouseUp(mapPoint.Value, MouseButton.Right, RawInputModifiers.None);
             var calculate = Assert.IsType<Button>(
                 window.FindControl<Button>("CalculateRadialButton"));
-            Assert.Same(viewModel.CalculateCommand, calculate.Command);
+            Assert.Same(viewModel.ForceRecalculateCommand, calculate.Command);
             calculate.Focus();
             window.KeyPress(
                 Key.Enter,


### PR DESCRIPTION
Route calculation previously required a separate manual action after selecting endpoints, even though calculating immediately is the usual intent. This change starts routing automatically when the final Start/End endpoint is placed and restarts safely when an existing endpoint changes.

- Adds endpoint-specific change signaling so plan loads and calculation result updates do not create routing loops.
- Cancels stale in-flight work before calculating against replacement coordinates.
- Keeps **Calculate route** in the map context menu as an explicit forced recalculation, refreshing only expired normal departure times while preserving valid future departures.
- Adds a **Cancel** action directly to the visible calculation progress rail.
- Leaves the separate Current position voyage-resume workflow unchanged.

Tests cover automatic start, endpoint replacement and stale-result cancellation, departure refresh rules, context-menu command binding, and progress cancellation.