### PR TITLE
Fix themed control visibility and picker clipping

### DIFF
--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -1,5 +1,208 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Styles.Resources>
+        <SolidColorBrush x:Key="AppControlForegroundBrush"
+                         Color="{DynamicResource TextPrimaryColor}" />
+        <SolidColorBrush x:Key="AppControlSecondaryForegroundBrush"
+                         Color="{DynamicResource TextSecondaryColor}" />
+        <SolidColorBrush x:Key="AppControlMutedForegroundBrush"
+                         Color="{DynamicResource TextMutedColor}" />
+        <SolidColorBrush x:Key="AppControlBackgroundBrush"
+                         Color="{DynamicResource SurfaceRaisedColor}" />
+        <SolidColorBrush x:Key="AppControlHoverBackgroundBrush"
+                         Color="{DynamicResource ControlHoverColor}" />
+        <SolidColorBrush x:Key="AppControlPressedBackgroundBrush"
+                         Color="{DynamicResource ControlPressedColor}" />
+        <SolidColorBrush x:Key="AppControlBorderBrush"
+                         Color="{DynamicResource StrongBorderColor}" />
+        <SolidColorBrush x:Key="AppDisabledForegroundBrush"
+                         Color="{DynamicResource DisabledTextColor}" />
+        <SolidColorBrush x:Key="AppDisabledBackgroundBrush"
+                         Color="{DynamicResource DisabledBackgroundColor}" />
+        <SolidColorBrush x:Key="AppSelectedForegroundBrush"
+                         Color="{DynamicResource ActiveToolTextColor}" />
+        <SolidColorBrush x:Key="AppSelectedBackgroundBrush"
+                         Color="{DynamicResource ActiveToolBackgroundColor}" />
+        <SolidColorBrush x:Key="AppAccentForegroundBrush"
+                         Color="{DynamicResource AccentTextColor}" />
+        <SolidColorBrush x:Key="AppAccentBackgroundBrush"
+                         Color="{DynamicResource AccentColor}" />
+        <SolidColorBrush x:Key="AppAccentHoverBackgroundBrush"
+                         Color="{DynamicResource AccentHoverColor}" />
+        <SolidColorBrush x:Key="AppAccentPressedBackgroundBrush"
+                         Color="{DynamicResource AccentPressedColor}" />
+        <SolidColorBrush x:Key="AppPopupBackgroundBrush"
+                         Color="{DynamicResource SurfaceColor}" />
+
+        <x:Double x:Key="DatePickerThemeMinWidth">0</x:Double>
+        <x:Double x:Key="TimePickerThemeMinWidth">0</x:Double>
+
+        <StaticResource x:Key="ButtonForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ButtonForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ButtonForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ButtonBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="ButtonBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ButtonBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="ButtonBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ButtonBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ButtonBorderBrushPressed" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ButtonBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+
+        <StaticResource x:Key="RepeatButtonForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="RepeatButtonForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="RepeatButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="RepeatButtonForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="RepeatButtonBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="RepeatButtonBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="RepeatButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="RepeatButtonBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="RepeatButtonBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="RepeatButtonBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="RepeatButtonBorderBrushPressed" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="RepeatButtonBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+
+        <StaticResource x:Key="ToggleButtonForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundChecked" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundCheckedPointerOver" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundCheckedPressed" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundCheckedDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundIndeterminate" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundIndeterminatePointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundIndeterminatePressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonForegroundIndeterminateDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundCheckedPointerOver" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundCheckedPressed" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundCheckedDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundIndeterminate" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundIndeterminatePointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundIndeterminatePressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ToggleButtonBackgroundIndeterminateDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+
+        <StaticResource x:Key="TextControlForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="TextControlForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="TextControlForegroundFocused" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="TextControlForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="TextControlPlaceholderForeground" ResourceKey="AppControlMutedForegroundBrush" />
+        <StaticResource x:Key="TextControlPlaceholderForegroundPointerOver" ResourceKey="AppControlMutedForegroundBrush" />
+        <StaticResource x:Key="TextControlPlaceholderForegroundFocused" ResourceKey="AppControlMutedForegroundBrush" />
+        <StaticResource x:Key="TextControlPlaceholderForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="TextControlBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="TextControlBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="TextControlBackgroundFocused" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="TextControlBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="TextControlBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TextControlBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TextControlBorderBrushFocused" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TextControlBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+
+        <StaticResource x:Key="ComboBoxForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ComboBoxForegroundFocused" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxForegroundFocusedPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxPlaceHolderForeground" ResourceKey="AppControlMutedForegroundBrush" />
+        <StaticResource x:Key="ComboBoxPlaceHolderForegroundFocusedPressed" ResourceKey="AppControlMutedForegroundBrush" />
+        <StaticResource x:Key="ComboBoxDropDownGlyphForeground" ResourceKey="AppControlSecondaryForegroundBrush" />
+        <StaticResource x:Key="ComboBoxDropDownGlyphForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ComboBoxDropDownGlyphForegroundFocused" ResourceKey="AppControlSecondaryForegroundBrush" />
+        <StaticResource x:Key="ComboBoxDropDownGlyphForegroundFocusedPressed" ResourceKey="AppControlSecondaryForegroundBrush" />
+        <StaticResource x:Key="ComboBoxBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ComboBoxBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ComboBoxBorderBrushPressed" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ComboBoxBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ComboBoxDropDownBackground" ResourceKey="AppPopupBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxDropDownBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ComboBoxItemForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundSelected" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundSelectedPressed" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundSelectedPointerOver" ResourceKey="AppSelectedForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemForegroundSelectedDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ComboBoxItemBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxItemBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxItemBackgroundSelected" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxItemBackgroundSelectedPointerOver" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="ComboBoxItemBackgroundSelectedPressed" ResourceKey="AppSelectedBackgroundBrush" />
+
+        <StaticResource x:Key="DatePickerButtonForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="DatePickerButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="DatePickerButtonForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="DatePickerButtonBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="DatePickerButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="DatePickerButtonBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="DatePickerButtonBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DatePickerButtonBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DatePickerFlyoutPresenterBackground" ResourceKey="AppPopupBackgroundBrush" />
+        <StaticResource x:Key="DatePickerFlyoutPresenterBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DatePickerFlyoutPresenterHighlightFill" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="DatePickerFlyoutPresenterSpacerFill" ResourceKey="AppControlBorderBrush" />
+
+        <StaticResource x:Key="TimePickerButtonForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="TimePickerButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="TimePickerButtonForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="TimePickerButtonBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="TimePickerButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="TimePickerButtonBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="TimePickerButtonBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TimePickerButtonBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TimePickerFlyoutPresenterBackground" ResourceKey="AppPopupBackgroundBrush" />
+        <StaticResource x:Key="TimePickerFlyoutPresenterBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="TimePickerFlyoutPresenterHighlightFill" ResourceKey="AppSelectedBackgroundBrush" />
+        <StaticResource x:Key="TimePickerFlyoutPresenterSpacerFill" ResourceKey="AppControlBorderBrush" />
+
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBackground" ResourceKey="AppPopupBackgroundBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonBorderBrushPressed" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="DateTimePickerFlyoutButtonForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+
+        <StaticResource x:Key="ExpanderHeaderForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderBackground" ResourceKey="AppControlBackgroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderBackgroundDisabled" ResourceKey="AppDisabledBackgroundBrush" />
+        <StaticResource x:Key="ExpanderHeaderBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ExpanderHeaderBorderBrushPointerOver" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ExpanderHeaderBorderBrushPressed" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ExpanderHeaderBorderBrushDisabled" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="ExpanderChevronForeground" ResourceKey="AppControlSecondaryForegroundBrush" />
+        <StaticResource x:Key="ExpanderChevronForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ExpanderChevronForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ExpanderChevronForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+
+        <StaticResource x:Key="ToolTipForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="ToolTipBackground" ResourceKey="AppPopupBackgroundBrush" />
+        <StaticResource x:Key="ToolTipBorderBrush" ResourceKey="AppControlBorderBrush" />
+        <StaticResource x:Key="MenuFlyoutItemForeground" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="MenuFlyoutItemForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="MenuFlyoutItemForegroundPressed" ResourceKey="AppControlForegroundBrush" />
+        <StaticResource x:Key="MenuFlyoutItemForegroundDisabled" ResourceKey="AppDisabledForegroundBrush" />
+        <StaticResource x:Key="MenuFlyoutItemBackgroundPointerOver" ResourceKey="AppControlHoverBackgroundBrush" />
+        <StaticResource x:Key="MenuFlyoutItemBackgroundPressed" ResourceKey="AppControlPressedBackgroundBrush" />
+    </Styles.Resources>
+
     <Style Selector="Window">
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
     </Style>
