### PR TITLE
Add production ECMWF forecast routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 This week adds land-aware routing, persistent multi-point voyage plans,
 sequential per-model calculation, rolling route resume, full-route
 visualization, and reusable NOAA forecast caching. It also modernizes the chart
-controls and strengthens native bridge launch guidance and automated
-validation.
+controls, adds production ECMWF IFS wind acquisition, and strengthens native
+bridge launch guidance and automated validation.
 
 > **Release status:** Unreleased draft for editorial review.
 
@@ -32,6 +32,10 @@ validation.
 
 ### Added
 
+- Added production ECMWF IFS 0.25-degree wind acquisition from ECMWF Open Data,
+  including rolling-cycle discovery, indexed 10u/10v byte-range downloads,
+  resumable persistent caching, native route-corridor loading, and normal
+  multi-model routing and weather overlays.
 - Added persistent Light, Dark, and **Kind of Blue** themes with a compact
   runtime selector and distinct interactive states.
   ([#22](https://github.com/frye/navtool/pull/22))
@@ -88,8 +92,8 @@ validation.
   coastline data is generalized and can omit small or recent hazards; routing
   still does not model currents, waves, traffic, restricted areas, depths, or
   safety limits.
-- Online ECMWF acquisition remains experimental and unavailable. Compatible
-  existing ECMWF IFS GRIB files can still be selected locally.
+- Online ECMWF support is wind-only. Routing still does not model waves or
+  currents, and ECMWF global field downloads can be larger than NOAA subsets.
 
 ## Week of July 13-17, 2026 (Draft)
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,15 @@ It targets macOS, Windows, and Linux.
 - Choose a local departure date/time, converted to UTC with DST validation.
 - Set the expected passage duration so only the required forecast times are
   acquired, up to the ten-day planning limit.
-- Download geographically subsetted NOAA GFS 0.25-degree 10 m wind fields, or
-  choose an existing GRIB through the operating system's native file picker.
+- Download NOAA GFS or ECMWF IFS 0.25-degree 10 m wind fields, or choose an
+  existing GRIB through the operating system's native file picker.
 - Calculate routes through the native `router-lib` bridge.
 - Apply bundled Natural Earth land geometry by default, with an optional
   higher-detail OSM-derived service override.
 - Watch historical destination-facing isochrone fronts, the emphasized latest
   front, and the closest provisional route stream onto the map while each model
   calculates.
-- Compare model routes with distinct map colors. ECMWF is shown as an
-  experimental option and currently fails explicitly because official indexed
-  retrieval is not implemented.
+- Compare NOAA GFS and ECMWF IFS routes with distinct map colors.
 - Render every saved successful itinerary leg together on one full-route map,
   including sailed history, while retaining waypoint guides for blocked,
   uncalculated, and out-of-window legs.
@@ -208,7 +206,6 @@ also be installed or packaged according to the target platform.
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |
 | `NAVTOOL_CACHE_ROOT` | Forecast cache directory |
 | `NAVTOOL_LAND_DATA_ENDPOINT` | Optional OSM-derived GeoJSON land service override; Navtool appends `south`, `west`, `north`, and `east` query parameters. When unset, bundled Natural Earth 1:10m land polygons are used. |
-| `NAVTOOL_ECMWF_EXPERIMENTAL` | `1` or `true` enables the experimental ECMWF path; acquisition still reports unsupported |
 
 The selected display theme is stored in `preferences/theme.txt` beneath
 `NAVTOOL_APP_DATA_ROOT` (or Navtool's default local application-data directory).
@@ -240,6 +237,20 @@ Navtool displays a warning. Enable **Use newest weather data** before calculatin
 to select that newest run; tiles already cached for it are still reused rather
 than downloaded again. NOMADS is not a bulk-download service and may be
 unavailable or throttle excessive usage.
+
+ECMWF data is downloaded from the official Open Data object store. Navtool reads
+the per-step JSON-lines indexes, retrieves only the global 10 m U/V wind messages
+with strict HTTP byte-range requests, and assembles them in an immutable GRIB2
+artifact. The native loader limits in-memory decoding to the buffered passage
+area. Global field downloads can be substantially larger than NOAA's geographic
+subsets; completed ranges are cached and reused across routes and restarts.
+
+Navtool considers the four deterministic IFS cycles each day. The 00/12 UTC
+cycles provide 3-hour steps through 144 hours and 6-hour steps through 240 hours;
+the 06/18 UTC cycles provide 3-hour steps through 90 hours. Publication is
+progressive and the rolling archive is short, so Navtool verifies every required
+index and falls back to an older covering cycle when a newer one is incomplete.
+Online ECMWF support currently acquires wind only.
 
 ## Existing GRIB files
 
@@ -304,11 +315,6 @@ independently. The routing engine does not model currents, waves, traffic,
 restricted areas, depths, or safety limits. The built-in vessel polar is an
 approximate demonstration model.
 
-ECMWF Open Data remains an explicit experimental option. Official data supports
-field/step selection but not server-side geographic cropping, and indexed
-10u/10v retrieval has not yet been implemented in this application. No fallback
-or other model is presented as ECMWF data.
-
 Multi-point results depend on the forecast available when each leg was
 calculated. A sailed line is historical planning context, not a recorded vessel
 track, and a stationary stopover is a schedule representation rather than
@@ -317,8 +323,11 @@ out-of-window legs intentionally show only itinerary guides and status.
 
 Saildocs is not used as an application API: it is an asynchronous email service
 for bandwidth-constrained users rather than a reliable regional download
-endpoint. ECMWF's official object store likewise does not provide server-side
-geographic cropping, so online ECMWF acquisition remains separate future work.
+endpoint.
+
+ECMWF forecast data is provided under the ECMWF Open Data terms. Users remain
+responsible for complying with the applicable licence and attribution
+requirements; see <https://www.ecmwf.int/en/forecasts/datasets/open-data>.
 
 ## Mapping licenses and attribution
 

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -519,6 +519,138 @@ std::filesystem::path create_tiled_grib() {
     return output_path;
 }
 
+std::filesystem::path create_ecmwf_grib(bool mixed_run = false) {
+    const auto output_path =
+        std::filesystem::temp_directory_path() /
+        ("navtool-ecmwf-" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()) +
+         ".grib2");
+    constexpr long longitude_count = 360L;
+    constexpr long latitude_count = 181L;
+    bool first_message = true;
+
+    try {
+        for (const long forecast_hour : {0L, 3L}) {
+            for (const auto* short_name : {"10u", "10v"}) {
+                codes_handle* handle =
+                    codes_grib_handle_new_from_samples(
+                        nullptr,
+                        "regular_ll_sfc_grib2");
+                if (handle == nullptr) {
+                    throw std::runtime_error(
+                        "unable to create ECMWF ecCodes GRIB sample");
+                }
+
+                try {
+                    require_codes_ok(
+                        codes_set_long(handle, "centre", 98L),
+                        "set ECMWF centre");
+                    require_codes_ok(
+                        codes_set_long(handle, "Ni", longitude_count),
+                        "set ECMWF Ni");
+                    require_codes_ok(
+                        codes_set_long(handle, "Nj", latitude_count),
+                        "set ECMWF Nj");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "latitudeOfFirstGridPointInDegrees",
+                            90.0),
+                        "set ECMWF first latitude");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "latitudeOfLastGridPointInDegrees",
+                            -90.0),
+                        "set ECMWF last latitude");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "longitudeOfFirstGridPointInDegrees",
+                            0.0),
+                        "set ECMWF first longitude");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "longitudeOfLastGridPointInDegrees",
+                            359.0),
+                        "set ECMWF last longitude");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "iDirectionIncrementInDegrees",
+                            1.0),
+                        "set ECMWF longitude increment");
+                    require_codes_ok(
+                        codes_set_double(
+                            handle,
+                            "jDirectionIncrementInDegrees",
+                            1.0),
+                        "set ECMWF latitude increment");
+                    require_codes_ok(
+                        codes_set_long(handle, "iScansNegatively", 0L),
+                        "set ECMWF i scan");
+                    require_codes_ok(
+                        codes_set_long(handle, "jScansPositively", 0L),
+                        "set ECMWF j scan");
+                    const bool use_mixed_run =
+                        mixed_run &&
+                        forecast_hour == 3L &&
+                        std::string{short_name} == "10v";
+                    require_codes_ok(
+                        codes_set_long(
+                            handle,
+                            "dataDate",
+                            use_mixed_run ? 20260804L : 20260803L),
+                        "set ECMWF date");
+                    require_codes_ok(
+                        codes_set_long(handle, "dataTime", 1800L),
+                        "set ECMWF time");
+                    require_codes_ok(
+                        codes_set_long(handle, "forecastTime", forecast_hour),
+                        "set ECMWF forecast time");
+                    const long parameter_id =
+                        std::string{short_name} == "10u" ? 165L : 166L;
+                    require_codes_ok(
+                        codes_set_long(handle, "paramId", parameter_id),
+                        "set ECMWF wind parameter");
+                    require_codes_ok(
+                        codes_set_long(handle, "level", 10L),
+                        "set ECMWF wind level");
+                    const std::vector<double> values(
+                        static_cast<std::size_t>(
+                            longitude_count * latitude_count),
+                        parameter_id == 165L ? 12.0 : 4.0);
+                    require_codes_ok(
+                        codes_set_double_array(
+                            handle,
+                            "values",
+                            values.data(),
+                            values.size()),
+                        "set ECMWF values");
+                    require_codes_ok(
+                        codes_write_message(
+                            handle,
+                            output_path.string().c_str(),
+                            first_message ? "w" : "a"),
+                        "write ECMWF GRIB message");
+                    first_message = false;
+                } catch (...) {
+                    codes_handle_delete(handle);
+                    throw;
+                }
+                codes_handle_delete(handle);
+            }
+        }
+    } catch (...) {
+        std::filesystem::remove(output_path);
+        throw;
+    }
+
+    return output_path;
+}
+
 }  // namespace
 
 int main() {
@@ -994,6 +1126,106 @@ int main() {
             std::filesystem::remove(tiled_grib);
             throw;
         }
+
+        const auto ecmwf_grib = create_ecmwf_grib();
+        try {
+            navtool_router_grib_descriptor_v1 ecmwf_desc{};
+            require_ok(
+                navtool_router_inspect_grib_v1(
+                    ecmwf_grib.string().c_str(),
+                    &ecmwf_desc),
+                "inspect ECMWF GRIB");
+            require(
+                ecmwf_desc.model_id == NAVTOOL_ROUTER_MODEL_ECMWF_IFS_V1,
+                "generated ECMWF GRIB has the wrong model identity");
+            require(
+                ecmwf_desc.first_valid_utc_epoch_seconds <
+                    ecmwf_desc.last_valid_utc_epoch_seconds,
+                "generated ECMWF GRIB does not have paired validity times");
+            require(
+                ecmwf_desc.south_latitude_degrees == -90.0 &&
+                    ecmwf_desc.north_latitude_degrees == 90.0,
+                "generated ECMWF GRIB does not report global latitude coverage");
+
+            require_ok(
+                navtool_router_forecast_load_bounded_v1(
+                    ecmwf_grib.string().c_str(),
+                    48.0,
+                    -124.0,
+                    49.0,
+                    -122.0,
+                    &forecast),
+                "load bounded ECMWF forecast");
+            require_ok(
+                navtool_router_forecast_get_metadata_v1(
+                    forecast,
+                    &metadata,
+                    &source,
+                    &source_length),
+                "read bounded ECMWF metadata");
+            require(
+                metadata.latitude_count == 2U &&
+                    metadata.longitude_count == 3U,
+                "ECMWF global forecast was not cropped to the requested corridor");
+            navtool_router_bridge_free_v1(source);
+
+            navtool_router_wind_sample_v1 ecmwf_sample{};
+            require_ok(
+                navtool_router_sample_grid_v1(
+                    forecast,
+                    48.5,
+                    -123.0,
+                    48.5,
+                    -123.0,
+                    1U,
+                    1U,
+                    metadata.first_valid_utc_epoch_seconds,
+                    &ecmwf_sample,
+                    1U),
+                "sample bounded ECMWF forecast");
+            require(
+                ecmwf_sample.valid == 1U &&
+                    std::abs(ecmwf_sample.east_mps - 12.0) < 1e-9 &&
+                    std::abs(ecmwf_sample.north_mps - 4.0) < 1e-9,
+                "ECMWF weather sampling returned unexpected wind");
+
+            departure = metadata.first_valid_utc_epoch_seconds;
+            route_json = nullptr;
+            route_json_length = 0U;
+            require_ok(
+                navtool_router_calculate_route_v1(
+                    forecast,
+                    48.5,
+                    -123.8,
+                    48.5,
+                    -123.2,
+                    &departure,
+                    &route_json,
+                    &route_json_length),
+                "calculate ECMWF route");
+            require(
+                route_json != nullptr && route_json_length > 0U,
+                "ECMWF route calculation returned no route");
+            navtool_router_bridge_free_v1(route_json);
+            require_ok(
+                navtool_router_forecast_destroy_v1(&forecast),
+                "destroy ECMWF forecast");
+            std::filesystem::remove(ecmwf_grib);
+        } catch (...) {
+            navtool_router_forecast_destroy_v1(&forecast);
+            std::filesystem::remove(ecmwf_grib);
+            throw;
+        }
+
+        const auto mixed_ecmwf_grib = create_ecmwf_grib(true);
+        navtool_router_grib_descriptor_v1 mixed_ecmwf_desc{};
+        require(
+            navtool_router_inspect_grib_v1(
+                mixed_ecmwf_grib.string().c_str(),
+                &mixed_ecmwf_desc) ==
+                NAVTOOL_ROUTER_STATUS_UNSUPPORTED_FORECAST_V1,
+            "mixed-run ECMWF GRIB was accepted");
+        std::filesystem::remove(mixed_ecmwf_grib);
 
         // ---- GRIB inspection API ----
 

--- a/src/Navtool.App/Services/AppComposition.cs
+++ b/src/Navtool.App/Services/AppComposition.cs
@@ -11,7 +11,6 @@ public static class AppComposition
     public const string ForecastHttpClientName = "Navtool.Forecasts";
     public const string AppDataRootEnvironmentVariable = "NAVTOOL_APP_DATA_ROOT";
     public const string CacheRootEnvironmentVariable = "NAVTOOL_CACHE_ROOT";
-    public const string EcmwfOptInEnvironmentVariable = "NAVTOOL_ECMWF_EXPERIMENTAL";
     public const string LandDataEndpointEnvironmentVariable = "NAVTOOL_LAND_DATA_ENDPOINT";
 
     public static ServiceProvider CreateServices()
@@ -62,8 +61,15 @@ public static class AppComposition
                 provider.GetRequiredService<IHttpClientFactory>().CreateClient(ForecastHttpClientName),
                 provider.GetRequiredService<AtomicFileCache>(),
                 logger: provider.GetRequiredService<ILogger<NoaaGfsForecastProvider>>()));
