### PR TITLE
Add route point telemetry popup on route click

### DIFF
--- a/src/Navtool.App/Services/RouteTelemetryPlacement.cs
+++ b/src/Navtool.App/Services/RouteTelemetryPlacement.cs
@@ -1,0 +1,141 @@
+using Navtool.App.Models;
+
+namespace Navtool.App.Services;
+
+public enum RouteTelemetrySide
+{
+    Right,
+    Left,
+    Centered
+}
+
+public readonly record struct RouteTelemetryConnector(ScreenPoint Start, ScreenPoint End);
+
+public sealed record RouteTelemetryPlacementResult(
+    ScreenPoint Anchor,
+    ScreenRect PopupBounds,
+    RouteTelemetrySide Side,
+    RouteTelemetryConnector Connector);
+
+public static class RouteTelemetryPlacement
+{
+    public static RouteTelemetryPlacementResult Calculate(
+        ScreenRect visibleBounds,
+        ScreenPoint anchor,
+        ScreenSize popupSize,
+        double gap,
+        double safeMargin)
+    {
+        Validate(visibleBounds, anchor, popupSize, gap, safeMargin);
+
+        var safeBounds = new ScreenRect(
+            visibleBounds.X + safeMargin,
+            visibleBounds.Y + safeMargin,
+            visibleBounds.Width - (safeMargin * 2),
+            visibleBounds.Height - (safeMargin * 2));
+        if (popupSize.Width > safeBounds.Width || popupSize.Height > safeBounds.Height)
+        {
+            throw new ArgumentException(
+                "Visible bounds cannot contain the route telemetry popup.",
+                nameof(popupSize));
+        }
+
+        var rightX = anchor.X + gap;
+        var leftX = anchor.X - gap - popupSize.Width;
+        var side = rightX + popupSize.Width <= safeBounds.Right
+            ? RouteTelemetrySide.Right
+            : leftX >= safeBounds.X
+                ? RouteTelemetrySide.Left
+                : RouteTelemetrySide.Centered;
+        var popupX = side switch
+        {
+            RouteTelemetrySide.Right => Math.Max(rightX, safeBounds.X),
+            RouteTelemetrySide.Left => Math.Min(leftX, safeBounds.Right - popupSize.Width),
+            _ => Math.Clamp(
+                anchor.X - (popupSize.Width / 2),
+                safeBounds.X,
+                safeBounds.Right - popupSize.Width)
+        };
+        var popupY = Math.Clamp(
+            anchor.Y - (popupSize.Height / 2),
+            safeBounds.Y,
+            safeBounds.Bottom - popupSize.Height);
+        var popupBounds = new ScreenRect(
+            popupX,
+            popupY,
+            popupSize.Width,
+            popupSize.Height);
+        var connectorEnd = side switch
+        {
+            RouteTelemetrySide.Right => new ScreenPoint(
+                popupBounds.X,
+                Math.Clamp(anchor.Y, popupBounds.Y, popupBounds.Bottom)),
+            RouteTelemetrySide.Left => new ScreenPoint(
+                popupBounds.Right,
+                Math.Clamp(anchor.Y, popupBounds.Y, popupBounds.Bottom)),
+            _ => ClosestVerticalEdge(anchor, popupBounds)
+        };
+
+        return new RouteTelemetryPlacementResult(
+            anchor,
+            popupBounds,
+            side,
+            new RouteTelemetryConnector(anchor, connectorEnd));
+    }
+
+    private static ScreenPoint ClosestVerticalEdge(ScreenPoint anchor, ScreenRect bounds)
+    {
+        var leftDistance = Math.Abs(anchor.X - bounds.X);
+        var rightDistance = Math.Abs(anchor.X - bounds.Right);
+        return new ScreenPoint(
+            leftDistance <= rightDistance ? bounds.X : bounds.Right,
+            Math.Clamp(anchor.Y, bounds.Y, bounds.Bottom));
+    }
+
+    private static void Validate(
+        ScreenRect visibleBounds,
+        ScreenPoint anchor,
+        ScreenSize popupSize,
+        double gap,
+        double safeMargin)
+    {
+        if (!IsFinite(visibleBounds.X) ||
+            !IsFinite(visibleBounds.Y) ||
+            !IsFinite(visibleBounds.Width) ||
+            !IsFinite(visibleBounds.Height) ||
+            visibleBounds.Width <= 0 ||
+            visibleBounds.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(visibleBounds));
+        }
+
+        if (!IsFinite(anchor.X) || !IsFinite(anchor.Y))
+        {
+            throw new ArgumentOutOfRangeException(nameof(anchor));
+        }
+
+        if (!IsFinite(popupSize.Width) ||
+            !IsFinite(popupSize.Height) ||
+            popupSize.Width <= 0 ||
+            popupSize.Height <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(popupSize));
+        }
+
+        if (!IsFinite(gap) || gap < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(gap));
+        }
+
+        if (!IsFinite(safeMargin) ||
+            safeMargin < 0 ||
+            (safeMargin * 2) >= visibleBounds.Width ||
+            (safeMargin * 2) >= visibleBounds.Height)
+        {
+            throw new ArgumentOutOfRangeException(nameof(safeMargin));
+        }
+    }
+
+    private static bool IsFinite(double value) => double.IsFinite(value);
+}
+

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -45,6 +45,40 @@
         <Setter Property="Background" Value="{DynamicResource OverlayBorderColor}" />
         <Setter Property="Foreground" Value="{DynamicResource AccentColor}" />
     </Style>