@@ -66,7 +269,7 @@
     </Style>
     <Style Selector="TextBlock.telemetry-label">
         <Setter Property="Foreground" Value="{DynamicResource TextMutedColor}" />
-        <Setter Property="FontSize" Value="9" />
+        <Setter Property="FontSize" Value="10" />
         <Setter Property="FontWeight" Value="SemiBold" />
         <Setter Property="LetterSpacing" Value="0.8" />
     </Style>
@@ -77,10 +280,27 @@
     </Style>
     <Style Selector="TextBlock.telemetry-hint">
         <Setter Property="Foreground" Value="{DynamicResource TextMutedColor}" />
-        <Setter Property="FontSize" Value="9" />
+        <Setter Property="FontSize" Value="10" />
     </Style>
     <Style Selector="Button">
         <Setter Property="MinHeight" Value="44" />
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+    <Style Selector="Button:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlHoverColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="Button:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource ControlPressedColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="Button:disabled /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource DisabledTextColor}" />
     </Style>
     <Style Selector="Button.primary">
         <Setter Property="Background" Value="{DynamicResource AccentColor}" />
@@ -132,6 +352,8 @@
         <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
         <Setter Property="CaretBrush" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="SelectionBrush" Value="{DynamicResource AccentColor}" />
+        <Setter Property="SelectionForegroundBrush" Value="{DynamicResource AccentTextColor}" />
     </Style>
     <Style Selector="TextBox:disabled">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