-        services.AddSingleton(_ => new EcmwfOpenDataForecastProvider(
-            new EcmwfOpenDataOptions { Enabled = IsExperimentalEcmwfEnabled() }));
+        services.AddSingleton<EcmwfOpenDataForecastProvider>(provider =>
+            new EcmwfOpenDataForecastProvider(
+                provider.GetRequiredService<IHttpClientFactory>().CreateClient(ForecastHttpClientName),
+                provider.GetRequiredService<AtomicFileCache>(),
+                logger: provider.GetRequiredService<ILogger<EcmwfOpenDataForecastProvider>>()));
+        services.AddSingleton<IForecastDownloadEstimator>(provider =>
+            provider.GetRequiredService<NoaaGfsForecastProvider>());
+        services.AddSingleton<IForecastDownloadEstimator>(provider =>
+            provider.GetRequiredService<EcmwfOpenDataForecastProvider>());
         services.AddSingleton<DeferredNativeRouteEngine>();
         services.AddSingleton<IRouteEngine>(provider =>
             provider.GetRequiredService<DeferredNativeRouteEngine>());
@@ -109,13 +115,6 @@ public static class AppComposition
         return !string.IsNullOrWhiteSpace(configured)
             ? Path.GetFullPath(configured)
             : Path.Combine(ResolveAppDataRoot(), "forecast-cache");
-    }
-
-    public static bool IsExperimentalEcmwfEnabled()
-    {
-        var value = Environment.GetEnvironmentVariable(EcmwfOptInEnvironmentVariable);
-        return string.Equals(value, "1", StringComparison.Ordinal) ||
-               string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
     }
 
     public static Uri? ResolveLandDataEndpoint()

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -53,7 +53,8 @@ public partial class MainViewModel : ViewModelBase
     private readonly IWeatherSampler? _weatherSampler;
     private readonly ILocalGribInspector? _localGribInspector;
     private readonly INativeRoutingPreflight? _nativeRoutingPreflight;
-    private readonly NoaaGfsForecastProvider? _noaaProvider;
+    private readonly IReadOnlyDictionary<ForecastModel, IForecastDownloadEstimator>
+        _forecastEstimators;
     private readonly TimeProvider _timeProvider;
     private readonly TimeZoneInfo _localTimeZone;
     private readonly ILogger<MainViewModel> _logger;
@@ -146,7 +147,7 @@ public partial class MainViewModel : ViewModelBase
     private string _noaaStatus = "Ready";
 
     [ObservableProperty]
-    private string _ecmwfStatus = "Experimental · not selected";
+    private string _ecmwfStatus = "Not selected";
 
     [ObservableProperty]
     private RouteMapSelection? _selectedRoutePoint;
@@ -197,14 +198,14 @@ public partial class MainViewModel : ViewModelBase
         IWeatherSampler weatherSampler,
         ILocalGribInspector localGribInspector,
         INativeRoutingPreflight nativeRoutingPreflight,
-        NoaaGfsForecastProvider noaaProvider,
+        IEnumerable<IForecastDownloadEstimator> forecastEstimators,
         ILogger<MainViewModel> logger)
         : this(
             workflow,
             weatherSampler,
             localGribInspector,
             nativeRoutingPreflight,
-            noaaProvider,
+            forecastEstimators,
             logger,
             null)
     {
@@ -215,7 +216,7 @@ public partial class MainViewModel : ViewModelBase
         IWeatherSampler weatherSampler,
         ILocalGribInspector localGribInspector,
         INativeRoutingPreflight nativeRoutingPreflight,
-        NoaaGfsForecastProvider noaaProvider,
+        IEnumerable<IForecastDownloadEstimator> forecastEstimators,
         ILogger<MainViewModel> logger,
         IRoutePlanRepository? routePlanRepository)
         : this(
@@ -227,8 +228,8 @@ public partial class MainViewModel : ViewModelBase
             logger,
             localGribInspector,
             nativeRoutingPreflight,
-            noaaProvider,
-            routePlanRepository)
+            routePlanRepository,
+            forecastEstimators: forecastEstimators)
     {
     }
 
@@ -237,7 +238,7 @@ public partial class MainViewModel : ViewModelBase
         IWeatherSampler weatherSampler,
         ILocalGribInspector localGribInspector,
         INativeRoutingPreflight nativeRoutingPreflight,
-        NoaaGfsForecastProvider noaaProvider,
+        IEnumerable<IForecastDownloadEstimator> forecastEstimators,
         ILogger<MainViewModel> logger,
         IRoutePlanRepository routePlanRepository,
         RoutePlanRoutingWorkflow routePlanWorkflow)
@@ -246,7 +247,7 @@ public partial class MainViewModel : ViewModelBase
             weatherSampler,
             localGribInspector,
             nativeRoutingPreflight,
-            noaaProvider,
+            forecastEstimators,
             logger,
             routePlanRepository,
             routePlanWorkflow,
@@ -259,7 +260,7 @@ public partial class MainViewModel : ViewModelBase
         IWeatherSampler weatherSampler,
         ILocalGribInspector localGribInspector,
         INativeRoutingPreflight nativeRoutingPreflight,
-        NoaaGfsForecastProvider noaaProvider,
+        IEnumerable<IForecastDownloadEstimator> forecastEstimators,
         ILogger<MainViewModel> logger,
         IRoutePlanRepository routePlanRepository,
         RoutePlanRoutingWorkflow routePlanWorkflow,
@@ -273,9 +274,9 @@ public partial class MainViewModel : ViewModelBase
             logger,
             localGribInspector,
             nativeRoutingPreflight,
-            noaaProvider,
             routePlanRepository,
-            routePlanWorkflow)
+            routePlanWorkflow,
+            forecastEstimators)
     {
     }
 
@@ -288,9 +289,9 @@ public partial class MainViewModel : ViewModelBase
         ILogger<MainViewModel>? logger = null,
         ILocalGribInspector? localGribInspector = null,
         INativeRoutingPreflight? nativeRoutingPreflight = null,
-        NoaaGfsForecastProvider? noaaProvider = null,
         IRoutePlanRepository? routePlanRepository = null,
-        RoutePlanRoutingWorkflow? routePlanWorkflow = null)
+        RoutePlanRoutingWorkflow? routePlanWorkflow = null,
+        IEnumerable<IForecastDownloadEstimator>? forecastEstimators = null)
     {
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(localTimeZone);
@@ -302,7 +303,8 @@ public partial class MainViewModel : ViewModelBase
         _weatherSampler = weatherSampler;
         _localGribInspector = localGribInspector;
         _nativeRoutingPreflight = nativeRoutingPreflight;
-        _noaaProvider = noaaProvider;
+        _forecastEstimators = (forecastEstimators ?? [])
+            .ToDictionary(estimator => estimator.Model);
         _timeProvider = timeProvider;
         _localTimeZone = localTimeZone;
         _logger = logger ?? NullLogger<MainViewModel>.Instance;
@@ -808,9 +810,7 @@ public partial class MainViewModel : ViewModelBase
         foreach (var model in request.Models)
         {
             _modelProgress[model] = 0;
-            SetModelStatus(model, IsExperimentalDownload(request, model)
-                ? "Experimental · queued"
-                : "Queued");
+            SetModelStatus(model, "Queued");
         }
 
         var progress = new Progress<RoutingProgress>(value =>
@@ -835,7 +835,6 @@ public partial class MainViewModel : ViewModelBase
                 });
             SetModelStatus(
                 value.Model,
-                $"{(IsExperimentalDownload(request, value.Model) ? "Experimental · " : string.Empty)}" +
                 $"{ProgressStageName(value.Stage)} {value.Fraction:P0}" +
                 $"{(string.IsNullOrWhiteSpace(value.Message) ? string.Empty : $" · {value.Message}")}");
             if (value.Snapshot is not null)
@@ -867,7 +866,6 @@ public partial class MainViewModel : ViewModelBase
                 });
             SetModelStatus(
                 value.Model,
-                $"{(IsExperimentalDownload(request, value.Model) ? "Experimental · " : string.Empty)}" +
                 $"leg {value.LegIndex + 1} {PlanProgressStageName(value.Status)} " +
                 $"{value.UnitFraction:P0}" +
                 $"{(string.IsNullOrWhiteSpace(value.Message) ? string.Empty : $" · {value.Message}")}");
@@ -1248,9 +1246,7 @@ public partial class MainViewModel : ViewModelBase
 
             var legStatuses = outcome.Legs.Select((leg, index) =>
                 $"leg {index + 1} {LegStatusName(leg, result.Plan.SailedLegIds.Contains(leg.LegId))}");
-            var modelStatus =
-                $"{(IsExperimentalDownload(result.Request.Selections, outcome.Model) ? "Experimental · " : string.Empty)}" +
-                string.Join(" · ", legStatuses);
+            var modelStatus = string.Join(" · ", legStatuses);
             SetModelStatus(outcome.Model, modelStatus);
 
             foreach (var leg in outcome.Legs)
@@ -1305,6 +1301,8 @@ public partial class MainViewModel : ViewModelBase
     partial void OnPassageHoursChanged(int value) => UpdateForecastAreaSummary();
 
     partial void OnUseNoaaChanged(bool value) => UpdateForecastAreaSummary();