+    <Style Selector="Button.route-telemetry">
+        <Setter Property="MinHeight" Value="0" />
+        <Setter Property="Padding" Value="12,10" />
+        <Setter Property="Background" Value="{DynamicResource OverlayBackgroundColor}" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource FocusColor}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    </Style>
+    <Style Selector="Button.route-telemetry:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="Button.route-telemetry:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlPressedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="TextBlock.telemetry-label">
+        <Setter Property="Foreground" Value="{DynamicResource TextMutedColor}" />
+        <Setter Property="FontSize" Value="9" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="LetterSpacing" Value="0.8" />
+    </Style>
+    <Style Selector="TextBlock.telemetry-value">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="FontSize" Value="13" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="TextBlock.telemetry-hint">
+        <Setter Property="Foreground" Value="{DynamicResource TextMutedColor}" />
+        <Setter Property="FontSize" Value="9" />
+    </Style>
     <Style Selector="Button">
         <Setter Property="MinHeight" Value="44" />
     </Style>

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -351,6 +351,8 @@ public partial class MainViewModel : ViewModelBase
 
     public event EventHandler<RouteMapSelection?>? RouteSelectionChanged;
 
+    public event EventHandler<RouteMapSelection>? RoutePointInspectionRequested;
+
     public Map Map { get; }
 
     public ItineraryEditorViewModel Itinerary { get; }
@@ -679,6 +681,25 @@ public partial class MainViewModel : ViewModelBase
         {
             FocusSelectedRoutePoint();
         }
+
+        RoutePointInspectionRequested?.Invoke(this, selection);
+    }
+
+    public void ClearRoutePointSelection()
+    {
+        SelectedRoutePoint = null;
+        _selectedStopoverLabel = null;
+        UpdateWeatherAvailability();
+    }
+
+    public MPoint GetProjectedRoutePoint(RouteMapSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+        var projected = selection.Key is { } key
+            ? _mapLayers.GetProjectedRoutePoint(key, selection.PointIndex)
+            : null;
+        return projected ?? MapProjection.ToContinuousMapPoints(
+            selection.Route.Points.Select(point => point.Location))[selection.PointIndex];
     }
 
     public async Task CalculateRoutesAsync()
@@ -1140,12 +1161,7 @@ public partial class MainViewModel : ViewModelBase
             resolution = 10_000;
         }
 
-        var projected = SelectedRoutePoint.Key is { } key
-            ? _mapLayers.GetProjectedRoutePoint(key, SelectedRoutePoint.PointIndex)
-            : null;
-        projected ??= MapProjection.ToContinuousMapPoints(
-            SelectedRoutePoint.Route.Points.Select(point => point.Location))[
-            SelectedRoutePoint.PointIndex];
+        var projected = GetProjectedRoutePoint(SelectedRoutePoint);
         Map.Navigator.CenterOnAndZoomTo(projected, Math.Min(resolution, 10_000));
     }
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -656,7 +656,7 @@
                          IsHitTestVisible="False" />
                 <Button x:Name="RouteTelemetryCard"
                         Classes="route-telemetry"
-                        Width="252"
+                        Width="296"
                         Height="132"
                         Click="OnRouteTelemetryCardClicked"
                         AutomationProperties.Name="Route point telemetry"
@@ -681,8 +681,8 @@
                         <Border Grid.Row="1"
                                 Background="{DynamicResource OverlayBorderColor}" />
                         <Grid Grid.Row="2"
-                              ColumnDefinitions="*,*,*,*"
-                              ColumnSpacing="8">
+                              ColumnDefinitions="*,*,*,*,*"
+                              ColumnSpacing="6">
                             <StackPanel>
                                 <TextBlock Text="BOAT"
                                            Classes="telemetry-label" />
@@ -698,13 +698,20 @@
                                            Classes="telemetry-value" />
                             </StackPanel>
                             <StackPanel Grid.Column="2">
+                                <TextBlock Text="TWD"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryTrueWindDirection"
+                                           Text="{Binding SelectedRoutePoint.Point.TrueWindDirectionDegrees, StringFormat={}{0:0}°}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="3">
                                 <TextBlock Text="AWS"
                                            Classes="telemetry-label" />
                                 <TextBlock x:Name="RouteTelemetryApparentWind"
                                            Text="{Binding SelectedRoutePoint.Point.ApparentWindSpeedKnots, StringFormat={}{0:0.0} kt}"
                                            Classes="telemetry-value" />
                             </StackPanel>
-                            <StackPanel Grid.Column="3">
+                            <StackPanel Grid.Column="4">
                                 <TextBlock Text="HDG"
                                            Classes="telemetry-label" />
                                 <TextBlock x:Name="RouteTelemetryHeading"

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -641,6 +641,85 @@
                            FontWeight="SemiBold" />
             </Border>
 