@@ -141,6 +363,7 @@
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
         <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
     </Style>
     <Style Selector="ComboBox:disabled">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
@@ -150,6 +373,8 @@
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
         <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="MinWidth" Value="0" />
     </Style>
     <Style Selector="DatePicker:disabled">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
@@ -159,6 +384,8 @@
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
         <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="MinWidth" Value="0" />
     </Style>
     <Style Selector="TimePicker:disabled">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
@@ -168,10 +395,62 @@
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
         <Setter Property="Background" Value="{DynamicResource SurfaceRaisedColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
     </Style>
     <Style Selector="NumericUpDown:disabled">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
         <Setter Property="Background" Value="{DynamicResource DisabledBackgroundColor}" />
+    </Style>
+    <Style Selector="CheckBox">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="CheckBox:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="CheckBox:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="CheckBox:disabled /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource DisabledTextColor}" />
+    </Style>
+    <Style Selector="RadioButton">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="RadioButton:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="RadioButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="RadioButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource DisabledTextColor}" />
+    </Style>
+    <Style Selector="DatePicker /template/ Button#PART_FlyoutButton TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="DatePicker:disabled /template/ Button#PART_FlyoutButton TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+    </Style>
+    <Style Selector="TimePicker /template/ Button#PART_FlyoutButton TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="TimePicker:disabled /template/ Button#PART_FlyoutButton TextBlock">
+        <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
+    </Style>
+    <Style Selector="DatePickerPresenter, TimePickerPresenter">
+        <Setter Property="Background" Value="{DynamicResource SurfaceColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
+    </Style>
+    <Style Selector="DatePickerPresenter ListBoxItem, TimePickerPresenter ListBoxItem">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+    </Style>
+    <Style Selector="DatePickerPresenter ListBoxItem:selected /template/ ContentPresenter, TimePickerPresenter ListBoxItem:selected /template/ ContentPresenter">
+        <Setter Property="Foreground" Value="{DynamicResource ActiveToolTextColor}" />
+    </Style>
+    <Style Selector="ToolTip">
+        <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="Background" Value="{DynamicResource SurfaceColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource StrongBorderColor}" />
     </Style>
     <Style Selector="ToggleButton.map-tool">
         <Setter Property="MinHeight" Value="44" />