+
+    partial void OnUseEcmwfChanged(bool value) => UpdateForecastAreaSummary();
 
     partial void OnForecastInputModeChanged(ForecastInputMode value)
     {
@@ -1457,7 +1455,6 @@ public partial class MainViewModel : ViewModelBase
                 if (route.IsForecastLimited)
                 {
                     status =
-                        $"{(IsExperimentalDownload(result.Request, outcome.Model) ? "Experimental · " : string.Empty)}" +
                         $"forecast ended · best estimate through {route.ArrivalTime:MMM d HH:mm} UTC";
                     warnings.Add(
                         $"{ModelName(outcome.Model)} route calculation ended because there is no more " +
@@ -1468,7 +1465,6 @@ public partial class MainViewModel : ViewModelBase
                 else
                 {
                     status =
-                        $"{(IsExperimentalDownload(result.Request, outcome.Model) ? "Experimental · " : string.Empty)}" +
                         $"complete · arrival {route.ArrivalTime:MMM d HH:mm} UTC";
                     if (route.ExceedsRequestedArrival)
                     {
@@ -1492,9 +1488,6 @@ public partial class MainViewModel : ViewModelBase
             else
             {
                 _mapLayers.ClearCalculationOverlay(outcome.Model);
-                var experimental = IsExperimentalDownload(result.Request, outcome.Model)
-                    ? "Experimental ECMWF"
-                    : ModelName(outcome.Model);
                 var failedStage = outcome.Failure!.Stage switch
                 {
                     ModelRouteFailureStage.ForecastAcquisition => "forecast acquisition",
@@ -1502,7 +1495,7 @@ public partial class MainViewModel : ViewModelBase
                     ModelRouteFailureStage.ResultValidation => "route result validation",
                     _ => "provider setup"
                 };
-                var message = $"{experimental} failed during {failedStage}: {outcome.Failure.Message}";
+                var message = $"{ModelName(outcome.Model)} failed during {failedStage}: {outcome.Failure.Message}";
                 failures.Add(message);
                 _logger.LogWarning(
                     "Forecast model {Model} failed during {FailureStage}: {FailureMessage}",
@@ -2173,9 +2166,7 @@ public partial class MainViewModel : ViewModelBase
             return;
         }
 
-        if (!UseNoaa ||
-            _noaaProvider is null ||
-            !TryGetPassageDuration(out var duration, out _) ||
+        if (!TryGetPassageDuration(out var duration, out _) ||
             !LocalDepartureConverter.TryConvertToUtc(
                 DepartureDate,
                 DepartureTime,
@@ -2189,15 +2180,35 @@ public partial class MainViewModel : ViewModelBase
 
         try
         {
-            var estimate = _noaaProvider.Estimate(new ForecastRequest(
-                ForecastModel.NoaaGfs,
-                bounds,
-                departure,
-                departure + duration));
-            ForecastAreaSummary =
-                $"{area} · {estimate.ForecastStepCount} times, " +
-                $"{estimate.PartCount} forecast part{(estimate.PartCount == 1 ? string.Empty : "s")} " +
-                "(cached parts are reused)";
+            var estimates = new List<string>();
+            if (UseNoaa &&
+                _forecastEstimators.TryGetValue(ForecastModel.NoaaGfs, out var noaaEstimator))
+            {
+                var estimate = noaaEstimator.EstimateDownload(new ForecastRequest(
+                    ForecastModel.NoaaGfs,
+                    bounds,
+                    departure,
+                    departure + duration));
+                estimates.Add(
+                    $"NOAA {estimate.ForecastStepCount} times/{estimate.PartCount} parts");
+            }
+
+            if (UseEcmwf &&
+                _forecastEstimators.TryGetValue(ForecastModel.EcmwfIfs, out var ecmwfEstimator))
+            {
+                var estimate = ecmwfEstimator.EstimateDownload(new ForecastRequest(
+                    ForecastModel.EcmwfIfs,
+                    bounds,
+                    departure,
+                    departure + duration));
+                estimates.Add(
+                    $"ECMWF {estimate.ForecastStepCount} times/" +
+                    $"{estimate.PartCount} global wind ranges");
+            }
+
+            ForecastAreaSummary = estimates.Count == 0
+                ? area
+                : $"{area} · {string.Join("; ", estimates)} (cached parts are reused)";
         }
         catch (Exception exception)
         {
@@ -2224,19 +2235,6 @@ public partial class MainViewModel : ViewModelBase
     private static string FormatBounds(GeographicBounds bounds) =>
         $"{bounds.South:0.##}° to {bounds.North:0.##}° latitude, " +
         $"{bounds.West:0.##}° to {bounds.East:0.##}° longitude";
-
-    private static bool IsExperimentalDownload(
-        RoutingWorkflowRequest request,
-        ForecastModel model) =>
-        IsExperimentalDownload(request.Selections, model);
-
-    private static bool IsExperimentalDownload(
-        IEnumerable<ForecastSelection> selections,
-        ForecastModel model) =>
-        model == ForecastModel.EcmwfIfs &&
-        selections.Any(selection =>
-            selection.Model == model &&
-            selection.Kind == ForecastSelectionKind.OfficialDownload);
 
     private static string PlanProgressStageName(RoutePlanRoutingUnitStatus status) => status switch
     {
@@ -2323,7 +2321,7 @@ public partial class MainViewModel : ViewModelBase
     private static string ModelName(ForecastModel model) => model switch
     {
         ForecastModel.NoaaGfs => "NOAA GFS",
-        ForecastModel.EcmwfIfs => "ECMWF IFS (experimental)",
+        ForecastModel.EcmwfIfs => "ECMWF IFS",
         _ => model.ToString()
     };
 

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -365,7 +365,7 @@
                                     </CheckBox>
                                     <CheckBox IsChecked="{Binding UseEcmwf}">
                                         <StackPanel>
-                                            <TextBlock Text="ECMWF IFS · EXPERIMENTAL"
+                                            <TextBlock Text="ECMWF IFS"
                                                        FontWeight="SemiBold" />
                                             <TextBlock Text="{Binding EcmwfStatus}"
                                                        Classes="muted"
@@ -748,7 +748,7 @@
                                                  Command="{Binding ActivateNoaaRouteCommand}"
                                                  IsChecked="{Binding IsNoaaRouteActive, Mode=OneWay}"
                                                  IsVisible="{Binding HasNoaaRoutes}" />
-                                    <RadioButton Content="ECMWF experimental"
+                                    <RadioButton Content="ECMWF IFS"
                                                  Command="{Binding ActivateEcmwfRouteCommand}"
                                                  IsChecked="{Binding IsEcmwfRouteActive, Mode=OneWay}"
                                                  IsVisible="{Binding HasEcmwfRoutes}" />
@@ -870,7 +870,7 @@
                                                      Command="{Binding ActivateNoaaWeatherCommand}"
                                                      IsChecked="{Binding IsNoaaWeatherActive, Mode=OneWay}"
                                                      IsVisible="{Binding HasNoaaWeather}" />
-                                        <RadioButton Content="ECMWF experimental"
+                                        <RadioButton Content="ECMWF IFS"
                                                      Command="{Binding ActivateEcmwfWeatherCommand}"
                                                      IsChecked="{Binding IsEcmwfWeatherActive, Mode=OneWay}"
                                                      IsVisible="{Binding HasEcmwfWeather}" />

--- a/src/Navtool.Core/Forecasts.cs
+++ b/src/Navtool.Core/Forecasts.cs
@@ -443,6 +443,20 @@ public sealed record ForecastCacheUsage
     public bool IsNewerRunAvailable => LatestPublishedRun > SelectedRun;
 }
 
+public sealed record ForecastDownloadEstimate(
+    ForecastModel Model,
+    int ForecastStepCount,
+    int PartCount,
+    long? EstimatedBytes,
+    string Warning);
+
+public interface IForecastDownloadEstimator
+{
+    ForecastModel Model { get; }
+
+    ForecastDownloadEstimate EstimateDownload(ForecastRequest request);
+}
+
 public interface IForecastProvider
 {
     ForecastProvider Provider { get; }

--- a/src/Navtool.Infrastructure/EcmwfOpenDataForecastProvider.cs
+++ b/src/Navtool.Infrastructure/EcmwfOpenDataForecastProvider.cs
@@ -1,16 +1,35 @@
+using System.Collections.Immutable;
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Navtool.Core;
 
 namespace Navtool.Infrastructure;
 
 public sealed record EcmwfOpenDataOptions
 {
-    public bool Enabled { get; init; }
-}
+    public Uri BaseUri { get; init; } = new("https://data.ecmwf.int/forecasts/");
 
-public enum ExperimentalProviderState
-{
-    Disabled,
-    EnabledButUnsupported
+    public int MaximumRunLookbackCycles { get; init; } = 12;
+
+    public long MaximumIndexBytes { get; init; } = 8L * 1024 * 1024;
+
+    public long MaximumRangeBytes { get; init; } = 64L * 1024 * 1024;
+
+    public long MaximumPartCacheBytes { get; init; } = 2L * 1024 * 1024 * 1024;
+
+    public int MaximumDownloadAttempts { get; init; } = 3;
+
+    public TimeSpan BaseRetryDelay { get; init; } = TimeSpan.FromSeconds(1);
+
+    public TimeSpan MaximumRetryDelay { get; init; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan MinimumRequestInterval { get; init; } = TimeSpan.FromMilliseconds(250);
 }
 
 public sealed record ForecastProviderEstimate(
@@ -19,70 +38,964 @@ public sealed record ForecastProviderEstimate(
     bool IsSupported,
     string Warning);
 
-public sealed class ExperimentalProviderDisabledException : InvalidOperationException
-{
-    public ExperimentalProviderDisabledException(string message)
-        : base(message)
-    {
-    }
-}
+internal sealed record EcmwfIndexPart(
+    int ForecastHour,
+    string Parameter,
+    long Offset,
+    long Length,
+    Uri DataUri,
+    string PartKey);
 
-public sealed class EcmwfOpenDataForecastProvider : IForecastProvider
+internal sealed record EcmwfAcquisitionPlan(
+    DateTimeOffset RunTime,
+    ImmutableArray<int> ForecastHours,
+    ImmutableArray<EcmwfIndexPart> Parts,
+    string CacheKey);
+
+public sealed class EcmwfOpenDataForecastProvider : IForecastProvider, IForecastDownloadEstimator
 {
+    private static readonly UTF8Encoding StrictUtf8 = new(false, true);
+    private static readonly ImmutableArray<int> LongCycleHours =
+        [.. Enumerable.Range(0, 49).Select(index => index * 3)
+            .Concat(Enumerable.Range(25, 16).Select(index => index * 6))];
+    private static readonly ImmutableArray<int> ShortCycleHours =
+        [.. Enumerable.Range(0, 31).Select(index => index * 3)];
+
+    private readonly HttpClient _httpClient;
+    private readonly AtomicFileCache _cache;
+    private readonly TimeProvider _timeProvider;
     private readonly EcmwfOpenDataOptions _options;
+    private readonly ILogger<EcmwfOpenDataForecastProvider> _logger;
+    private readonly KeyedAsyncGate _acquisitionGate = new();
 
-    public EcmwfOpenDataForecastProvider(EcmwfOpenDataOptions? options = null)
+    public EcmwfOpenDataForecastProvider(
+        HttpClient httpClient,
+        AtomicFileCache cache,
+        TimeProvider? timeProvider = null,
+        EcmwfOpenDataOptions? options = null,
+        ILogger<EcmwfOpenDataForecastProvider>? logger = null)
     {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(cache);
+        _httpClient = httpClient;
+        _cache = cache;
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _options = options ?? new EcmwfOpenDataOptions();
+        _logger = logger ?? NullLogger<EcmwfOpenDataForecastProvider>.Instance;
+        ValidateOptions(_options);
     }
 
     public ForecastProvider Provider => ForecastProvider.Ecmwf;
 
     public ForecastModel Model => ForecastModel.EcmwfIfs;
 
-    public bool IsExperimental => true;
-
-    public ExperimentalProviderState State => _options.Enabled
-        ? ExperimentalProviderState.EnabledButUnsupported
-        : ExperimentalProviderState.Disabled;
-
     public ForecastProviderEstimate Estimate(ForecastRequest request)
     {
-        ArgumentNullException.ThrowIfNull(request);
-        if (request.Model != Model)
-        {
-            throw new ArgumentException("The ECMWF provider only estimates EcmwfIfs requests.", nameof(request));
-        }
-
-        var sixHourIntervals = Math.Max(
-            1,
-            (int)Math.Ceiling((request.Through - request.From).TotalHours / 6d) + 1);
+        ValidateRequest(request);
+        var run = SelectNewestCoveringRun(request, _timeProvider.GetUtcNow());
+        var hours = GetRequiredForecastHours(run, request.From, request.Through);
         return new ForecastProviderEstimate(
-            checked(sixHourIntervals * 2),
+            checked(hours.Length * 2),
             null,
-            false,
-            "Experimental only: official ECMWF Open Data .index byte ranges for 10u/10v are not yet implemented; no forecast will be returned.");
+            true,
+            "ECMWF downloads global indexed 10 m wind fields; route bounds are applied while loading the forecast.");
     }
 
-    public ValueTask<ForecastAcquisition> AcquireAsync(
+    public ForecastDownloadEstimate EstimateDownload(ForecastRequest request)
+    {
+        var estimate = Estimate(request);
+        return new ForecastDownloadEstimate(
+            Model,
+            estimate.EstimatedRangeRequests / 2,
+            estimate.EstimatedRangeRequests,
+            estimate.EstimatedBytes,
+            estimate.Warning);
+    }
+
+    public async ValueTask<ForecastAcquisition> AcquireAsync(
         ForecastRequest request,
         IProgress<ForecastProgress>? progress,
         CancellationToken cancellationToken)
+    {
+        ValidateRequest(request);
+        cancellationToken.ThrowIfCancellationRequested();
+        using var lease = await _acquisitionGate.EnterAsync(
+                "ecmwf-open-data-service",
+                cancellationToken)
+            .ConfigureAwait(false);
+        return await AcquireCoreAsync(request, progress, cancellationToken).ConfigureAwait(false);
+    }
+
+    public DateTimeOffset SelectNewestCoveringRun(ForecastRequest request, DateTimeOffset now)
+    {
+        ValidateRequest(request);
+        foreach (var candidate in GetCandidateRuns(now))
+        {
+            if (CanCover(candidate, request.From, request.Through))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "No retained ECMWF IFS run can cover the requested departure and route horizon.");
+    }
+
+    public static ImmutableArray<int> GetRequiredForecastHours(
+        DateTimeOffset runTime,
+        DateTimeOffset from,
+        DateTimeOffset through)
+    {
+        var run = runTime.ToUniversalTime();
+        var startHours = (from.ToUniversalTime() - run).TotalHours;
+        var endHours = (through.ToUniversalTime() - run).TotalHours;
+        var available = IsLongCycle(run) ? LongCycleHours : ShortCycleHours;
+        if (startHours < 0 || endHours < startHours || endHours > available[^1])
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(through),
+                $"The requested interval must be within the ECMWF {available[^1]}-hour horizon for the {run:HH} UTC cycle.");
+        }
+
+        var firstIndex = -1;
+        var lastIndex = -1;
+        for (var index = 0; index < available.Length; index++)
+        {
+            if (available[index] <= startHours)
+            {
+                firstIndex = index;
+            }
+
+            if (lastIndex < 0 && available[index] >= endHours)
+            {
+                lastIndex = index;
+            }
+        }
+
+        if (firstIndex < 0 || lastIndex < firstIndex)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(through),
+                "The ECMWF forecast cannot bracket the requested interval.");
+        }
+
+        return available[firstIndex..(lastIndex + 1)];
+    }
+
+    public Uri BuildProductUri(DateTimeOffset runTime, int forecastHour, string extension)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(extension);
+        if (extension is not ("index" or "grib2"))
+        {
+            throw new ArgumentException("ECMWF product extension must be index or grib2.", nameof(extension));
+        }
+
+        var run = runTime.ToUniversalTime();
+        var available = IsLongCycle(run) ? LongCycleHours : ShortCycleHours;
+        if (!available.Contains(forecastHour))
+        {
+            throw new ArgumentOutOfRangeException(nameof(forecastHour));
+        }
+
+        var relative =
+            $"{run:yyyyMMdd}/{run:HH}z/ifs/0p25/oper/{run:yyyyMMddHHmmss}-{forecastHour}h-oper-fc.{extension}";
+        return new Uri(_options.BaseUri, relative);
+    }
+
+    internal static ImmutableArray<EcmwfIndexPart> ParseIndex(
+        string jsonLines,
+        int forecastHour,
+        Uri dataUri)
+    {
+        ArgumentNullException.ThrowIfNull(jsonLines);
+        ArgumentNullException.ThrowIfNull(dataUri);
+        var matches = new Dictionary<string, (long Offset, long Length)>(StringComparer.Ordinal);
+        using var reader = new StringReader(jsonLines);
+        var lineNumber = 0;
+        while (reader.ReadLine() is { } line)
+        {
+            lineNumber++;
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            JsonDocument document;
+            try
+            {
+                document = JsonDocument.Parse(line);
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidDataException(
+                    $"ECMWF index line {lineNumber} is invalid JSON.",
+                    exception);
+            }
+
+            using (document)
+            {
+                var root = document.RootElement;
+                if (!root.TryGetProperty("param", out var parameterElement) ||
+                    parameterElement.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+
+                var parameter = parameterElement.GetString();
+                if (parameter is not ("10u" or "10v"))
+                {
+                    continue;
+                }
+
+                if (!root.TryGetProperty("levtype", out var levelType) ||
+                    levelType.ValueKind != JsonValueKind.String ||
+                    !string.Equals(levelType.GetString(), "sfc", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!TryReadInt64(root, "_offset", out var offset) ||
+                    !TryReadInt64(root, "_length", out var length) ||
+                    offset < 0 ||
+                    length <= 0)
+                {
+                    throw new InvalidDataException(
+                        $"ECMWF index line {lineNumber} has an invalid byte offset or length.");
+                }
+
+                if (!matches.TryAdd(parameter, (offset, length)))
+                {
+                    throw new InvalidDataException(
+                        $"ECMWF index contains more than one {parameter} surface field for forecast hour {forecastHour}.");
+                }
+            }
+        }
+
+        if (!matches.ContainsKey("10u") || !matches.ContainsKey("10v"))
+        {
+            throw new InvalidDataException(
+                $"ECMWF index does not contain paired 10u and 10v surface fields for forecast hour {forecastHour}.");
+        }
+
+        var ordered = new[] { "10u", "10v" }
+            .Select(parameter =>
+            {
+                var range = matches[parameter];
+                var end = checked(range.Offset + range.Length);
+                return (
+                    Part: new EcmwfIndexPart(
+                        forecastHour,
+                        parameter,
+                        range.Offset,
+                        range.Length,
+                        dataUri,
+                        AtomicFileCache.CreateKey(
+                            "ecmwf-part",
+                            dataUri.AbsoluteUri,
+                            parameter,
+                            range.Offset.ToString(CultureInfo.InvariantCulture),
+                            range.Length.ToString(CultureInfo.InvariantCulture))),
+                    End: end);
+            })
+            .OrderBy(item => item.Part.Offset)
+            .ToArray();
+        if (ordered[0].End > ordered[1].Part.Offset)
+        {
+            throw new InvalidDataException(
+                $"ECMWF index byte ranges overlap for forecast hour {forecastHour}.");
+        }
+
+        return [.. ordered.Select(item => item.Part).OrderBy(part => part.Parameter, StringComparer.Ordinal)];
+    }
+
+    private async ValueTask<ForecastAcquisition> AcquireCoreAsync(
+        ForecastRequest request,
+        IProgress<ForecastProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        var now = _timeProvider.GetUtcNow();
+        Report(progress, ForecastProgressStage.Queued, 0, "Selecting ECMWF IFS run");
+        var candidates = GetCandidateRuns(now)
+            .Where(candidate => CanCover(candidate, request.From, request.Through))
+            .ToImmutableArray();
+        if (candidates.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                "No retained ECMWF IFS run can cover the requested departure and route horizon.");
+        }
+
+        if (request.RefreshPolicy == ForecastRefreshPolicy.PreferCache)
+        {
+            foreach (var candidate in candidates)
+            {
+                var hours = GetRequiredForecastHours(candidate, request.From, request.Through);
+                var cacheKey = CreateAssemblyCacheKey(candidate, hours);
+                var cached = await _cache.TryGetAsync(cacheKey, now, cancellationToken).ConfigureAwait(false);
+                if (cached is not null)
+                {
+                    Report(progress, ForecastProgressStage.Completed, 1, "Using cached ECMWF IFS forecast");
+                    return CreateAcquisition(
+                        request,
+                        candidate,
+                        cached,
+                        ForecastAcquisitionSource.Cache,
+                        new ForecastCacheUsage(
+                            hours.Length * 2,
+                            0,
+                            candidate,
+                            candidate));
+                }
+            }
+        }
+
+        EcmwfAcquisitionPlan? plan = null;
+        Exception? lastFailure = null;
+        for (var index = 0; index < candidates.Length; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var candidate = candidates[index];
+            Report(
+                progress,
+                ForecastProgressStage.Queued,
+                index / (double)candidates.Length,
+                $"Checking ECMWF IFS {candidate:yyyy-MM-dd HH}:00 UTC");
+            try
+            {
+                plan = await TryBuildPlanAsync(request, candidate, cancellationToken).ConfigureAwait(false);
+                if (plan is not null)
+                {
+                    break;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception) when (
+                exception is HttpRequestException or ForecastDownloadException or InvalidDataException)
+            {
+                lastFailure = exception;
+                _logger.LogWarning(
+                    exception,
+                    "ECMWF IFS run {RunTime} is not usable; trying an older covering run",
+                    candidate);
+            }
+        }
+
+        if (plan is null)
+        {
+            throw new ForecastDownloadException(
+                "No published ECMWF IFS run with complete paired 10u/10v indexes covers the requested interval.",
+                lastFailure ?? new InvalidOperationException("No complete ECMWF run was found."));
+        }
+
+        var existingAssembly = await _cache.TryGetAsync(plan.CacheKey, now, cancellationToken)
+            .ConfigureAwait(false);
+        if (existingAssembly is not null)
+        {
+            Report(progress, ForecastProgressStage.Completed, 1, "Using cached ECMWF IFS forecast");
+            return CreateAcquisition(
+                request,
+                plan.RunTime,
+                existingAssembly,
+                ForecastAcquisitionSource.Cache,
+                new ForecastCacheUsage(
+                    plan.Parts.Length,
+                    0,
+                    plan.RunTime,
+                    plan.RunTime));
+        }
+
+        var partsDirectory = Path.Combine(_cache.RootDirectory, "ecmwf-parts");
+        Directory.CreateDirectory(partsDirectory);
+        SweepOrphanedPartials(partsDirectory);
+        var downloadedParts = 0;
+        for (var index = 0; index < plan.Parts.Length; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var part = plan.Parts[index];
+            var partPath = Path.Combine(partsDirectory, part.PartKey + ".grib2");
+            if (IsValidPartFile(partPath, part.Length))
+            {
+                File.SetLastWriteTimeUtc(partPath, now.UtcDateTime);
+                Report(
+                    progress,
+                    ForecastProgressStage.Downloading,
+                    (index + 1) / (double)plan.Parts.Length,
+                    $"Resumed cached ECMWF f{part.ForecastHour:000} {part.Parameter}");
+                continue;
+            }
+
+            if (File.Exists(partPath))
+            {
+                File.Delete(partPath);
+            }
+
+            if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+            {
+                await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
+            }
+
+            Report(
+                progress,
+                ForecastProgressStage.Downloading,
+                index / (double)plan.Parts.Length,
+                $"Downloading ECMWF f{part.ForecastHour:000} {part.Parameter} ({index + 1}/{plan.Parts.Length})");
+            await DownloadPartAsync(part, partPath, cancellationToken).ConfigureAwait(false);
+            downloadedParts++;
+        }
+
+        Report(progress, ForecastProgressStage.Decoding, 1, "Assembling ECMWF IFS GRIB2 artifact");
+        var cacheNow = _timeProvider.GetUtcNow();
+        var stored = await _cache.StoreAsync(
+                plan.CacheKey,
+                cacheNow,
+                DateTimeOffset.MaxValue,
+                async (output, token) =>
+                {
+                    foreach (var part in plan.Parts)
+                    {
+                        var partPath = Path.Combine(partsDirectory, part.PartKey + ".grib2");
+                        await using var input = new FileStream(
+                            partPath,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.Read,
+                            128 * 1024,
+                            FileOptions.Asynchronous | FileOptions.SequentialScan);
+                        await input.CopyToAsync(output, token).ConfigureAwait(false);
+                    }
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+        PrunePartCache(partsDirectory, plan.Parts.Select(part => part.PartKey).ToHashSet(StringComparer.Ordinal));
+
+        Report(progress, ForecastProgressStage.Completed, 1, "ECMWF IFS forecast ready");
+        return CreateAcquisition(
+            request,
+            plan.RunTime,
+            stored,
+            downloadedParts == 0 ? ForecastAcquisitionSource.Cache : ForecastAcquisitionSource.Remote,
+            new ForecastCacheUsage(
+                plan.Parts.Length - downloadedParts,
+                downloadedParts,
+                plan.RunTime,
+                plan.RunTime));
+    }
+
+    private async ValueTask<EcmwfAcquisitionPlan?> TryBuildPlanAsync(
+        ForecastRequest request,
+        DateTimeOffset runTime,
+        CancellationToken cancellationToken)
+    {
+        var hours = GetRequiredForecastHours(runTime, request.From, request.Through);
+        var builder = ImmutableArray.CreateBuilder<EcmwfIndexPart>(hours.Length * 2);
+        foreach (var hour in hours)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var dataUri = BuildProductUri(runTime, hour, "grib2");
+            var indexUri = BuildProductUri(runTime, hour, "index");
+            var index = await DownloadIndexAsync(indexUri, cancellationToken).ConfigureAwait(false);
+            if (index is null)
+            {
+                return null;
+            }
+
+            var parts = ParseIndex(index, hour, dataUri);
+            if (parts.Any(part => part.Length > _options.MaximumRangeBytes))
+            {
+                throw new InvalidDataException(
+                    $"ECMWF index contains a wind range larger than the configured limit for forecast hour {hour}.");
+            }
+
+            builder.AddRange(parts);
+        }
+
+        return new EcmwfAcquisitionPlan(
+            runTime,
+            hours,
+            builder.MoveToImmutable(),
+            CreateAssemblyCacheKey(runTime, hours));
+    }
+
+    private async ValueTask<string?> DownloadIndexAsync(
+        Uri uri,
+        CancellationToken cancellationToken)
+    {
+        Exception? lastFailure = null;
+        for (var attempt = 1; attempt <= _options.MaximumDownloadAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                using var response = await _httpClient.SendAsync(
+                        request,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return null;
+                }
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw CreateHttpFailure("ECMWF index", uri, response);
+                }
+
+                var contentLength = response.Content.Headers.ContentLength;
+                if (contentLength is > 0 && contentLength > _options.MaximumIndexBytes)
+                {
+                    throw new ForecastDownloadException(
+                        $"ECMWF index response for '{uri}' exceeds the configured size limit.");
+                }
+
+                await using var input = await response.Content.ReadAsStreamAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                using var output = new MemoryStream();
+                await CopyBoundedAsync(
+                    input,
+                    output,
+                    _options.MaximumIndexBytes,
+                    cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    return StrictUtf8.GetString(
+                        output.GetBuffer(),
+                        0,
+                        checked((int)output.Length));
+                }
+                catch (DecoderFallbackException exception)
+                {
+                    throw new InvalidDataException(
+                        $"ECMWF index response for '{uri.GetLeftPart(UriPartial.Path)}' is not valid UTF-8.",
+                        exception);
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception) when (IsTransientFailure(exception))
+            {
+                lastFailure = exception;
+                if (attempt == _options.MaximumDownloadAttempts)
+                {
+                    break;
+                }
+
+                await DelayForRetryAsync(exception, attempt, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new ForecastDownloadException(
+            $"ECMWF index request failed after {_options.MaximumDownloadAttempts} attempts for '{uri}': {lastFailure!.Message}",
+            lastFailure);
+    }
+
+    private async ValueTask DownloadPartAsync(
+        EcmwfIndexPart part,
+        string partPath,
+        CancellationToken cancellationToken)
+    {
+        var tempPath = $"{partPath}.{Guid.NewGuid():N}.partial";
+        try
+        {
+            Exception? lastFailure = null;
+            for (var attempt = 1; attempt <= _options.MaximumDownloadAttempts; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    await DownloadRangeAttemptAsync(part, tempPath, cancellationToken)
+                        .ConfigureAwait(false);
+                    File.Move(tempPath, partPath);
+                    return;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception exception) when (IsTransientFailure(exception))
+                {
+                    lastFailure = exception;
+                    TryDelete(tempPath);
+                    if (attempt == _options.MaximumDownloadAttempts)
+                    {
+                        break;
+                    }
+
+                    await DelayForRetryAsync(exception, attempt, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            throw new ForecastDownloadException(
+                $"ECMWF range request failed after {_options.MaximumDownloadAttempts} attempts for " +
+                $"f{part.ForecastHour:000} {part.Parameter}: {lastFailure!.Message}",
+                lastFailure);
+        }
+        finally
+        {
+            TryDelete(tempPath);
+        }
+    }
+
+    private async ValueTask DownloadRangeAttemptAsync(
+        EcmwfIndexPart part,
+        string tempPath,
+        CancellationToken cancellationToken)
+    {
+        var end = checked(part.Offset + part.Length - 1);
+        using var request = new HttpRequestMessage(HttpMethod.Get, part.DataUri);
+        request.Headers.Range = new RangeHeaderValue(part.Offset, end);
+        using var response = await _httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.PartialContent)
+        {
+            if (!response.IsSuccessStatusCode ||
+                ForecastHttpSupport.IsTransientStatus(response.StatusCode))
+            {
+                throw CreateHttpFailure("ECMWF byte range", part.DataUri, response);
+            }
+
+            throw new ForecastDownloadException(
+                $"ECMWF byte-range request for '{part.DataUri}' returned {(int)response.StatusCode}; " +
+                "HTTP 206 Partial Content is required.");
+        }
+
+        var range = response.Content.Headers.ContentRange;
+        if (range?.From != part.Offset || range.To != end ||
+            response.Content.Headers.ContentLength != part.Length)
+        {
+            throw new ForecastDownloadException(
+                $"ECMWF returned an inconsistent Content-Range for f{part.ForecastHour:000} {part.Parameter}.");
+        }
+
+        if (part.Length > _options.MaximumRangeBytes)
+        {
+            throw new ForecastDownloadException(
+                $"ECMWF range for f{part.ForecastHour:000} {part.Parameter} exceeds the configured size limit.");
+        }
+
+        var mediaType = response.Content.Headers.ContentType?.MediaType;
+        if (mediaType is not null && ForecastHttpSupport.IsTextMediaType(mediaType))
+        {
+            throw new ForecastDownloadException(
+                $"ECMWF returned unexpected content type '{mediaType}' for a GRIB byte range.");
+        }
+
+        await using var input = await response.Content.ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        await using (var output = new FileStream(
+                         tempPath,
+                         FileMode.CreateNew,
+                         FileAccess.Write,
+                         FileShare.None,
+                         128 * 1024,
+                         FileOptions.Asynchronous | FileOptions.WriteThrough))
+        {
+            await CopyExactAsync(input, output, part.Length, cancellationToken).ConfigureAwait(false);
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+            output.Flush(true);
+        }
+
+        if (!IsValidPartFile(tempPath, part.Length))
+        {
+            throw new ForecastDownloadException(
+                $"ECMWF range for f{part.ForecastHour:000} {part.Parameter} is not one complete GRIB message.");
+        }
+    }
+
+    private ImmutableArray<DateTimeOffset> GetCandidateRuns(DateTimeOffset now)
+    {
+        var utc = now.ToUniversalTime();
+        var latest = new DateTimeOffset(
+            utc.Year,
+            utc.Month,
+            utc.Day,
+            (utc.Hour / 6) * 6,
+            0,
+            0,
+            TimeSpan.Zero);
+        return
+        [
+            .. Enumerable.Range(0, _options.MaximumRunLookbackCycles)
+                .Select(index => latest.AddHours(-6d * index))
+        ];
+    }
+
+    private static bool CanCover(
+        DateTimeOffset run,
+        DateTimeOffset from,
+        DateTimeOffset through)
+    {
+        var horizon = IsLongCycle(run) ? 240 : 90;
+        return run <= from.ToUniversalTime() && through.ToUniversalTime() <= run.AddHours(horizon);
+    }
+
+    private static bool IsLongCycle(DateTimeOffset run) => run.ToUniversalTime().Hour is 0 or 12;
+
+    private static string CreateAssemblyCacheKey(
+        DateTimeOffset runTime,
+        ImmutableArray<int> hours) =>
+        AtomicFileCache.CreateKey(
+            "ecmwf-ifs",
+            runTime.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture),
+            string.Join(",", hours));
+
+    private static ForecastAcquisition CreateAcquisition(
+        ForecastRequest request,
+        DateTimeOffset runTime,
+        AtomicCacheEntry cached,
+        ForecastAcquisitionSource source,
+        ForecastCacheUsage usage) =>
+        new(
+            request,
+            new ForecastRun(ForecastProvider.Ecmwf, ForecastModel.EcmwfIfs, runTime),
+            new LocalGribArtifact(cached.Path, cached.LengthBytes, cached.Metadata.CreatedAt),
+            source,
+            cached.Metadata,
+            usage);
+
+    private static bool TryReadInt64(JsonElement root, string name, out long value)
+    {
+        value = 0;
+        if (!root.TryGetProperty(name, out var element))
+        {
+            return false;
+        }
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.TryGetInt64(out value),
+            JsonValueKind.String => long.TryParse(
+                element.GetString(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out value),
+            _ => false
+        };
+    }
+
+    private async ValueTask DelayForRetryAsync(
+        Exception exception,
+        int completedAttempts,
+        CancellationToken cancellationToken)
+    {
+        var retryAfter = exception is TransientEcmwfException transient
+            ? transient.RetryAfter
+            : null;
+        var exponential = TimeSpan.FromTicks(
+            Math.Min(
+                _options.MaximumRetryDelay.Ticks,
+                _options.BaseRetryDelay.Ticks * (1L << Math.Min(completedAttempts - 1, 20))));
+        var delay = retryAfter is { } serverDelay && serverDelay > exponential
+            ? serverDelay
+            : exponential;
+        if (delay > _options.MaximumRetryDelay)
+        {
+            delay = _options.MaximumRetryDelay;
+        }
+
+        if (delay > TimeSpan.Zero)
+        {
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static Exception CreateHttpFailure(
+        string operation,
+        Uri uri,
+        HttpResponseMessage response)
+    {
+        var message =
+            $"{operation} returned {(int)response.StatusCode} ({response.ReasonPhrase}) for '{uri}'.";
+        return ForecastHttpSupport.IsTransientStatus(response.StatusCode)
+            ? new TransientEcmwfException(message, ForecastHttpSupport.GetRetryAfter(response))
+            : new ForecastDownloadException(message);
+    }
+
+    private static bool IsTransientFailure(Exception exception) =>
+        exception is HttpRequestException or HttpIOException or TransientEcmwfException ||
+        exception is OperationCanceledException;
+
+
+    private static async ValueTask CopyBoundedAsync(
+        Stream input,
+        Stream output,
+        long maximumBytes,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[128 * 1024];
+        long total = 0;
+        while (true)
+        {
+            var read = await input.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                return;
+            }
+
+            total = checked(total + read);
+            if (total > maximumBytes)
+            {
+                throw new ForecastDownloadException("ECMWF response exceeds the configured size limit.");
+            }
+
+            await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask CopyExactAsync(
+        Stream input,
+        Stream output,
+        long expectedBytes,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new byte[128 * 1024];
+        long total = 0;
+        while (total < expectedBytes)
+        {
+            var requested = (int)Math.Min(buffer.Length, expectedBytes - total);
+            var read = await input.ReadAsync(buffer.AsMemory(0, requested), cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new ForecastDownloadException(
+                    $"ECMWF range ended after {total} bytes; {expectedBytes} bytes were expected.");
+            }
+
+            await output.WriteAsync(buffer.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
+            total += read;
+        }
+
+        var extra = await input.ReadAsync(buffer.AsMemory(0, 1), cancellationToken).ConfigureAwait(false);
+        if (extra != 0)
+        {
+            throw new ForecastDownloadException("ECMWF range returned more bytes than its index length.");
+        }
+    }
+
+    private static bool IsValidPartFile(string path, long expectedLength)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        var file = new FileInfo(path);
+        if (file.Length != expectedLength || file.Length < 20)
+        {
+            return false;
+        }
+
+        Span<byte> header = stackalloc byte[16];
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        if (stream.Read(header) != header.Length ||
+            !header[..4].SequenceEqual("GRIB"u8) ||
+            header[7] != 2 ||
+            BinaryPrimitives.ReadUInt64BigEndian(header[8..]) != (ulong)expectedLength)
+        {
+            return false;
+        }
+
+        Span<byte> marker = stackalloc byte[4];
+        stream.Seek(-4, SeekOrigin.End);
+        return stream.Read(marker) == marker.Length && marker.SequenceEqual("7777"u8);
+    }
+
+    private static void SweepOrphanedPartials(string directory)
+    {
+        foreach (var path in Directory.EnumerateFiles(directory, "*.partial", SearchOption.TopDirectoryOnly))
+        {
+            TryDelete(path);
+        }
+    }
+
+    private void PrunePartCache(string directory, HashSet<string> protectedKeys)
+    {
+        var files = Directory.EnumerateFiles(directory, "*.grib2", SearchOption.TopDirectoryOnly)
+            .Select(path => new FileInfo(path))
+            .OrderBy(file => file.LastWriteTimeUtc)
+            .ToList();
+        var total = files.Sum(file => file.Length);
+        foreach (var file in files)
+        {
+            if (total <= _options.MaximumPartCacheBytes)
+            {
+                break;
+            }
+
+            var key = Path.GetFileNameWithoutExtension(file.Name);
+            if (protectedKeys.Contains(key))
+            {
+                continue;
+            }
+
+            total -= file.Length;
+            TryDelete(file.FullName);
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (FileNotFoundException)
+        {
+        }
+        catch (DirectoryNotFoundException)
+        {
+        }
+    }
+
+    private static void ValidateOptions(EcmwfOpenDataOptions options)
+    {
+        if (!options.BaseUri.IsAbsoluteUri ||
+            options.BaseUri.Scheme is not ("http" or "https"))
+        {
+            throw new ArgumentException("The ECMWF base URI must be an absolute HTTP or HTTPS URI.", nameof(options));
+        }
+
+        if (options.MaximumRunLookbackCycles <= 0 ||
+            options.MaximumIndexBytes <= 0 ||
+            options.MaximumRangeBytes <= 0 ||
+            options.MaximumPartCacheBytes <= 0 ||
+            options.MaximumDownloadAttempts <= 0 ||
+            options.BaseRetryDelay < TimeSpan.Zero ||
+            options.MaximumRetryDelay < options.BaseRetryDelay ||
+            options.MinimumRequestInterval < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "ECMWF acquisition limits are invalid.");
+        }
+    }
+
+    private void ValidateRequest(ForecastRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (request.Model != Model)
         {
             throw new ArgumentException("The ECMWF provider only supplies EcmwfIfs requests.", nameof(request));
         }
+    }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        if (!_options.Enabled)
-        {
-            throw new ExperimentalProviderDisabledException(
-                "ECMWF Open Data support is experimental and disabled. Set EcmwfOpenDataOptions.Enabled only after accepting the experimental limitation.");
-        }
+    private void Report(
+        IProgress<ForecastProgress>? progress,
+        ForecastProgressStage stage,
+        double fraction,
+        string message) =>
+        progress?.Report(new ForecastProgress(Provider, Model, stage, fraction, message));
 
-        throw new NotSupportedException(
-            "ECMWF Open Data acquisition is explicitly unsupported: indexed HTTP byte-range retrieval for both 10u and 10v has not been implemented. No artifact was created.");
+    private sealed class TransientEcmwfException(
+        string message,
+        TimeSpan? retryAfter) : IOException(message)
+    {
+        public TimeSpan? RetryAfter { get; } = retryAfter;
     }
 }

--- a/src/Navtool.Infrastructure/EcmwfOpenDataForecastProvider.cs
+++ b/src/Navtool.Infrastructure/EcmwfOpenDataForecastProvider.cs
@@ -119,6 +119,25 @@ public sealed class EcmwfOpenDataForecastProvider : IForecastProvider, IForecast
     {
         ValidateRequest(request);
         cancellationToken.ThrowIfCancellationRequested();
+        if (request.RefreshPolicy == ForecastRefreshPolicy.PreferCache)
+        {
+            var now = _timeProvider.GetUtcNow();
+            var candidates = GetCandidateRuns(now)
+                .Where(candidate => CanCover(candidate, request.From, request.Through))
+                .ToImmutableArray();
+            var cached = await TryAcquireCachedAsync(
+                    request,
+                    candidates,
+                    now,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (cached is not null)
+            {
+                return cached;
+            }
+        }
+
         using var lease = await _acquisitionGate.EnterAsync(
                 "ecmwf-open-data-service",
                 cancellationToken)
@@ -326,25 +345,16 @@ public sealed class EcmwfOpenDataForecastProvider : IForecastProvider, IForecast
 
         if (request.RefreshPolicy == ForecastRefreshPolicy.PreferCache)
         {
-            foreach (var candidate in candidates)
+            var cached = await TryAcquireCachedAsync(
+                    request,
+                    candidates,
+                    now,
+                    progress,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (cached is not null)
             {
-                var hours = GetRequiredForecastHours(candidate, request.From, request.Through);
-                var cacheKey = CreateAssemblyCacheKey(candidate, hours);
-                var cached = await _cache.TryGetAsync(cacheKey, now, cancellationToken).ConfigureAwait(false);
-                if (cached is not null)
-                {
-                    Report(progress, ForecastProgressStage.Completed, 1, "Using cached ECMWF IFS forecast");
-                    return CreateAcquisition(
-                        request,
-                        candidate,
-                        cached,
-                        ForecastAcquisitionSource.Cache,
-                        new ForecastCacheUsage(
-                            hours.Length * 2,
-                            0,
-                            candidate,
-                            candidate));
-                }
+                return cached;
             }
         }
 
@@ -481,6 +491,39 @@ public sealed class EcmwfOpenDataForecastProvider : IForecastProvider, IForecast
                 downloadedParts,
                 plan.RunTime,
                 plan.RunTime));
+    }
+
+    private async ValueTask<ForecastAcquisition?> TryAcquireCachedAsync(
+        ForecastRequest request,
+        ImmutableArray<DateTimeOffset> candidates,
+        DateTimeOffset now,
+        IProgress<ForecastProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        foreach (var candidate in candidates)
+        {
+            var hours = GetRequiredForecastHours(candidate, request.From, request.Through);
+            var cacheKey = CreateAssemblyCacheKey(candidate, hours);
+            var cached = await _cache.TryGetAsync(cacheKey, now, cancellationToken).ConfigureAwait(false);
+            if (cached is null)
+            {
+                continue;
+            }
+
+            Report(progress, ForecastProgressStage.Completed, 1, "Using cached ECMWF IFS forecast");
+            return CreateAcquisition(
+                request,
+                candidate,
+                cached,
+                ForecastAcquisitionSource.Cache,
+                new ForecastCacheUsage(
+                    hours.Length * 2,
+                    0,
+                    candidate,
+                    candidate));
+        }
+
+        return null;
     }
 
     private async ValueTask<EcmwfAcquisitionPlan?> TryBuildPlanAsync(
@@ -895,17 +938,25 @@ public sealed class EcmwfOpenDataForecastProvider : IForecastProvider, IForecast
 
         Span<byte> header = stackalloc byte[16];
         using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-        if (stream.Read(header) != header.Length ||
-            !header[..4].SequenceEqual("GRIB"u8) ||
-            header[7] != 2 ||
-            BinaryPrimitives.ReadUInt64BigEndian(header[8..]) != (ulong)expectedLength)
+        try
+        {
+            stream.ReadExactly(header);
+            if (!header[..4].SequenceEqual("GRIB"u8) ||
+                header[7] != 2 ||
+                BinaryPrimitives.ReadUInt64BigEndian(header[8..]) != (ulong)expectedLength)
+            {
+                return false;
+            }
+
+            Span<byte> marker = stackalloc byte[4];
+            stream.Seek(-4, SeekOrigin.End);
+            stream.ReadExactly(marker);
+            return marker.SequenceEqual("7777"u8);
+        }
+        catch (EndOfStreamException)
         {
             return false;
         }
-
-        Span<byte> marker = stackalloc byte[4];
-        stream.Seek(-4, SeekOrigin.End);
-        return stream.Read(marker) == marker.Length && marker.SequenceEqual("7777"u8);
     }
 
     private static void SweepOrphanedPartials(string directory)

--- a/src/Navtool.Infrastructure/ForecastHttpSupport.cs
+++ b/src/Navtool.Infrastructure/ForecastHttpSupport.cs
@@ -1,0 +1,37 @@
+using System.Net;
+
+namespace Navtool.Infrastructure;
+
+internal static class ForecastHttpSupport
+{
+    public static bool IsTransientStatus(HttpStatusCode statusCode) =>
+        statusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests ||
+        (int)statusCode is 425 or >= 300 and <= 399 or >= 500 and <= 599;
+
+    public static TimeSpan? GetRetryAfter(HttpResponseMessage response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter?.Delta is { } delta && delta >= TimeSpan.Zero)
+        {
+            return delta;
+        }
+
+        if (retryAfter?.Date is { } date)
+        {
+            var delay = date - DateTimeOffset.UtcNow;
+            return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
+        }
+
+        return null;
+    }
+
+    public static bool IsTextMediaType(string mediaType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(mediaType);
+        return mediaType.StartsWith("text/", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("html", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("json", StringComparison.OrdinalIgnoreCase) ||
+               mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Navtool.Infrastructure/KeyedAsyncGate.cs
+++ b/src/Navtool.Infrastructure/KeyedAsyncGate.cs
@@ -1,0 +1,88 @@
+namespace Navtool.Infrastructure;
+
+internal sealed class KeyedAsyncGate
+{
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+    private readonly object _sync = new();
+
+    public int ActiveKeyCount
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _entries.Count;
+            }
+        }
+    }
+
+    public async ValueTask<IDisposable> EnterAsync(
+        string key,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        Entry entry;
+        lock (_sync)
+        {
+            if (!_entries.TryGetValue(key, out entry!))
+            {
+                entry = new Entry();
+                _entries[key] = entry;
+            }
+
+            entry.ReferenceCount++;
+        }
+
+        try
+        {
+            await entry.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            return new Lease(this, key, entry);
+        }
+        catch
+        {
+            Return(key, entry, releaseSemaphore: false);
+            throw;
+        }
+    }
+
+    private void Return(string key, Entry entry, bool releaseSemaphore)
+    {
+        if (releaseSemaphore)
+        {
+            entry.Semaphore.Release();
+        }
+
+        lock (_sync)
+        {
+            entry.ReferenceCount--;
+            if (entry.ReferenceCount == 0)
+            {
+                _entries.Remove(key);
+                entry.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private sealed class Entry
+    {
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+        public int ReferenceCount { get; set; }
+    }
+
+    private sealed class Lease(
+        KeyedAsyncGate owner,
+        string key,
+        Entry entry) : IDisposable
+    {
+        private KeyedAsyncGate? _owner = owner;
+
+        public void Dispose()
+        {
+            Interlocked.Exchange(ref _owner, null)?.Return(
+                key,
+                entry,
+                releaseSemaphore: true);
+        }
+    }
+}

--- a/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
+++ b/src/Navtool.Infrastructure/NoaaGfsForecastProvider.cs
@@ -64,7 +64,7 @@ internal sealed record GribPartDescriptor(
     string PartKey,
     Uri RequestUri);
 
-public sealed class NoaaGfsForecastProvider : IForecastProvider
+public sealed class NoaaGfsForecastProvider : IForecastProvider, IForecastDownloadEstimator
 {
     private static readonly ImmutableArray<int> AvailableForecastHours = BuildAvailableHours();
     private readonly HttpClient _httpClient;
@@ -73,12 +73,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
     private readonly NoaaGfsOptions _options;
     private readonly ILogger<NoaaGfsForecastProvider> _logger;
 
-    // Ref-counted keyed gates: a gate exists only while one or more acquisitions target
-    // its cache key. The last acquisition to release the key removes and disposes the
-    // entry, so this dictionary cannot grow unbounded over a long-lived singleton session.
-    private readonly Dictionary<string, AcquisitionGate> _acquisitionGates =
-        new(StringComparer.Ordinal);
-    private readonly object _acquisitionGatesLock = new();
+    private readonly KeyedAsyncGate _acquisitionGates = new();
     private readonly Dictionary<string, int> _activePartPaths;
     private readonly object _activePartPathsLock = new();
 
@@ -107,16 +102,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
 
     // Number of live acquisition gates. Exposed for tests to assert gates are released
     // (and not leaked) once acquisitions complete.
-    internal int ActiveAcquisitionGateCount
-    {
-        get
-        {
-            lock (_acquisitionGatesLock)
-            {
-                return _acquisitionGates.Count;
-            }
-        }
-    }
+    internal int ActiveAcquisitionGateCount => _acquisitionGates.ActiveKeyCount;
 
     public NoaaGfsDownloadEstimate Estimate(ForecastRequest request)
     {
@@ -131,6 +117,17 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         var bounds = AlignBoundsToGrid(request.Bounds);
         var tiles = GetCacheTiles(bounds, _options.CacheTileSizeDegrees);
         return new NoaaGfsDownloadEstimate(runTime, bounds, steps.Length, tiles.Length);
+    }
+
+    public ForecastDownloadEstimate EstimateDownload(ForecastRequest request)
+    {
+        var estimate = Estimate(request);
+        return new ForecastDownloadEstimate(
+            Model,
+            estimate.ForecastStepCount,
+            estimate.PartCount,
+            null,
+            "NOAA downloads geographically subsetted 10 m wind fields.");
     }
 
     public async ValueTask<ForecastAcquisition> AcquireAsync(
@@ -150,62 +147,9 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         // core so the gate and the download/store always agree on the same key, even if
         // the clock advances across a run-publish boundary while queued behind the gate.
         var plan = await SelectAcquisitionPlanAsync(request, cancellationToken).ConfigureAwait(false);
-        var gate = RentGate(plan.CacheKey);
-
-        try
-        {
-            await gate.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch
-        {
-            ReturnGate(plan.CacheKey, gate);
-            throw;
-        }
-
-        try
-        {
-            return await AcquireCoreAsync(request, plan, progress, cancellationToken).ConfigureAwait(false);
-        }
-        finally
-        {
-            gate.Semaphore.Release();
-            ReturnGate(plan.CacheKey, gate);
-        }
-    }
-
-    // A single-permit gate plus the count of acquisitions currently referencing its key.
-    private sealed class AcquisitionGate
-    {
-        public SemaphoreSlim Semaphore { get; } = new(1, 1);
-
-        public int RefCount { get; set; }
-    }
-
-    private AcquisitionGate RentGate(string cacheKey)
-    {
-        lock (_acquisitionGatesLock)
-        {
-            if (!_acquisitionGates.TryGetValue(cacheKey, out var gate))
-            {
-                gate = new AcquisitionGate();
-                _acquisitionGates[cacheKey] = gate;
-            }
-
-            gate.RefCount++;
-            return gate;
-        }
-    }
-
-    private void ReturnGate(string cacheKey, AcquisitionGate gate)
-    {
-        lock (_acquisitionGatesLock)
-        {
-            if (--gate.RefCount == 0)
-            {
-                _acquisitionGates.Remove(cacheKey);
-                gate.Semaphore.Dispose();
-            }
-        }
+        using var lease = await _acquisitionGates.EnterAsync(plan.CacheKey, cancellationToken)
+            .ConfigureAwait(false);
+        return await AcquireCoreAsync(request, plan, progress, cancellationToken).ConfigureAwait(false);
     }
 
     // Resolves the definitive run selection, step set, grid-aligned bounds, and cache key
@@ -357,56 +301,44 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             var part = manifest[index];
             var partFile = Path.Combine(partsDirectory, part.PartKey + ".grib2");
 
-            var partGate = RentGate(part.PartKey);
-            var partGateAcquired = false;
-            try
+            using var partLease = await _acquisitionGates.EnterAsync(
+                    part.PartKey,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (File.Exists(partFile))
             {
-                await partGate.Semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                partGateAcquired = true;
-                if (File.Exists(partFile))
-                {
-                    File.SetLastWriteTimeUtc(partFile, now.UtcDateTime);
-                    _logger.LogInformation(
-                        "Reusing cached tile {PartIndex}/{Total} f{ForecastHour:000} tile {RegionIndex}",
-                        index + 1, totalParts, part.ForecastHour, part.RegionIndex);
-                    Report(
-                        progress,
-                        ForecastProgressStage.Downloading,
-                        (index + 1) / (double)totalParts,
-                        $"Resumed cached f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
-                    continue;
-                }
-
-                if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
-                {
-                    await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
-                }
-
-                Report(
-                    progress,
-                    ForecastProgressStage.Downloading,
-                    index / (double)totalParts,
-                    $"Downloading GFS f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
-
-                await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
-                downloadedParts++;
-                PrunePartCache(partsDirectory, manifest);
-
+                File.SetLastWriteTimeUtc(partFile, now.UtcDateTime);
+                _logger.LogInformation(
+                    "Reusing cached tile {PartIndex}/{Total} f{ForecastHour:000} tile {RegionIndex}",
+                    index + 1, totalParts, part.ForecastHour, part.RegionIndex);
                 Report(
                     progress,
                     ForecastProgressStage.Downloading,
                     (index + 1) / (double)totalParts,
-                    $"Downloaded {index + 1}/{totalParts} GFS tiles ({downloadedParts} new this run)");
+                    $"Resumed cached f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
+                continue;
             }
-            finally
-            {
-                if (partGateAcquired)
-                {
-                    partGate.Semaphore.Release();
-                }
 
-                ReturnGate(part.PartKey, partGate);
+            if (downloadedParts > 0 && _options.MinimumRequestInterval > TimeSpan.Zero)
+            {
+                await Task.Delay(_options.MinimumRequestInterval, cancellationToken).ConfigureAwait(false);
             }
+
+            Report(
+                progress,
+                ForecastProgressStage.Downloading,
+                index / (double)totalParts,
+                $"Downloading GFS f{part.ForecastHour:000} tile {index + 1}/{totalParts}");
+
+            await DownloadPartAsync(part, partFile, cancellationToken).ConfigureAwait(false);
+            downloadedParts++;
+            PrunePartCache(partsDirectory, manifest);
+
+            Report(
+                progress,
+                ForecastProgressStage.Downloading,
+                (index + 1) / (double)totalParts,
+                $"Downloaded {index + 1}/{totalParts} GFS tiles ({downloadedParts} new this run)");
         }
 
         // Concatenate all parts in manifest order into the final cached artifact.
@@ -849,11 +781,11 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
                 : $" Redirect location: '{response.Headers.Location}'.";
             var message =
                 $"NOAA NOMADS returned {(int)response.StatusCode} ({response.ReasonPhrase}) for '{uri}'.{location}";
-            if (IsTransientStatus(response.StatusCode))
+            if (ForecastHttpSupport.IsTransientStatus(response.StatusCode))
             {
                 throw new TransientForecastDownloadException(
                     message,
-                    GetRetryAfter(response));
+                    ForecastHttpSupport.GetRetryAfter(response));
             }
 
             throw new ForecastDownloadException(message);
@@ -871,11 +803,7 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
         }
 
         var mediaType = response.Content.Headers.ContentType?.MediaType;
-        if (mediaType is not null &&
-            (mediaType.StartsWith("text/", StringComparison.OrdinalIgnoreCase) ||
-             mediaType.Contains("html", StringComparison.OrdinalIgnoreCase) ||
-             mediaType.Contains("json", StringComparison.OrdinalIgnoreCase) ||
-             mediaType.Contains("xml", StringComparison.OrdinalIgnoreCase)))
+        if (mediaType is not null && ForecastHttpSupport.IsTextMediaType(mediaType))
         {
             throw new ForecastDownloadException(
                 $"NOAA NOMADS returned unexpected content type '{mediaType}' for '{uri}'.");
@@ -945,33 +873,11 @@ public sealed class NoaaGfsForecastProvider : IForecastProvider
             Math.Min(jitteredMilliseconds, _options.MaximumRetryDelay.TotalMilliseconds));
     }
 
-    private static TimeSpan? GetRetryAfter(HttpResponseMessage response)
-    {
-        var retryAfter = response.Headers.RetryAfter;
-        if (retryAfter?.Delta is { } delta && delta >= TimeSpan.Zero)
-        {
-            return delta;
-        }
-
-        if (retryAfter?.Date is { } date)
-        {
-            var delay = date - DateTimeOffset.UtcNow;
-            return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
-        }
-
-        return null;
-    }
-
     private static bool IsTransientFailure(Exception exception) =>
         exception is HttpRequestException or
             HttpIOException or
             OperationCanceledException or
             TransientForecastDownloadException;
-
-    private static bool IsTransientStatus(HttpStatusCode statusCode) =>
-        statusCode is HttpStatusCode.RequestTimeout or
-            HttpStatusCode.TooManyRequests ||
-        (int)statusCode is 425 or >= 300 and <= 399 or >= 500 and <= 599;
 
     private static void EnsureRollbackDestination(Stream destination)
     {

--- a/tests/Navtool.App.Tests/AppCompositionTests.cs
+++ b/tests/Navtool.App.Tests/AppCompositionTests.cs
@@ -44,6 +44,11 @@ public sealed class AppCompositionTests
                 services.GetRequiredService<IRoutePlanRepository>());
             Assert.Equal(Path.Combine(root, "routes"), repository.RootDirectory);
             Assert.NotNull(services.GetRequiredService<RoutePlanRoutingWorkflow>());
+            Assert.NotNull(services.GetRequiredService<EcmwfOpenDataForecastProvider>());
+            Assert.Equal(
+                [ForecastModel.NoaaGfs, ForecastModel.EcmwfIfs],
+                services.GetServices<IForecastDownloadEstimator>()
+                    .Select(estimator => estimator.Model));
             Assert.NotNull(services.GetRequiredService<MainViewModel>().Itinerary);
             var tileOptions = services.GetRequiredService<OsmTileOptions>();
             Assert.Equal(

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -61,6 +61,31 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public void Forecast_area_summary_reports_selected_provider_estimates()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            new FixedTimeProvider(Now),
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false),
+            forecastEstimators:
+            [
+                new StubForecastEstimator(ForecastModel.NoaaGfs, 4, 8),
+                new StubForecastEstimator(ForecastModel.EcmwfIfs, 3, 6)
+            ]);
+        viewModel.SetEndpoints(
+            new Coordinate(34, -64),
+            new Coordinate(39, -52));
+        viewModel.DepartureDate = Now.AddHours(1);
+        viewModel.DepartureTime = Now.AddHours(1).TimeOfDay;
+        viewModel.UseEcmwf = true;
+
+        Assert.Contains("NOAA 4 times/8 parts", viewModel.ForecastAreaSummary);
+        Assert.Contains("ECMWF 3 times/6 global wind ranges", viewModel.ForecastAreaSummary);
+    }
+
+    [Fact]
     public void LocalDepartureConversionHandlesUtcAndDstEdgeCases()
     {
         Assert.True(LocalDepartureConverter.TryConvertToUtc(
@@ -114,7 +139,7 @@ public sealed class MainViewModelWorkflowTests
         Assert.True(viewModel.HasTimeline);
         Assert.Equal(ForecastModel.NoaaGfs, viewModel.SelectedRoutePoint!.Route.Model);
         Assert.Contains("complete", viewModel.NoaaStatus, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("Experimental ECMWF failed", viewModel.ErrorMessage);
+        Assert.Contains("ECMWF IFS failed", viewModel.ErrorMessage);
         Assert.Contains("indexed ranges are unavailable", viewModel.EcmwfStatus);
     }
 
@@ -1406,6 +1431,17 @@ public sealed class MainViewModelWorkflowTests
         }
 
         Assert.True(predicate());
+    }
+
+    private sealed class StubForecastEstimator(
+        ForecastModel model,
+        int forecastStepCount,
+        int partCount) : IForecastDownloadEstimator
+    {
+        public ForecastModel Model { get; } = model;
+
+        public ForecastDownloadEstimate EstimateDownload(ForecastRequest request) =>
+            new(Model, forecastStepCount, partCount, null, string.Empty);
     }
 
     private static ForecastAcquisition CreateAcquisition(

--- a/tests/Navtool.Infrastructure.Tests/EcmwfLiveSmokeTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/EcmwfLiveSmokeTests.cs
@@ -1,0 +1,72 @@
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+public sealed class EcmwfLiveSmokeTests
+{
+    [Fact]
+    public async Task Current_open_data_can_be_downloaded_inspected_sampled_and_routed()
+    {
+        if (!string.Equals(
+                Environment.GetEnvironmentVariable("NAVTOOL_ECMWF_LIVE_SMOKE"),
+                "1",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        using var directory = new TestDirectory();
+        using var client = new HttpClient
+        {
+            Timeout = TimeSpan.FromMinutes(10)
+        };
+        var provider = new EcmwfOpenDataForecastProvider(
+            client,
+            new AtomicFileCache(new AtomicFileCacheOptions(directory.Path)));
+        var now = DateTimeOffset.UtcNow;
+        var bounds = new GeographicBounds(48, 49, -124, -122);
+        var request = new ForecastRequest(
+            ForecastModel.EcmwfIfs,
+            bounds,
+            now.AddHours(1),
+            now.AddHours(4),
+            ForecastRefreshPolicy.LatestAvailable);
+
+        var acquisition = await provider.AcquireAsync(
+            request,
+            null,
+            CancellationToken.None);
+        var bridge = new NativeRouterBridge();
+        var descriptor = bridge.InspectGrib(
+            acquisition.Artifact.Path,
+            CancellationToken.None);
+
+        Assert.Equal(NativeGribModelId.EcmwfIfs, descriptor.ModelId);
+        using var forecast = bridge.LoadForecast(
+            acquisition.Artifact.Path,
+            bounds,
+            CancellationToken.None);
+        var sampled = bridge.SampleViewport(
+            forecast,
+            bounds,
+            2,
+            2,
+            forecast.Metadata.FirstValidAt,
+            CancellationToken.None);
+        Assert.All(sampled, wind => Assert.True(wind.IsValid));
+
+        var route = bridge.CalculateRoute(
+            forecast,
+            new RouteRequest(
+                "ecmwf-live-smoke",
+                new Coordinate(48.5, -123.8),
+                new Coordinate(48.5, -123.2),
+                forecast.Metadata.FirstValidAt,
+                forecast.Metadata.LastValidAt),
+            ForecastModel.EcmwfIfs,
+            cancellationToken: CancellationToken.None);
+        Assert.NotEmpty(route.Points);
+        Assert.Equal(ForecastModel.EcmwfIfs, route.Model);
+    }
+}

--- a/tests/Navtool.Infrastructure.Tests/EcmwfOpenDataForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/EcmwfOpenDataForecastProviderTests.cs
@@ -1,3 +1,6 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Http.Headers;
 using Navtool.Core;
 using Navtool.Infrastructure;
 
@@ -5,42 +8,478 @@ namespace Navtool.Infrastructure.Tests;
 
 public sealed class EcmwfOpenDataForecastProviderTests
 {
-    [Fact]
-    public async Task Provider_is_disabled_by_default_and_never_fakes_success()
-    {
-        var provider = new EcmwfOpenDataForecastProvider();
-        var request = CreateRequest();
+    private static readonly DateTimeOffset Now =
+        new(2026, 7, 14, 20, 0, 0, TimeSpan.Zero);
+    private static readonly byte[] UWind = CreateGribMessage((byte)'u');
+    private static readonly byte[] VWind = CreateGribMessage((byte)'v');
 
-        var estimate = provider.Estimate(request);
-        Assert.Equal(ExperimentalProviderState.Disabled, provider.State);
-        Assert.False(estimate.IsSupported);
-        Assert.Contains("not yet implemented", estimate.Warning);
-        await Assert.ThrowsAsync<ExperimentalProviderDisabledException>(async () =>
-            await provider.AcquireAsync(request, null, CancellationToken.None));
+    [Fact]
+    public void Required_steps_follow_long_and_short_cycle_cadence()
+    {
+        var longRun = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+        var shortRun = new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal(
+            [144, 150],
+            EcmwfOpenDataForecastProvider.GetRequiredForecastHours(
+                longRun,
+                longRun.AddHours(144),
+                longRun.AddHours(145)).ToArray());
+        Assert.Equal(
+            [87, 90],
+            EcmwfOpenDataForecastProvider.GetRequiredForecastHours(
+                shortRun,
+                shortRun.AddHours(88),
+                shortRun.AddHours(90)).ToArray());
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            EcmwfOpenDataForecastProvider.GetRequiredForecastHours(
+                shortRun,
+                shortRun.AddHours(89),
+                shortRun.AddHours(91)));
     }
 
     [Fact]
-    public async Task Opt_in_reports_explicit_unsupported_indexed_retrieval()
+    public void Product_uri_uses_current_open_data_layout()
     {
-        var provider = new EcmwfOpenDataForecastProvider(
-            new EcmwfOpenDataOptions { Enabled = true });
+        using var directory = new TestDirectory();
+        using var client = new HttpClient(new EcmwfHandler());
+        var provider = CreateProvider(directory.Path, client);
+        var run = new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
 
-        var exception = await Assert.ThrowsAsync<NotSupportedException>(async () =>
-            await provider.AcquireAsync(CreateRequest(), null, CancellationToken.None));
+        var uri = provider.BuildProductUri(run, 24, "index");
 
-        Assert.Equal(ExperimentalProviderState.EnabledButUnsupported, provider.State);
-        Assert.Contains("byte-range", exception.Message);
-        Assert.Contains("10u", exception.Message);
-        Assert.Contains("10v", exception.Message);
+        Assert.Equal(
+            "https://example.test/forecasts/20260714/12z/ifs/0p25/oper/" +
+            "20260714120000-24h-oper-fc.index",
+            uri.AbsoluteUri);
     }
 
-    private static ForecastRequest CreateRequest()
+    [Fact]
+    public void Index_parser_selects_exact_paired_surface_wind_ranges()
     {
-        var from = new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero);
-        return new ForecastRequest(
+        var dataUri = new Uri("https://example.test/data.grib2");
+        var index =
+            $$"""
+              {"param":"2t","levtype":"sfc","_offset":0,"_length":5}
+              {"param":"10u","levtype":"sfc","_offset":5,"_length":{{UWind.Length}}}
+              {"param":"10v","levtype":"sfc","_offset":{{5 + UWind.Length}},"_length":"{{VWind.Length}}"}
+              """;
+
+        var parts = EcmwfOpenDataForecastProvider.ParseIndex(index, 3, dataUri);
+
+        Assert.Collection(
+            parts,
+            part =>
+            {
+                Assert.Equal("10u", part.Parameter);
+                Assert.Equal(5, part.Offset);
+                Assert.Equal(UWind.Length, part.Length);
+            },
+            part =>
+            {
+                Assert.Equal("10v", part.Parameter);
+                Assert.Equal(5 + UWind.Length, part.Offset);
+                Assert.Equal(VWind.Length, part.Length);
+            });
+    }
+
+    [Theory]
+    [InlineData("""{"param":"10u","levtype":"sfc","_offset":0,"_length":15}""")]
+    [InlineData(
+        """
+        {"param":"10u","levtype":"sfc","_offset":0,"_length":15}
+        {"param":"10u","levtype":"sfc","_offset":15,"_length":15}
+        {"param":"10v","levtype":"sfc","_offset":30,"_length":15}
+        """)]
+    [InlineData(
+        """
+        {"param":"10u","levtype":"sfc","_offset":0,"_length":20}
+        {"param":"10v","levtype":"sfc","_offset":10,"_length":15}
+        """)]
+    [InlineData(
+        """
+        {"param":"10u","_offset":0,"_length":20}
+        {"param":"10v","levtype":"sfc","_offset":20,"_length":20}
+        """)]
+    public void Index_parser_rejects_incomplete_duplicate_or_overlapping_ranges(string index)
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            EcmwfOpenDataForecastProvider.ParseIndex(
+                index,
+                3,
+                new Uri("https://example.test/data.grib2")));
+    }
+
+    [Fact]
+    public async Task Acquire_downloads_indexed_wind_parts_and_reuses_final_cache()
+    {
+        using var directory = new TestDirectory();
+        var handler = new EcmwfHandler();
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var request = CreateRequest(
+            new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+            TimeSpan.FromHours(3));
+        var progress = new List<ForecastProgress>();
+
+        var acquired = await provider.AcquireAsync(
+            request,
+            new InlineProgress<ForecastProgress>(progress.Add),
+            CancellationToken.None);
+        var requestsAfterDownload = handler.RequestCount;
+        var cached = await provider.AcquireAsync(request, null, CancellationToken.None);
+
+        Assert.Equal(ForecastAcquisitionSource.Remote, acquired.Source);
+        Assert.Equal(ForecastAcquisitionSource.Cache, cached.Source);
+        Assert.Equal(new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero), acquired.Run.InitializedAt);
+        Assert.Equal(4, acquired.CacheUsage!.DownloadedPartCount);
+        Assert.Equal(4, cached.CacheUsage!.ReusedPartCount);
+        Assert.Equal(requestsAfterDownload, handler.RequestCount);
+        Assert.Equal(
+            2 * (UWind.Length + VWind.Length),
+            new FileInfo(acquired.Artifact.Path).Length);
+        Assert.Equal(ForecastProgressStage.Completed, progress[^1].Stage);
+        Assert.All(handler.RangeHeaders, range => Assert.NotNull(range));
+    }
+
+    [Fact]
+    public async Task Acquire_falls_back_when_newest_covering_cycle_is_not_published()
+    {
+        using var directory = new TestDirectory();
+        var handler = new EcmwfHandler(unpublishedCycleHour: 18);
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        var request = CreateRequest(
+            new DateTimeOffset(2026, 7, 14, 19, 0, 0, TimeSpan.Zero),
+            TimeSpan.FromHours(2));
+
+        var acquired = await provider.AcquireAsync(request, null, CancellationToken.None);
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 14, 12, 0, 0, TimeSpan.Zero), acquired.Run.InitializedAt);
+        Assert.Contains(handler.Requests, uri => uri.AbsolutePath.Contains("/18z/", StringComparison.Ordinal));
+        Assert.Contains(handler.Requests, uri => uri.AbsolutePath.Contains("/12z/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_server_that_ignores_byte_range()
+    {
+        using var directory = new TestDirectory();
+        var handler = new EcmwfHandler(ignoreRanges: true);
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(
+            directory.Path,
+            client,
+            new EcmwfOpenDataOptions
+            {
+                BaseUri = new Uri("https://example.test/forecasts/"),
+                MaximumDownloadAttempts = 1,
+                MinimumRequestInterval = TimeSpan.Zero
+            });
+
+        var exception = await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await provider.AcquireAsync(
+                CreateRequest(
+                    new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+                    TimeSpan.FromHours(3)),
+                null,
+                CancellationToken.None));
+
+        Assert.Contains("206", exception.InnerException?.Message ?? exception.Message);
+        Assert.Empty(Directory.EnumerateFiles(directory.Path, "*.partial", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task Acquire_rejects_grib_with_inconsistent_declared_length()
+    {
+        using var directory = new TestDirectory();
+        var handler = new EcmwfHandler(invalidGribLength: true);
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(
+            directory.Path,
+            client,
+            new EcmwfOpenDataOptions
+            {
+                BaseUri = new Uri("https://example.test/forecasts/"),
+                MaximumDownloadAttempts = 1,
+                MinimumRequestInterval = TimeSpan.Zero
+            });
+
+        var exception = await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+            await provider.AcquireAsync(
+                CreateRequest(
+                    new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+                    TimeSpan.FromHours(3)),
+                null,
+                CancellationToken.None));
+
+        Assert.Contains("complete GRIB", exception.Message);
+        Assert.Empty(Directory.EnumerateFiles(directory.Path, "*.partial", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task Acquire_resumes_valid_parts_after_a_failed_attempt()
+    {
+        using var directory = new TestDirectory();
+        using (var failingClient = new HttpClient(new EcmwfHandler(failRangeRequest: 2)))
+        {
+            var failingProvider = CreateProvider(
+                directory.Path,
+                failingClient,
+                new EcmwfOpenDataOptions
+                {
+                    BaseUri = new Uri("https://example.test/forecasts/"),
+                    MaximumDownloadAttempts = 1,
+                    MinimumRequestInterval = TimeSpan.Zero
+                });
+            await Assert.ThrowsAsync<ForecastDownloadException>(async () =>
+                await failingProvider.AcquireAsync(
+                    CreateRequest(
+                        new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+                        TimeSpan.FromHours(3)),
+                    null,
+                    CancellationToken.None));
+        }
+
+        var resumedHandler = new EcmwfHandler();
+        using var resumedClient = new HttpClient(resumedHandler);
+        var resumedProvider = CreateProvider(directory.Path, resumedClient);
+        var acquired = await resumedProvider.AcquireAsync(
+            CreateRequest(
+                new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+                TimeSpan.FromHours(3)),
+            null,
+            CancellationToken.None);
+
+        Assert.Equal(1, acquired.CacheUsage!.ReusedPartCount);
+        Assert.Equal(3, acquired.CacheUsage.DownloadedPartCount);
+        Assert.Equal(3, resumedHandler.RangeRequestCount);
+    }
+
+    [Fact]
+    public async Task Refresh_policy_reuses_covering_cache_or_selects_newest_cycle()
+    {
+        using var directory = new TestDirectory();
+        var clock = new MutableTimeProvider(Now);
+        var handler = new EcmwfHandler();
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client, timeProvider: clock);
+        var from = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var preferCache = CreateRequest(from, TimeSpan.FromHours(3));
+
+        var initial = await provider.AcquireAsync(preferCache, null, CancellationToken.None);
+        clock.UtcNow = new DateTimeOffset(2026, 7, 15, 2, 0, 0, TimeSpan.Zero);
+        var reused = await provider.AcquireAsync(preferCache, null, CancellationToken.None);
+        var refreshed = await provider.AcquireAsync(
+            new ForecastRequest(
+                preferCache.Model,
+                preferCache.Bounds,
+                preferCache.From,
+                preferCache.Through,
+                ForecastRefreshPolicy.LatestAvailable),
+            null,
+            CancellationToken.None);
+
+        Assert.Equal(new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero), initial.Run.InitializedAt);
+        Assert.Equal(initial.Run.InitializedAt, reused.Run.InitializedAt);
+        Assert.Equal(ForecastAcquisitionSource.Cache, reused.Source);
+        Assert.Equal(new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero), refreshed.Run.InitializedAt);
+        Assert.Equal(ForecastAcquisitionSource.Remote, refreshed.Source);
+    }
+
+    [Fact]
+    public async Task Acquire_propagates_caller_cancellation_during_index_request()
+    {
+        using var directory = new TestDirectory();
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new EcmwfHandler(async (_, token) =>
+        {
+            entered.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            throw new InvalidOperationException("Unreachable.");
+        });
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client);
+        using var cancellation = new CancellationTokenSource();
+
+        var acquisition = provider.AcquireAsync(
+            CreateRequest(
+                new DateTimeOffset(2026, 7, 14, 18, 0, 0, TimeSpan.Zero),
+                TimeSpan.FromHours(3)),
+            null,
+            cancellation.Token).AsTask();
+        await entered.Task;
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => acquisition);
+    }
+
+    private static ForecastRequest CreateRequest(DateTimeOffset from, TimeSpan duration) =>
+        new(
             ForecastModel.EcmwfIfs,
             new GeographicBounds(40, 50, -70, -50),
             from,
-            from.AddHours(18));
+            from + duration);
+
+    private static byte[] CreateGribMessage(byte component)
+    {
+        var bytes = new byte[21];
+        "GRIB"u8.CopyTo(bytes);
+        bytes[7] = 2;
+        BinaryPrimitives.WriteUInt64BigEndian(bytes.AsSpan(8, 8), (ulong)bytes.Length);
+        bytes[16] = component;
+        "7777"u8.CopyTo(bytes.AsSpan(bytes.Length - 4));
+        return bytes;
+    }
+
+    private static EcmwfOpenDataForecastProvider CreateProvider(
+        string cacheRoot,
+        HttpClient client,
+        EcmwfOpenDataOptions? options = null,
+        TimeProvider? timeProvider = null) =>
+        new(
+            client,
+            new AtomicFileCache(new AtomicFileCacheOptions(cacheRoot)),
+            timeProvider ?? new FixedTimeProvider(Now),
+            options ?? new EcmwfOpenDataOptions
+            {
+                BaseUri = new Uri("https://example.test/forecasts/"),
+                BaseRetryDelay = TimeSpan.Zero,
+                MaximumRetryDelay = TimeSpan.Zero,
+                MinimumRequestInterval = TimeSpan.Zero
+            });
+
+    private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>
+    {
+        public void Report(T value) => report(value);
+    }
+
+    private sealed class EcmwfHandler : HttpMessageHandler
+    {
+        private readonly int? _unpublishedCycleHour;
+        private readonly bool _ignoreRanges;
+        private readonly int? _failRangeRequest;
+        private readonly bool _invalidGribLength;
+        private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? _override;
+        private readonly List<Uri> _requests = [];
+        private readonly List<RangeHeaderValue?> _rangeHeaders = [];
+        private readonly object _sync = new();
+        private int _requestCount;
+        private int _rangeRequestCount;
+
+        public EcmwfHandler(
+            int? unpublishedCycleHour = null,
+            bool ignoreRanges = false,
+            int? failRangeRequest = null,
+            bool invalidGribLength = false)
+        {
+            _unpublishedCycleHour = unpublishedCycleHour;
+            _ignoreRanges = ignoreRanges;
+            _failRangeRequest = failRangeRequest;
+            _invalidGribLength = invalidGribLength;
+        }
+
+        public EcmwfHandler(
+            Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> responseOverride)
+        {
+            _override = responseOverride;
+        }
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        public int RangeRequestCount => Volatile.Read(ref _rangeRequestCount);
+
+        public IReadOnlyList<Uri> Requests
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _requests.ToArray();
+                }
+            }
+        }
+
+        public IReadOnlyList<RangeHeaderValue?> RangeHeaders
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _rangeHeaders.ToArray();
+                }
+            }
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            lock (_sync)
+            {
+                _requests.Add(request.RequestUri!);
+            }
+
+            if (_override is not null)
+            {
+                return _override(request, cancellationToken);
+            }
+
+            var uri = request.RequestUri!;
+            if (_unpublishedCycleHour is { } hour &&
+                uri.AbsolutePath.Contains($"/{hour:00}z/", StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            if (uri.AbsolutePath.EndsWith(".index", StringComparison.Ordinal))
+            {
+                var content =
+                    $$"""
+                      {"param":"10u","levtype":"sfc","_offset":0,"_length":{{UWind.Length}}}
+                      {"param":"10v","levtype":"sfc","_offset":{{UWind.Length}},"_length":{{VWind.Length}}}
+                      """;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(content)
+                });
+            }
+
+            var range = request.Headers.Range;
+            var rangeRequest = Interlocked.Increment(ref _rangeRequestCount);
+            lock (_sync)
+            {
+                _rangeHeaders.Add(range);
+            }
+
+            if (_failRangeRequest == rangeRequest)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+            }
+
+            var from = range?.Ranges.Single().From;
+            var bytes = (from == 0 ? UWind : VWind).ToArray();
+            if (_invalidGribLength)
+            {
+                BinaryPrimitives.WriteUInt64BigEndian(
+                    bytes.AsSpan(8, 8),
+                    (ulong)(bytes.Length + 1));
+            }
+            var response = new HttpResponseMessage(
+                _ignoreRanges ? HttpStatusCode.OK : HttpStatusCode.PartialContent)
+            {
+                Content = new ByteArrayContent(bytes)
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+            if (!_ignoreRanges)
+            {
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                    from!.Value,
+                    from.Value + bytes.Length - 1,
+                    UWind.Length + VWind.Length);
+            }
+
+            return Task.FromResult(response);
+        }
     }
 }

--- a/tests/Navtool.Infrastructure.Tests/EcmwfOpenDataForecastProviderTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/EcmwfOpenDataForecastProviderTests.cs
@@ -287,6 +287,54 @@ public sealed class EcmwfOpenDataForecastProviderTests
     }
 
     [Fact]
+    public async Task Covering_cache_hit_is_not_blocked_by_remote_acquisition()
+    {
+        using var directory = new TestDirectory();
+        var clock = new MutableTimeProvider(Now);
+        var remoteEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRemote = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        EcmwfHandler? handler = null;
+        handler = new EcmwfHandler(async (request, token) =>
+        {
+            if (request.RequestUri!.AbsolutePath.Contains("/00z/", StringComparison.Ordinal) &&
+                request.RequestUri.AbsolutePath.EndsWith(".index", StringComparison.Ordinal))
+            {
+                remoteEntered.TrySetResult();
+                await releaseRemote.Task.WaitAsync(token);
+            }
+
+            return handler!.CreateStandardResponse(request);
+        });
+        using var client = new HttpClient(handler);
+        var provider = CreateProvider(directory.Path, client, timeProvider: clock);
+        var from = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var preferCache = CreateRequest(from, TimeSpan.FromHours(3));
+        await provider.AcquireAsync(preferCache, null, CancellationToken.None);
+        clock.UtcNow = new DateTimeOffset(2026, 7, 15, 2, 0, 0, TimeSpan.Zero);
+        var latest = new ForecastRequest(
+            preferCache.Model,
+            preferCache.Bounds,
+            preferCache.From,
+            preferCache.Through,
+            ForecastRefreshPolicy.LatestAvailable);
+
+        var remote = provider.AcquireAsync(latest, null, CancellationToken.None).AsTask();
+        await remoteEntered.Task;
+        var cached = provider.AcquireAsync(preferCache, null, CancellationToken.None).AsTask();
+        try
+        {
+            Assert.Same(cached, await Task.WhenAny(cached, Task.Delay(TimeSpan.FromSeconds(1))));
+            Assert.Equal(ForecastAcquisitionSource.Cache, (await cached).Source);
+        }
+        finally
+        {
+            releaseRemote.TrySetResult();
+        }
+
+        Assert.Equal(ForecastAcquisitionSource.Remote, (await remote).Source);
+    }
+
+    [Fact]
     public async Task Acquire_propagates_caller_cancellation_during_index_request()
     {
         using var directory = new TestDirectory();
@@ -425,11 +473,16 @@ public sealed class EcmwfOpenDataForecastProviderTests
                 return _override(request, cancellationToken);
             }
 
+            return Task.FromResult(CreateStandardResponse(request));
+        }
+
+        public HttpResponseMessage CreateStandardResponse(HttpRequestMessage request)
+        {
             var uri = request.RequestUri!;
             if (_unpublishedCycleHour is { } hour &&
                 uri.AbsolutePath.Contains($"/{hour:00}z/", StringComparison.Ordinal))
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
             }
 
             if (uri.AbsolutePath.EndsWith(".index", StringComparison.Ordinal))
@@ -439,10 +492,10 @@ public sealed class EcmwfOpenDataForecastProviderTests
                       {"param":"10u","levtype":"sfc","_offset":0,"_length":{{UWind.Length}}}
                       {"param":"10v","levtype":"sfc","_offset":{{UWind.Length}},"_length":{{VWind.Length}}}
                       """;
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(content)
-                });
+                };
             }
 
             var range = request.Headers.Range;
@@ -454,7 +507,7 @@ public sealed class EcmwfOpenDataForecastProviderTests
 
             if (_failRangeRequest == rangeRequest)
             {
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.BadRequest));
+                return new HttpResponseMessage(HttpStatusCode.BadRequest);
             }
 
             var from = range?.Ranges.Single().From;
@@ -479,7 +532,7 @@ public sealed class EcmwfOpenDataForecastProviderTests
                     UWind.Length + VWind.Length);
             }
 
-            return Task.FromResult(response);
+            return response;
         }
     }
 }


### PR DESCRIPTION
ECMWF was exposed in the UI but the official-download path was an experimental stub that always failed. This change makes deterministic ECMWF IFS wind forecasts a supported routing source alongside NOAA GFS.

## What changed

- Discover covering 00/06/12/18 UTC IFS cycles and apply their cycle-specific forecast horizons.
- Parse ECMWF JSON-lines indexes and fetch only paired surface `10u`/`10v` GRIB2 messages with strict HTTP range validation.
- Resume and reuse immutable cached parts, assemble single-run artifacts atomically, and preserve cache refresh semantics.
- Add provider-neutral download estimates plus shared HTTP policy and keyed acquisition gates without changing NOAA behavior.
- Remove the experimental opt-in and wording, then wire normal ECMWF progress, failures, routes, timelines, and weather overlays through the existing workflows.
- Add deterministic ecCodes fixtures for ECMWF inspection, bounded loading, sampling, mixed-run rejection, and native route calculation, plus an opt-in live Open Data smoke test.

## Design note

ECMWF Open Data does not offer server-side geographic cropping. This version downloads the indexed global 10 m wind messages and applies the route corridor in the native bounded loader. The larger transfer is explicit in the UI and documentation, while cached parts are reusable across routes and restarts. Wave and current routing remain out of scope.

## Validation

- 283 managed tests passed.
- Native bridge build and tests passed through `scripts/build-native.sh`.
- Live ECMWF download, inspection, bounded sampling, and route calculation passed.
- Supported application launch completed bridge preflight without `Routing engine unavailable`.