+            <Canvas x:Name="RouteTelemetryLayer"
+                    IsVisible="False">
+                <Line x:Name="RouteTelemetryConnector"
+                      Stroke="{DynamicResource FocusColor}"
+                      StrokeThickness="2"
+                      IsHitTestVisible="False" />
+                <Ellipse x:Name="RouteTelemetryAnchor"
+                         Width="16"
+                         Height="16"
+                         Fill="{DynamicResource FocusColor}"
+                         Stroke="{DynamicResource MarkerOutlineColor}"
+                         StrokeThickness="3"
+                         IsHitTestVisible="False" />
+                <Button x:Name="RouteTelemetryCard"
+                        Classes="route-telemetry"
+                        Width="252"
+                        Height="132"
+                        Click="OnRouteTelemetryCardClicked"
+                        AutomationProperties.Name="Route point telemetry"
+                        AutomationProperties.HelpText="Shows route point telemetry. Click or tap to close.">
+                    <Grid RowDefinitions="Auto,1,Auto,Auto"
+                          RowSpacing="8">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <StackPanel Spacing="1">
+                                <TextBlock Text="ROUTE POINT"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryTime"
+                                           Text="{Binding SelectedRoutePoint.Point.Timestamp, StringFormat={}{0:dd MMM · HH:mm} UTC}"
+                                           FontSize="14"
+                                           FontWeight="SemiBold" />
+                            </StackPanel>
+                            <TextBlock Grid.Column="1"
+                                       Text="×"
+                                       FontSize="18"
+                                       Foreground="{DynamicResource TextMutedColor}"
+                                       VerticalAlignment="Top" />
+                        </Grid>
+                        <Border Grid.Row="1"
+                                Background="{DynamicResource OverlayBorderColor}" />
+                        <Grid Grid.Row="2"
+                              ColumnDefinitions="*,*,*,*"
+                              ColumnSpacing="8">
+                            <StackPanel>
+                                <TextBlock Text="BOAT"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryBoatSpeed"
+                                           Text="{Binding SelectedRoutePoint.Point.BoatSpeedKnots, StringFormat={}{0:0.0} kt}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="1">
+                                <TextBlock Text="TWS"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryTrueWind"
+                                           Text="{Binding SelectedRoutePoint.Point.TrueWindSpeedKnots, StringFormat={}{0:0.0} kt}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="2">
+                                <TextBlock Text="AWS"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryApparentWind"
+                                           Text="{Binding SelectedRoutePoint.Point.ApparentWindSpeedKnots, StringFormat={}{0:0.0} kt}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="3">
+                                <TextBlock Text="HDG"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryHeading"
+                                           Text="{Binding SelectedRoutePoint.Point.HeadingDegrees, StringFormat={}{0:0}°}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                        </Grid>
+                        <TextBlock Grid.Row="3"
+                                   Text="Tap to close"
+                                   Classes="telemetry-hint"
+                                   HorizontalAlignment="Right" />
+                    </Grid>
+                </Button>
+            </Canvas>
+
             <Canvas x:Name="RadialMenuLayer"
                     IsVisible="False">
                 <Line x:Name="RadialConnector"

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -36,6 +36,10 @@ public partial class MainWindow : Window
     private const double RadialActionHeight = 48;
     private const double RadialRadius = 82;
     private const double RadialSafeMargin = 16;
+    private const double RouteTelemetryWidth = 252;
+    private const double RouteTelemetryHeight = 132;
+    private const double RouteTelemetryGap = 18;
+    private const double RouteTelemetrySafeMargin = 12;
     private static AppThemeService? _defaultThemeService;
     private static readonly FilePickerFileType GribFileType = new("GRIB forecasts")
     {
@@ -59,6 +63,12 @@ public partial class MainWindow : Window
     private Button? _inspectRadialButton;
     private Line? _radialConnector;
     private Ellipse? _radialAnchor;
+    private Canvas? _routeTelemetryLayer;
+    private Button? _routeTelemetryCard;
+    private Line? _routeTelemetryConnector;
+    private Ellipse? _routeTelemetryAnchor;
+    private MainViewModel? _subscribedViewModel;
+    private RouteMapSelection? _routeTelemetrySelection;
     private ScreenPoint? _lastPointerPosition;
     private MPoint? _capturedWorldPoint;
     private RouteMapSelection? _capturedRouteSelection;
@@ -121,6 +131,10 @@ public partial class MainWindow : Window
         _inspectRadialButton = this.FindControl<Button>("InspectRadialButton")!;
         _radialConnector = this.FindControl<Line>("RadialConnector")!;
         _radialAnchor = this.FindControl<Ellipse>("RadialAnchor")!;
+        _routeTelemetryLayer = this.FindControl<Canvas>("RouteTelemetryLayer")!;
+        _routeTelemetryCard = this.FindControl<Button>("RouteTelemetryCard")!;
+        _routeTelemetryConnector = this.FindControl<Line>("RouteTelemetryConnector")!;
+        _routeTelemetryAnchor = this.FindControl<Ellipse>("RouteTelemetryAnchor")!;
         ApplyDrawerState();
     }
 