--- a/src/Navtool.App/Themes/Dark.axaml
+++ b/src/Navtool.App/Themes/Dark.axaml
@@ -25,7 +25,7 @@
     <Color x:Key="ControlHoverColor">#303B41</Color>
     <Color x:Key="ControlPressedColor">#3A474E</Color>
     <Color x:Key="DisabledBackgroundColor">#293137</Color>
-    <Color x:Key="DisabledTextColor">#77858B</Color>
+    <Color x:Key="DisabledTextColor">#91A0A6</Color>
     <Color x:Key="FocusColor">#63C4E6</Color>
     <Color x:Key="OverlayBackgroundColor">#F2232C32</Color>
     <Color x:Key="OverlayBorderColor">#526168</Color>

--- a/src/Navtool.App/Themes/KindOfBlue.axaml
+++ b/src/Navtool.App/Themes/KindOfBlue.axaml
@@ -25,7 +25,7 @@
     <Color x:Key="ControlHoverColor">#1A3A51</Color>
     <Color x:Key="ControlPressedColor">#244B64</Color>
     <Color x:Key="DisabledBackgroundColor">#172A38</Color>
-    <Color x:Key="DisabledTextColor">#708898</Color>
+    <Color x:Key="DisabledTextColor">#849BA8</Color>
     <Color x:Key="FocusColor">#E0C783</Color>
     <Color x:Key="OverlayBackgroundColor">#F20D2233</Color>
     <Color x:Key="OverlayBorderColor">#3F6176</Color>

--- a/src/Navtool.App/Themes/Light.axaml
+++ b/src/Navtool.App/Themes/Light.axaml
@@ -25,7 +25,7 @@
     <Color x:Key="ControlHoverColor">#EAF1F4</Color>
     <Color x:Key="ControlPressedColor">#DCE8ED</Color>
     <Color x:Key="DisabledBackgroundColor">#E7ECEF</Color>
-    <Color x:Key="DisabledTextColor">#87949B</Color>
+    <Color x:Key="DisabledTextColor">#586872</Color>
     <Color x:Key="FocusColor">#0078A8</Color>
     <Color x:Key="OverlayBackgroundColor">#F4FFFFFF</Color>
     <Color x:Key="OverlayBorderColor">#D4DEE2</Color>

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -52,12 +52,12 @@
                             </StackPanel>
                             <TextBlock Grid.Column="1"
                                       Text="NAVTOOL"
-                                      FontSize="9"
+                                      FontSize="10"
                                       FontWeight="SemiBold"
                                       Foreground="{DynamicResource TextSecondaryColor}"
                                       TextAlignment="Center"
                                       VerticalAlignment="Center"
-                                      Opacity="0.75" />
+                                      Opacity="0.9" />
                         </Grid>
 
                         <Border Classes="card">
@@ -233,8 +233,10 @@
                                 </Grid>
                                 <Grid ColumnDefinitions="*,104"
                                       ColumnSpacing="7">
-                                    <DatePicker SelectedDate="{Binding Itinerary.CurrentPositionDepartureDate}" />
-                                    <TimePicker Grid.Column="1"
+                                    <DatePicker x:Name="CurrentPositionDatePicker"
+                                                SelectedDate="{Binding Itinerary.CurrentPositionDepartureDate}" />
+                                    <TimePicker x:Name="CurrentPositionTimePicker"
+                                                Grid.Column="1"
                                                 SelectedTime="{Binding Itinerary.CurrentPositionDepartureTimeOfDay}"
                                                 ClockIdentifier="24HourClock" />
                                 </Grid>
@@ -290,13 +292,15 @@
                                     <StackPanel Spacing="4">
                                         <TextBlock Classes="field-label"
                                                    Text="Departure date" />
-                                        <DatePicker SelectedDate="{Binding DepartureDate}" />
+                                        <DatePicker x:Name="DepartureDatePicker"
+                                                    SelectedDate="{Binding DepartureDate}" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="1"
                                                 Spacing="4">
                                         <TextBlock Classes="field-label"
                                                    Text="Departure time" />
-                                        <TimePicker SelectedTime="{Binding DepartureTime}"
+                                        <TimePicker x:Name="DepartureTimePicker"
+                                                    SelectedTime="{Binding DepartureTime}"
                                                     ClockIdentifier="24HourClock" />
                                     </StackPanel>
                                 </Grid>
@@ -505,9 +509,9 @@
                                TextAlignment="Center" />
                     <TextBlock Text="WEATHER ROUTING"
                                Classes="muted"
-                               FontSize="8"
+                               FontSize="9"
                                TextAlignment="Center"
-                               Opacity="0.8" />
+                               Opacity="0.9" />
                 </StackPanel>
             </Border>
 

--- a/tests/Navtool.App.Tests/AppThemeTests.cs
+++ b/tests/Navtool.App.Tests/AppThemeTests.cs
@@ -40,11 +40,19 @@ public sealed class AppThemeTests
                 window.FindControl<ToggleButton>("SetDestinationButton"));
             var calculateButton = Assert.IsType<Button>(
                 window.FindControl<Button>("CalculateRoutesButton"));
+            var cancelButton = Assert.IsType<Button>(
+                window.FindControl<Button>("CancelButton"));
 
             Assert.Equal("Light", Assert.IsType<AppThemeOption>(selector.SelectedItem).DisplayName);
             Assert.IsAssignableFrom<ISolidColorBrush>(window.Background);
             Assert.False(viewModel.CalculateCommand.CanExecute(null));
             Assert.False(calculateButton.IsEffectivelyEnabled);
+            Assert.Equal(
+                Avalonia.Layout.HorizontalAlignment.Center,
+                cancelButton.HorizontalContentAlignment);
+            Assert.Equal(
+                Avalonia.Layout.VerticalAlignment.Center,
+                cancelButton.VerticalContentAlignment);
 
             foreach (var option in AppThemeService.AvailableThemes)
             {
@@ -97,6 +105,9 @@ public sealed class AppThemeTests
             AssertContrast("AccentTextColor", "AccentPressedColor", 4.5);
             AssertContrast("ActiveToolTextColor", "ActiveToolBackgroundColor", 4.5);
             AssertContrast("TextPrimaryColor", "SurfaceRaisedColor", 4.5);
+            AssertContrast("TextPrimaryColor", "ControlHoverColor", 4.5);
+            AssertContrast("TextPrimaryColor", "ControlPressedColor", 4.5);
+            AssertContrast("DisabledTextColor", "DisabledBackgroundColor", 4.5);
 
             foreach (var key in new[]
                      {
@@ -164,6 +175,126 @@ public sealed class AppThemeTests
                         expectedBackground,
                         Assert.IsAssignableFrom<ISolidColorBrush>(input.Background).Color);
                 });
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void FluentControlStatesUseSemanticColorsInEveryTheme()
+    {
+        var service = AppThemeService.CreateTransient();
+        service.Initialize(Application.Current!);
+        var window = new MainWindow(service)
+        {
+            DataContext = CreateViewModel()
+        };
+        var mappings = new (string ResourceKey, string ColorKey)[]
+        {
+            ("ButtonForeground", "TextPrimaryColor"),
+            ("ButtonForegroundPointerOver", "TextPrimaryColor"),
+            ("ButtonForegroundPressed", "TextPrimaryColor"),
+            ("ButtonForegroundDisabled", "DisabledTextColor"),
+            ("ButtonBackground", "SurfaceRaisedColor"),
+            ("ButtonBackgroundPointerOver", "ControlHoverColor"),
+            ("ButtonBackgroundPressed", "ControlPressedColor"),
+            ("ButtonBackgroundDisabled", "DisabledBackgroundColor"),
+            ("ToggleButtonForegroundChecked", "ActiveToolTextColor"),
+            ("ToggleButtonBackgroundChecked", "ActiveToolBackgroundColor"),
+            ("TextControlForeground", "TextPrimaryColor"),
+            ("TextControlForegroundDisabled", "DisabledTextColor"),
+            ("TextControlPlaceholderForeground", "TextMutedColor"),
+            ("ComboBoxForegroundFocused", "TextPrimaryColor"),
+            ("ComboBoxForegroundDisabled", "DisabledTextColor"),
+            ("ComboBoxItemForegroundSelected", "ActiveToolTextColor"),
+            ("ComboBoxItemBackgroundSelected", "ActiveToolBackgroundColor"),
+            ("DatePickerButtonForeground", "TextPrimaryColor"),
+            ("DatePickerButtonForegroundDisabled", "DisabledTextColor"),
+            ("TimePickerButtonForeground", "TextPrimaryColor"),
+            ("TimePickerButtonForegroundDisabled", "DisabledTextColor"),
+            ("ExpanderHeaderForeground", "TextPrimaryColor"),
+            ("ExpanderHeaderForegroundDisabled", "DisabledTextColor"),
+            ("ToolTipForeground", "TextPrimaryColor"),
+            ("ToolTipBackground", "SurfaceColor"),
+            ("MenuFlyoutItemForeground", "TextPrimaryColor"),
+            ("MenuFlyoutItemForegroundDisabled", "DisabledTextColor")
+        };
+
+        try
+        {
+            window.Show();
+
+            foreach (var option in AppThemeService.AvailableThemes)
+            {
+                service.SelectTheme(option.Theme);
+                Dispatcher.UIThread.RunJobs();
+
+                foreach (var (resourceKey, colorKey) in mappings)
+                {
+                    Assert.True(
+                        window.TryFindResource(resourceKey, out var value),
+                        $"{resourceKey} must be available in {option.DisplayName}.");
+                    Assert.Equal(
+                        FindColorResource(colorKey),
+                        Assert.IsAssignableFrom<ISolidColorBrush>(value).Color);
+                }
+            }
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void CompactPickerTemplateTextUsesSemanticColorsInEveryTheme()
+    {
+        var service = AppThemeService.CreateTransient();
+        service.Initialize(Application.Current!);
+        var window = new MainWindow(service)
+        {
+            DataContext = CreateViewModel()
+        };
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            var datePicker = Assert.IsType<DatePicker>(
+                window.FindControl<DatePicker>("DepartureDatePicker"));
+            var timePicker = Assert.IsType<TimePicker>(
+                window.FindControl<TimePicker>("DepartureTimePicker"));
+            datePicker.SelectedDate = new DateTimeOffset(
+                2026,
+                8,
+                4,
+                0,
+                0,
+                0,
+                TimeSpan.Zero);
+            timePicker.SelectedTime = new TimeSpan(8, 22, 0);
+            Dispatcher.UIThread.RunJobs();
+
+            foreach (var option in AppThemeService.AvailableThemes)
+            {
+                service.SelectTheme(option.Theme);
+                Dispatcher.UIThread.RunJobs();
+                var expectedForeground = FindColorResource("TextPrimaryColor");
+
+                AssertTemplateTextForeground(
+                    datePicker,
+                    expectedForeground,
+                    "PART_DayTextBlock",
+                    "PART_MonthTextBlock",
+                    "PART_YearTextBlock");
+                AssertTemplateTextForeground(
+                    timePicker,
+                    expectedForeground,
+                    "PART_HourTextBlock",
+                    "PART_MinuteTextBlock");
             }
         }
         finally
@@ -286,5 +417,27 @@ public sealed class AppThemeTests
             .OfType<ContentPresenter>()
             .Single(candidate => candidate.Name == "PART_ContentPresenter");
         return Assert.IsAssignableFrom<ISolidColorBrush>(presenter.Background).Color;
+    }
+
+    private static void AssertTemplateTextForeground(
+        TemplatedControl control,
+        Color expectedForeground,
+        params string[] partNames)
+    {
+        control.ApplyTemplate();
+        var textParts = control.GetVisualDescendants()
+            .OfType<TextBlock>()
+            .Where(part => partNames.Contains(part.Name))
+            .ToArray();
+
+        Assert.Equal(partNames.Length, textParts.Length);
+        Assert.All(textParts, part =>
+        {
+            Assert.True(part.IsEffectivelyVisible, $"{part.Name} must be visible.");
+            Assert.False(string.IsNullOrWhiteSpace(part.Text), $"{part.Name} must display a value.");
+            Assert.Equal(
+                expectedForeground,
+                Assert.IsAssignableFrom<ISolidColorBrush>(part.Foreground).Color);
+        });
     }
 }

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -788,6 +788,8 @@ public sealed class MainWindowLayoutTests
             .Where(part => partNames.Contains(part.Name))
             .ToArray();
 