@@ -131,8 +145,12 @@ public partial class MainWindow : Window
             return;
         }
 
+        _subscribedViewModel = viewModel;
+        _subscribedViewModel.RouteSelectionChanged += OnRouteSelectionChanged;
+        _subscribedViewModel.RoutePointInspectionRequested += OnRoutePointInspectionRequested;
         _subscribedNavigator = viewModel.Map.Navigator;
         _subscribedNavigator.ViewportChanged += OnViewportChanged;
+        ScheduleRouteTelemetryRefresh();
         ScheduleWeatherRefresh();
     }
 
@@ -149,6 +167,12 @@ public partial class MainWindow : Window
         if (_subscribedNavigator is not null)
         {
             _subscribedNavigator.ViewportChanged -= OnViewportChanged;
+        }
+
+        if (_subscribedViewModel is not null)
+        {
+            _subscribedViewModel.RouteSelectionChanged -= OnRouteSelectionChanged;
+            _subscribedViewModel.RoutePointInspectionRequested -= OnRoutePointInspectionRequested;
         }
 
         Loaded -= OnLoaded;
@@ -170,6 +194,7 @@ public partial class MainWindow : Window
     private void OnViewportChanged(object? sender, ViewportChangedEventArgs e)
     {
         CloseRadialMenu();
+        ScheduleRouteTelemetryRefresh();
         if (DataContext is MainViewModel viewModel)
         {
             viewModel.RequestWeatherRefreshFromViewport();
@@ -262,6 +287,13 @@ public partial class MainWindow : Window
         {
             e.Handled = true;
             CloseRadialMenu();
+            return;
+        }
+
+        if (e.Key == Key.Escape && _routeTelemetrySelection is not null)
+        {
+            e.Handled = true;
+            _subscribedViewModel?.ClearRoutePointSelection();
             return;
         }
 
@@ -429,6 +461,98 @@ public partial class MainWindow : Window
         _mapControl?.Focus();
     }
 
+    private void OnRouteSelectionChanged(object? sender, RouteMapSelection? selection)
+    {
+        if (selection is null)
+        {
+            _routeTelemetrySelection = null;
+        }
+        else if (_routeTelemetrySelection is not null)
+        {
+            _routeTelemetrySelection = selection;
+        }
+
+        ScheduleRouteTelemetryRefresh();
+    }
+
+    private void OnRoutePointInspectionRequested(object? sender, RouteMapSelection selection)
+    {
+        _routeTelemetrySelection = selection;
+        ScheduleRouteTelemetryRefresh();
+    }
+
+    private void OnRouteTelemetryCardClicked(object? sender, RoutedEventArgs e)
+    {
+        e.Handled = true;
+        _subscribedViewModel?.ClearRoutePointSelection();
+        _mapControl?.Focus();
+    }
+
+    private void ScheduleRouteTelemetryRefresh()
+    {
+        Dispatcher.UIThread.Post(UpdateRouteTelemetryOverlay, DispatcherPriority.Loaded);
+    }
+
+    private void UpdateRouteTelemetryOverlay()
+    {
+        if (_mapControl is null ||
+            _routeTelemetryLayer is null ||
+            _routeTelemetryCard is null ||
+            _routeTelemetryConnector is null ||
+            _routeTelemetryAnchor is null ||
+            _subscribedViewModel is null ||
+            _routeTelemetrySelection is not { } selection ||
+            _mapControl.Bounds.Width <= 0 ||
+            _mapControl.Bounds.Height <= 0)
+        {
+            HideRouteTelemetryOverlay();
+            return;
+        }
+
+        var projected = _subscribedViewModel.GetProjectedRoutePoint(selection);
+        var screen = _mapControl.Map.Navigator.Viewport.WorldToScreen(projected);
+        var anchor = new ScreenPoint(screen.X, screen.Y);
+        var visibleBounds = new ScreenRect(
+            0,
+            0,
+            _mapControl.Bounds.Width,
+            _mapControl.Bounds.Height);
+        if (anchor.X < visibleBounds.X ||
+            anchor.Y < visibleBounds.Y ||
+            anchor.X > visibleBounds.Right ||
+            anchor.Y > visibleBounds.Bottom)
+        {
+            HideRouteTelemetryOverlay();
+            return;
+        }
+
+        var placement = RouteTelemetryPlacement.Calculate(
+            visibleBounds,
+            anchor,
+            new ScreenSize(RouteTelemetryWidth, RouteTelemetryHeight),
+            RouteTelemetryGap,
+            RouteTelemetrySafeMargin);
+        Canvas.SetLeft(_routeTelemetryAnchor, anchor.X - (_routeTelemetryAnchor.Width / 2));
+        Canvas.SetTop(_routeTelemetryAnchor, anchor.Y - (_routeTelemetryAnchor.Height / 2));
+        Canvas.SetLeft(_routeTelemetryCard, placement.PopupBounds.X);
+        Canvas.SetTop(_routeTelemetryCard, placement.PopupBounds.Y);
+        _routeTelemetryConnector.StartPoint = new Point(
+            placement.Connector.Start.X,
+            placement.Connector.Start.Y);
+        _routeTelemetryConnector.EndPoint = new Point(
+            placement.Connector.End.X,
+            placement.Connector.End.Y);
+        _routeTelemetryLayer.IsVisible = true;
+    }
+
+    private void HideRouteTelemetryOverlay()
+    {
+        if (_routeTelemetryLayer is not null)
+        {
+            _routeTelemetryLayer.IsVisible = false;
+        }
+    }
+
     private void OnPlanningDrawerClicked(object? sender, RoutedEventArgs e)
     {
         SetPlanningDrawerOpen(!IsPlanningDrawerOpen);
@@ -494,6 +618,7 @@ public partial class MainWindow : Window
         _routeDrawerHandle.IsChecked = IsRouteDrawerOpen;
         _planningDrawerHandle.Content = IsPlanningDrawerOpen ? "‹" : "›";
         _routeDrawerHandle.Content = IsRouteDrawerOpen ? "›" : "‹";
+        ScheduleRouteTelemetryRefresh();
         ScheduleWeatherRefresh();
     }
 
@@ -516,6 +641,7 @@ public partial class MainWindow : Window
             return;
         }
 
+        ScheduleRouteTelemetryRefresh();
         ScheduleWeatherRefresh();
     }
 

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -69,6 +69,7 @@ public partial class MainWindow : Window
     private Ellipse? _routeTelemetryAnchor;
     private MainViewModel? _subscribedViewModel;
     private RouteMapSelection? _routeTelemetrySelection;
+    private MPoint? _routeTelemetryProjection;
     private ScreenPoint? _lastPointerPosition;
     private MPoint? _capturedWorldPoint;
     private RouteMapSelection? _capturedRouteSelection;
@@ -465,11 +466,11 @@ public partial class MainWindow : Window
     {
         if (selection is null)
         {
-            _routeTelemetrySelection = null;
+            SetRouteTelemetrySelection(null);
         }
         else if (_routeTelemetrySelection is not null)
         {
-            _routeTelemetrySelection = selection;
+            SetRouteTelemetrySelection(selection);
         }
 
         ScheduleRouteTelemetryRefresh();
@@ -477,8 +478,14 @@ public partial class MainWindow : Window
 
     private void OnRoutePointInspectionRequested(object? sender, RouteMapSelection selection)
     {
-        _routeTelemetrySelection = selection;
+        SetRouteTelemetrySelection(selection);
         ScheduleRouteTelemetryRefresh();
+    }
+
+    private void SetRouteTelemetrySelection(RouteMapSelection? selection)
+    {
+        _routeTelemetrySelection = selection;
+        _routeTelemetryProjection = null;
     }
 
     private void OnRouteTelemetryCardClicked(object? sender, RoutedEventArgs e)
@@ -509,7 +516,8 @@ public partial class MainWindow : Window
             return;
         }
 
-        var projected = _subscribedViewModel.GetProjectedRoutePoint(selection);
+        var projected = _routeTelemetryProjection ??=
+            _subscribedViewModel.GetProjectedRoutePoint(selection);
         var screen = _mapControl.Map.Navigator.Viewport.WorldToScreen(projected);
         var anchor = new ScreenPoint(screen.X, screen.Y);
         var visibleBounds = new ScreenRect(
@@ -520,7 +528,8 @@ public partial class MainWindow : Window
         if (anchor.X < visibleBounds.X ||
             anchor.Y < visibleBounds.Y ||
             anchor.X > visibleBounds.Right ||
-            anchor.Y > visibleBounds.Bottom)
+            anchor.Y > visibleBounds.Bottom ||
+            !CanPlaceRouteTelemetry(visibleBounds))
         {
             HideRouteTelemetryOverlay();
             return;
@@ -544,6 +553,10 @@ public partial class MainWindow : Window
             placement.Connector.End.Y);
         _routeTelemetryLayer.IsVisible = true;
     }