+        Assert.True(picker.Bounds.Width > 1, $"{picker.Name} must be arranged.");
+        Assert.True(flyoutButton.Bounds.Width > 1, $"{picker.Name} flyout must be arranged.");
         Assert.True(
             flyoutButton.Bounds.Width <= picker.Bounds.Width + 0.5,
             $"{picker.Name} flyout content must not exceed its allocated width.");

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -693,6 +693,46 @@ public sealed class MainWindowLayoutTests
     }
 
     [AvaloniaFact]
+    public void CompactPickersKeepEveryValueSegmentInsideTheDrawerFields()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            var datePicker = Assert.IsType<DatePicker>(
+                window.FindControl<DatePicker>("DepartureDatePicker"));
+            var timePicker = Assert.IsType<TimePicker>(
+                window.FindControl<TimePicker>("DepartureTimePicker"));
+            datePicker.SelectedDate = new DateTimeOffset(
+                2026,
+                8,
+                4,
+                0,
+                0,
+                0,
+                TimeSpan.Zero);
+            timePicker.SelectedTime = new TimeSpan(8, 22, 0);
+            Dispatcher.UIThread.RunJobs();
+
+            AssertPickerFits(
+                datePicker,
+                "PART_DayTextBlock",
+                "PART_MonthTextBlock",
+                "PART_YearTextBlock");
+            AssertPickerFits(
+                timePicker,
+                "PART_HourTextBlock",
+                "PART_MinuteTextBlock");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void FieldLayoutsExposeLabelsAndAlignedActionRows()
     {
         var window = CreateWindow();
@@ -731,6 +771,38 @@ public sealed class MainWindowLayoutTests
 
     private static MainWindow CreateWindow() =>
         new() { DataContext = CreateViewModel() };
+
+    private static void AssertPickerFits(
+        TemplatedControl picker,
+        params string[] partNames)
+    {
+        picker.ApplyTemplate();
+        var descendants = picker.GetVisualDescendants().ToArray();
+        var flyoutButton = descendants
+            .OfType<Button>()
+            .Single(control => control.Name == "PART_FlyoutButton");
+        var textParts = descendants
+            .OfType<TextBlock>()
+            .Where(part => partNames.Contains(part.Name))
+            .ToArray();
+
+        Assert.True(
+            flyoutButton.Bounds.Width <= picker.Bounds.Width + 0.5,
+            $"{picker.Name} flyout content must not exceed its allocated width.");
+        Assert.Equal(partNames.Length, textParts.Length);
+
+        foreach (var part in textParts)
+        {
+            Assert.True(part.IsEffectivelyVisible, $"{part.Name} must be visible.");
+            Assert.False(string.IsNullOrWhiteSpace(part.Text), $"{part.Name} must display a value.");
+            var origin = part.TranslatePoint(default, flyoutButton);
+            Assert.NotNull(origin);
+            Assert.True(origin.Value.X >= -0.5, $"{part.Name} must start inside the picker.");
+            Assert.True(
+                origin.Value.X + part.Bounds.Width <= flyoutButton.Bounds.Width + 0.5,
+                $"{part.Name} must end inside the picker.");
+        }
+    }
 
     private static RouteMapSelection CreateRouteSelection(Coordinate coordinate)
     {

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -696,6 +696,8 @@ public sealed class MainWindowLayoutTests
     public void CompactPickersKeepEveryValueSegmentInsideTheDrawerFields()
     {
         var window = CreateWindow();
+        window.Width = 1040;
+        window.Height = 680;
 
         try
         {


### PR DESCRIPTION
The custom palettes styled outer controls, but Avalonia Fluent template parts and interaction states could still resolve to unrelated defaults. Date and time pickers also retained large template minimum widths, clipping most value segments inside the planning drawer.

## Summary

- Map Fluent control foregrounds, backgrounds, popup surfaces, and normal/hover/pressed/disabled/selected states to the app's semantic theme colors.
- Improve disabled-text contrast and readability of small overlay labels across Light, Dark, and Kind of Blue.
- Remove the picker template minimum-width constraint so complete date/time values fit in compact drawer fields.
- Center standard button content, including Cancel, while preserving explicit stretch layouts such as telemetry cards.
- Add regression coverage for palette contrast, rendered picker text, Fluent state resources, and picker bounds.

## Validation

- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj`
- Visual review through `./scripts/run.sh` in all three themes, including the time-picker flyout and Cancel alignment.
- Native bridge preflight completed successfully without a routing-engine-unavailable state.