+
+    private static bool CanPlaceRouteTelemetry(ScreenRect visibleBounds) =>
+        visibleBounds.Width - (RouteTelemetrySafeMargin * 2) >= RouteTelemetryWidth &&
+        visibleBounds.Height - (RouteTelemetrySafeMargin * 2) >= RouteTelemetryHeight;
 
     private void HideRouteTelemetryOverlay()
     {

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -36,7 +36,7 @@ public partial class MainWindow : Window
     private const double RadialActionHeight = 48;
     private const double RadialRadius = 82;
     private const double RadialSafeMargin = 16;
-    private const double RouteTelemetryWidth = 252;
+    private const double RouteTelemetryWidth = 296;
     private const double RouteTelemetryHeight = 132;
     private const double RouteTelemetryGap = 18;
     private const double RouteTelemetrySafeMargin = 12;

--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -200,12 +200,7 @@ public sealed record RoutePoint
     {
         get
         {
-            var (trueWindEast, trueWindNorth) = ToVectorToward(
-                TrueWindSpeedKnots,
-                NormalizeDirection(TrueWindDirectionDegrees + 180d));
-            var (boatEast, boatNorth) = ToVectorToward(BoatSpeedKnots, HeadingDegrees);
-            var apparentEast = trueWindEast - boatEast;
-            var apparentNorth = trueWindNorth - boatNorth;
+            var (apparentEast, apparentNorth) = GetApparentWindVector();
             if (Math.Abs(apparentEast) < 1e-9 && Math.Abs(apparentNorth) < 1e-9)
             {
                 return 0d;
@@ -218,6 +213,26 @@ public sealed record RoutePoint
     }
 
     public double ApparentWindAngleDegrees => Math.Abs(ApparentWindAngleSignedDegrees);
+
+    public double ApparentWindSpeedKnots
+    {
+        get
+        {
+            var (apparentEast, apparentNorth) = GetApparentWindVector();
+            return Math.Sqrt(
+                (apparentEast * apparentEast) +
+                (apparentNorth * apparentNorth));
+        }
+    }
+
+    private (double East, double North) GetApparentWindVector()
+    {
+        var (trueWindEast, trueWindNorth) = ToVectorToward(
+            TrueWindSpeedKnots,
+            NormalizeDirection(TrueWindDirectionDegrees + 180d));
+        var (boatEast, boatNorth) = ToVectorToward(BoatSpeedKnots, HeadingDegrees);
+        return (trueWindEast - boatEast, trueWindNorth - boatNorth);
+    }
 
     private static (double East, double North) ToVectorToward(double speed, double directionDegrees)
     {

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1406,6 +1406,15 @@ public sealed class MainViewModelWorkflowTests
         Assert.Equal(capturedSelection.TimelineTimestamp, viewModel.SelectedTimelineUtc);
         Assert.Equal(ForecastModel.EcmwfIfs, viewModel.ActiveWeatherModel);
         Assert.Contains("ECMWF", viewModel.StatusMessage);
+        Assert.Equal(
+            capturedSelection.Point.ApparentWindSpeedKnots,
+            viewModel.SelectedRoutePoint.Point.ApparentWindSpeedKnots);
+
+        var selectedLeg = viewModel.SelectedLeg;
+        viewModel.ClearRoutePointSelection();
+
+        Assert.Null(viewModel.SelectedRoutePoint);
+        Assert.Same(selectedLeg, viewModel.SelectedLeg);
     }
 
     [Fact]

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -485,6 +485,10 @@ public sealed class MainWindowLayoutTests
                 Assert.IsType<TextBlock>(
                     window.FindControl<TextBlock>("RouteTelemetryTrueWind")).Text);
             Assert.Equal(
+                "180°",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryTrueWindDirection")).Text);
+            Assert.Equal(
                 "16.2 kt",
                 Assert.IsType<TextBlock>(
                     window.FindControl<TextBlock>("RouteTelemetryApparentWind")).Text);

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -439,6 +439,116 @@ public sealed class MainWindowLayoutTests
     }
 
     [AvaloniaFact]
+    public void RouteTelemetryShowsRequestedFieldsAndSupportsTouchAndEscapeDismissal()
+    {
+        var window = CreateWindow();
+        var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            var map = Assert.IsType<MapControl>(window.FindControl<MapControl>("MapView"));
+            var center = map.Bounds.Center;
+            var coordinate = MapProjection.ToCoordinate(
+                map.Map.Navigator.Viewport.ScreenToWorld(center.X, center.Y));
+            var selection = CreateRouteSelection(coordinate);
+            var projected = viewModel.GetProjectedRoutePoint(selection);
+            viewModel.Map.Navigator.SetViewport(new Mapsui.Viewport(
+                projected.X,
+                projected.Y,
+                10_000,
+                0,
+                map.Bounds.Width,
+                map.Bounds.Height));
+
+            viewModel.SelectRoutePoint(selection, focus: false);
+            Dispatcher.UIThread.RunJobs();
+
+            var layer = Assert.IsType<Canvas>(
+                window.FindControl<Canvas>("RouteTelemetryLayer"));
+            var card = Assert.IsType<Button>(
+                window.FindControl<Button>("RouteTelemetryCard"));
+            Assert.True(layer.IsVisible);
+            Assert.Equal("Route point telemetry", AutomationProperties.GetName(card));
+            Assert.Contains("Click or tap to close", AutomationProperties.GetHelpText(card));
+            Assert.Equal(
+                "14 Jul · 12:00 UTC",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryTime")).Text);
+            Assert.Equal(
+                "6.0 kt",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryBoatSpeed")).Text);
+            Assert.Equal(
+                "15.0 kt",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryTrueWind")).Text);
+            Assert.Equal(
+                "16.2 kt",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryApparentWind")).Text);
+            Assert.Equal(
+                "90°",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryHeading")).Text);
+            Assert.True(new ScreenRect(0, 0, map.Bounds.Width, map.Bounds.Height).Contains(
+                new ScreenRect(
+                    Canvas.GetLeft(card),
+                    Canvas.GetTop(card),
+                    card.Width,
+                    card.Height)));
+
+            card.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Null(viewModel.SelectedRoutePoint);
+            Assert.False(layer.IsVisible);
+
+            viewModel.SelectRoutePoint(selection, focus: false);
+            Dispatcher.UIThread.RunJobs();
+            map.Focus();
+            window.KeyPress(
+                Key.Escape,
+                RawInputModifiers.None,
+                PhysicalKey.Escape,
+                string.Empty);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Null(viewModel.SelectedRoutePoint);
+            Assert.False(layer.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void ExistingRouteSelectionDoesNotOpenTelemetryWhenWindowLoads()
+    {
+        var viewModel = CreateViewModel();
+        viewModel.SelectRoutePoint(
+            CreateRouteSelection(new Coordinate(0, 0)),
+            focus: false);
+        var window = new MainWindow { DataContext = viewModel };
+
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.NotNull(viewModel.SelectedRoutePoint);
+            Assert.False(Assert.IsType<Canvas>(
+                window.FindControl<Canvas>("RouteTelemetryLayer")).IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void LegsListButtonsAreWiredToTheRealMarkAndUnmarkSailedCommands()
     {
         var viewModel = new MainViewModel(
@@ -607,6 +717,37 @@ public sealed class MainWindowLayoutTests
 
     private static MainWindow CreateWindow() =>
         new() { DataContext = CreateViewModel() };
+
+    private static RouteMapSelection CreateRouteSelection(Coordinate coordinate)
+    {
+        var departure = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+        var destination = new Coordinate(
+            Math.Clamp(coordinate.Latitude + 0.25, -89, 89),
+            coordinate.Longitude <= 179.5
+                ? coordinate.Longitude + 0.25
+                : coordinate.Longitude - 0.25);
+        var request = new RouteRequest(
+            "telemetry-test",
+            coordinate,
+            destination,
+            departure,
+            departure.AddHours(6));
+        var point = new RoutePoint(coordinate, departure, 90, 6, 15, 180, 0);
+        var route = new RouteResult(
+            request,
+            ForecastModel.NoaaGfs,
+            [
+                point,
+                new RoutePoint(destination, departure.AddHours(6), 90, 6, 15, 180, 30)
+            ],
+            new RouteDiagnostics(10, 20, 5, 2));
+        return new RouteMapSelection(
+            route,
+            0,
+            point,
+            RouteHitKind.RoutePoint,
+            0);
+    }
 
     private static MainViewModel CreateViewModel() =>
         new(

--- a/tests/Navtool.App.Tests/RouteTelemetryPlacementTests.cs
+++ b/tests/Navtool.App.Tests/RouteTelemetryPlacementTests.cs
@@ -1,0 +1,78 @@
+using Navtool.App.Models;
+using Navtool.App.Services;
+
+namespace Navtool.App.Tests;
+
+public sealed class RouteTelemetryPlacementTests
+{
+    [Fact]
+    public void PlacesPopupToTheRightOfTheRoutePointWhenSpaceIsAvailable()
+    {
+        var result = RouteTelemetryPlacement.Calculate(
+            new ScreenRect(0, 0, 800, 600),
+            new ScreenPoint(300, 250),
+            new ScreenSize(220, 150),
+            gap: 18,
+            safeMargin: 12);
+
+        Assert.Equal(RouteTelemetrySide.Right, result.Side);
+        Assert.Equal(318, result.PopupBounds.X);
+        Assert.Equal(175, result.PopupBounds.Y);
+        Assert.Equal(result.Anchor, result.Connector.Start);
+        Assert.Equal(result.PopupBounds.X, result.Connector.End.X);
+        Assert.Equal(result.Anchor.Y, result.Connector.End.Y);
+    }
+
+    [Fact]
+    public void FlipsPopupToTheLeftNearTheRightEdge()
+    {
+        var result = RouteTelemetryPlacement.Calculate(
+            new ScreenRect(0, 0, 800, 600),
+            new ScreenPoint(760, 250),
+            new ScreenSize(220, 150),
+            gap: 18,
+            safeMargin: 12);
+
+        Assert.Equal(RouteTelemetrySide.Left, result.Side);
+        Assert.Equal(522, result.PopupBounds.X);
+        Assert.Equal(result.PopupBounds.Right, result.Connector.End.X);
+    }
+
+    [Theory]
+    [InlineData(20, 20)]
+    [InlineData(400, 20)]
+    [InlineData(780, 20)]
+    [InlineData(20, 580)]
+    [InlineData(400, 580)]
+    [InlineData(780, 580)]
+    public void KeepsPopupWithinSafeBoundsAtEveryEdge(double anchorX, double anchorY)
+    {
+        var visibleBounds = new ScreenRect(0, 0, 800, 600);
+        const double margin = 12;
+        var safeBounds = new ScreenRect(12, 12, 776, 576);
+
+        var result = RouteTelemetryPlacement.Calculate(
+            visibleBounds,
+            new ScreenPoint(anchorX, anchorY),
+            new ScreenSize(220, 150),
+            gap: 18,
+            safeMargin: margin);
+
+        Assert.True(safeBounds.Contains(result.PopupBounds));
+    }
+
+    [Fact]
+    public void CentersPopupWhenNeitherSideHasEnoughSpace()
+    {
+        var result = RouteTelemetryPlacement.Calculate(
+            new ScreenRect(0, 0, 260, 300),
+            new ScreenPoint(130, 150),
+            new ScreenSize(220, 150),
+            gap: 18,
+            safeMargin: 12);
+
+        Assert.Equal(RouteTelemetrySide.Centered, result.Side);
+        Assert.Equal(20, result.PopupBounds.X);
+        Assert.True(new ScreenRect(12, 12, 236, 276).Contains(result.PopupBounds));
+    }
+}

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -61,17 +61,19 @@ public sealed class NativeBridgeContractTests
     }
 
     [Theory]
-    [InlineData(90, 6, 15, 180, 68.19859051364824)]
-    [InlineData(90, 6, 15, 0, -68.19859051364818)]
-    [InlineData(90, 6, 0, 0, 0)]
-    [InlineData(90, 6, 15, 270, 180)]
-    [InlineData(350, 5, 20, 20, 24.133261210456055)]
-    public void Route_point_derives_apparent_wind_angle(
+    [InlineData(90, 6, 15, 180, 68.19859051364824, 16.15549442140351)]
+    [InlineData(90, 6, 15, 0, -68.19859051364818, 16.15549442140351)]
+    [InlineData(90, 6, 0, 0, 0, 6)]
+    [InlineData(90, 6, 15, 270, 180, 9)]
+    [InlineData(90, 6, 6, 270, 0, 0)]
+    [InlineData(350, 5, 20, 20, 24.133261210456055, 24.458231349729438)]
+    public void Route_point_derives_apparent_wind(
         double headingDegrees,
         double boatSpeedKnots,
         double trueWindSpeedKnots,
         double trueWindDirectionDegrees,
-        double expectedSignedAngle)
+        double expectedSignedAngle,
+        double expectedSpeed)
     {
         var point = new RoutePoint(
             new Coordinate(42, -60),
@@ -84,6 +86,7 @@ public sealed class NativeBridgeContractTests
 
         Assert.Equal(expectedSignedAngle, point.ApparentWindAngleSignedDegrees, 6);
         Assert.Equal(Math.Abs(expectedSignedAngle), point.ApparentWindAngleDegrees, 6);
+        Assert.Equal(expectedSpeed, point.ApparentWindSpeedKnots, 6);
     }
 
     [Fact]


### PR DESCRIPTION
Clicking a route already resolved the nearest discrete route point and updated the shared timeline, but that point had no marker on the map and its telemetry was only readable in the route drawer. This adds a PredictWind-style card anchored to the selected point so the key numbers are visible right where you clicked.

![Route point telemetry card anchored to the selected point](https://github.com/user-attachments/assets/ad3bfdad-3157-49b3-9759-683f13f5509c)

## What it does

Clicking the route (or using the radial Inspect action) drops a high-contrast anchor on the nearest route point and shows a compact card next to it with the UTC arrival time, boat speed, true wind speed, true wind direction, apparent wind speed and heading. The card stays put while you pan and zoom, follows subsequent selections, hides while its point is offscreen, and closes on Escape or by tapping the card (the whole card is a touch target, for touchscreens).

## Approach

- `RoutePoint.ApparentWindSpeedKnots` is derived from the same apparent wind vector that already backed the apparent wind angle, so the two can never drift apart. This is the only core model change; no native router or forecast contract change was needed.
- `RouteTelemetryPlacement` is a small pure helper that decides which side of the anchor the card sits on, flips near an edge, clamps inside safe bounds, and returns the connector endpoints. Keeping the math out of the view makes it unit testable.
- `MainWindow` renders the anchor, connector and card in a screen-space canvas and re-projects them on selection changes, viewport changes, drawer toggles and window resizes.

## Worth a closer look

The popup deliberately distinguishes *selection* from *inspection*. `SelectedRoutePoint` is set by the timeline on every route calculation, so keying the popup off `RouteSelectionChanged` alone made it appear unbidden on startup. There is now a separate `RoutePointInspectionRequested` event that only an explicit user inspection raises; `RouteSelectionChanged` only updates an already-open card or clears it. `ExistingRouteSelectionDoesNotOpenTelemetryWhenWindowLoads` locks that behaviour in.

`ClearRoutePointSelection` intentionally keeps `SelectedLeg` so dismissing the card does not throw away the selected itinerary leg.

The card is intentionally limited to these six fields. Coordinates, cumulative distance, model/run source and apparent wind angle remain in the route drawer.

## Testing

284 tests pass (Core 67, Infrastructure 86, App 131) and the app was launched through `./scripts/run.sh` with the native bridge preflight green and no `Routing engine unavailable` banner. The screenshot above is from that run, captured by clicking the calculated route; the values are self-consistent (wind from 101 deg with the boat heading 270 deg is nearly dead downwind, so AWS 2.7 kt against TWS 6.8 kt at 4.4 kt boat speed checks out).

Heads up for anyone running tests locally: the test projects do not set `IsTestProject`, so a plain `dotnet test` builds them and then silently skips VSTest while still exiting 0. Use `dotnet test Navtool.sln -p:IsTestProject=true` to actually execute them. CI is currently green, so this is a local-invocation gotcha rather than something this PR changes.
