### PR TITLE
Support router-lib v0.4 routing features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ bridge launch guidance and automated validation.
   together, selected from the list or map, and inspected on a route-wide
   active-model timeline with explicit stopover holds.
   ([#43](https://github.com/frye/navtool/pull/43))
+- **Router-lib v0.4 routing:** Standard routes now use destination/VMG heading
+  augmentation, midpoint wind sampling, and monotone-cubic polar interpolation
+  by default. A temporary professional panel exposes the time-dependent lattice
+  solver and advanced routing controls.
 
 ### Added
 
@@ -51,6 +55,9 @@ bridge launch guidance and automated validation.
 
 ### Improved
 
+- Added ABI-v6 solver-aware progress, lattice search markers and diagnostics,
+  configured beam/lattice dispatch, and schema-v3 result attribution while
+  preserving legacy bridge exports and route-plan migration.
 - Restored one open, destination-facing isochrone front per routing step,
   retained forecast-limited estimates, softened display-only corners, widened
   the useful destination aperture, and suppressed misleading singleton marks.
@@ -94,6 +101,9 @@ bridge launch guidance and automated validation.
   safety limits.
 - Online ECMWF support is wind-only. Routing still does not model waves or
   currents, and ECMWF global field downloads can be larger than NOAA subsets.
+- Professional lattice routing is serial and does not produce beam-style
+  isochrones or destination fronts; Navtool displays its search point and
+  provisional route instead.
 
 ## Week of July 13-17, 2026 (Draft)
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,16 @@ It targets macOS, Windows, and Linux.
   acquired, up to the ten-day planning limit.
 - Download NOAA GFS or ECMWF IFS 0.25-degree 10 m wind fields, or choose an
   existing GRIB through the operating system's native file picker.
-- Calculate routes through the native `router-lib` bridge.
+- Calculate routes through the native `router-lib` v0.4 bridge with enhanced
+  beam-routing accuracy enabled by default.
 - Apply bundled Natural Earth land geometry by default, with an optional
   higher-detail OSM-derived service override.
 - Watch historical destination-facing isochrone fronts, the emphasized latest
   front, and the closest provisional route stream onto the map while each model
   calculates.
+- Temporarily enable professional routing controls to select the deterministic
+  time-dependent lattice solver and tune maneuver, wind, polar, pruning, front,
+  and lattice-search behavior.
 - Compare NOAA GFS and ECMWF IFS routes with distinct map colors.
 - Render every saved successful itinerary leg together on one full-route map,
   including sailed history, while retaining waypoint guides for blocked,
@@ -114,6 +118,23 @@ cmake --build native/Navtool.RouterBridge/build --config Release --parallel
 `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` can also be overridden if you need to
 fetch releases from a different fork.
 
+## Routing profiles
+
+Standard calculations use Navtool's balanced isochrone-beam profile. It augments
+the normal heading set with destination-bearing and velocity-made-good headings,
+samples wind at segment midpoints, and uses monotone-cubic polar-angle
+interpolation. It intentionally adds no tack or gybe delay, no hard maximum-wind
+cutoff, and clamps wind above the polar's tabulated range.
+
+Enable **Professional routing features** in the planning drawer to reveal the
+temporary router-lib v0.4 controls. Professional mode can select either the
+isochrone beam or deterministic time-dependent lattice solver and configure
+maneuver penalties, heading augmentation, wind sampling, polar interpolation,
+wind limits, pruning, and solver-specific settings. The toggle and edited values
+reset when Navtool exits and are never stored as application preferences or route
+plan inputs. Completed results do retain solver attribution and lattice
+diagnostics.
+
 ## Multi-point routes and visualization
 
 Each forecast model calculates itinerary legs sequentially. A successful leg's
@@ -140,14 +161,15 @@ calculation generations cannot replace newer itinerary state.
 
 ## Streaming route visualization
 
-Navtool uses router-lib's `Router::optimize_view` progress contract. After each
-completed search step, the native bridge synchronously copies the
-callback-scoped reachability contours, destination-facing front, provisional
-route, and cumulative diagnostics into immutable managed data. The callback
-returns promptly; Mapsui updates are posted through the application's progress
-pipeline to the Avalonia UI context.
+Navtool uses router-lib's `Router::optimize_view` progress contract. The native
+bridge synchronously copies callback-scoped progress into immutable managed data.
+Beam progress contains reachability contours, the destination-facing front, the
+provisional route, and cumulative diagnostics. Lattice progress instead contains
+the provisional route, current search point, settled/queued/relaxed label counts,
+and refinement state. The callback returns promptly; Mapsui updates are posted
+through the application's progress pipeline to the Avalonia UI context.
 
-At every routing time step, Navtool accumulates the router-provided open,
+For beam routing, Navtool accumulates the router-provided open,
 destination-facing front as thin, translucent historical context. The front
 uses a 120-degree aperture on each side of the destination bearing to preserve
 useful port and starboard context without drawing the backward envelope.
@@ -159,22 +181,22 @@ and exclude internal search clusters. The model's provisional route is also
 replaced by the latest snapshot. Successful and forecast-limited search overlays
 remain visible with the final route. Failed model overlays and all
 cancelled-calculation overlays are cleared. Fronts, routes, and map-fit bounds
-are unwrapped safely at the antimeridian.
+are unwrapped safely at the antimeridian. Lattice routing does not synthesize
+isochrones or destination fronts that router-lib does not provide; it renders the
+search-point marker and latest provisional route instead.
 
 When forecast coverage ends before the destination is reached, Navtool promotes
 the final provisional route to a selectable forecast-limited estimate, retains
-the accumulated isochrone fronts and latest isochrone front, and
-displays an amber warning. Complete final routes remain authoritative and may
-differ from the last provisional route.
+the solver-appropriate search overlay, and displays an amber warning. Complete
+final routes remain authoritative and may differ from the last provisional route.
 
-The ABI-v5 bridge preserves the existing final-route and v1-v4 streaming
-functions. The v4 entry point adds pre-retention segment eligibility to the v3
-destination-front stream. The v5 entry point combines optional segment
-eligibility with display-contour topology and open destination-front segments
-in one snapshot. Callback array and coordinate pointers are valid only for the
-duration of the synchronous callback and must be copied by consumers. Navtool
-rejects stale bridges so missing contour or land-constraint support cannot
-silently degrade display or routing safety.
+The ABI-v6 bridge preserves the existing final-route and v1-v5 streaming
+functions. The v6 entry point adds fixed-layout routing options, solver identity,
+search points, and lattice counters while retaining optional pre-retention
+segment eligibility. Callback array and coordinate pointers are valid only for
+the duration of the synchronous callback and must be copied by consumers.
+Navtool rejects stale bridges so missing configuration or land-constraint
+support cannot silently degrade routing safety.
 
 ## Publish
 
@@ -212,9 +234,11 @@ also be installed or packaged according to the target platform.
 The selected display theme is stored in `preferences/theme.txt` beneath
 `NAVTOOL_APP_DATA_ROOT` (or Navtool's default local application-data directory).
 Route plans are stored atomically as JSON beneath `routes/` in the same root.
-Plan files contain waypoint, stopover, calculation-session, leg-outcome, sailed
-state, and route-point metadata, but never forecast binaries. Files from unknown
-future schemas or with inconsistent IDs/references are rejected visibly.
+Schema-v3 plan files contain waypoint, stopover, calculation-session, leg-outcome,
+sailed state, route-point metadata, solver attribution, and optional lattice
+diagnostics, but never forecast binaries or professional input settings. Schema
+v1 and v2 documents migrate forward; unknown future schemas or inconsistent
+IDs/references are rejected visibly.
 Opening a saved plan restores full-route geometry, sailed history, per-model leg
 status, and the model-specific timeline. Weather overlays are not restored from
 route JSON.
@@ -297,8 +321,8 @@ service must be suitable for production use and return OSM-derived data under
 the Open Database License; public Overpass endpoints are not used as a default.
 
 Land avoidance also requires router-lib's pre-retention segment-eligibility
-capability. Navtool's ABI-v5 bridge preserves the v1-v4 route entry points and
-exposes combined contour streaming and segment eligibility additively. When land
+capability. Navtool's ABI-v6 bridge preserves the v1-v5 route entry points and
+adds configured beam and lattice dispatch. When land
 geometry is available, every candidate segment is checked before router-lib
 retains it. A configured service failure marks the route as unchecked rather
 than silently falling back to less detailed geometry. Direct lower-level bridge
@@ -316,6 +340,11 @@ recent, small, generalized, or inaccurately mapped hazards and must be verified
 independently. The routing engine does not model currents, waves, traffic,
 restricted areas, depths, or safety limits. The built-in vessel polar is an
 approximate demonstration model.
+
+The professional lattice solver reports search points and counters, not
+isochrones or destination-front geometry. It is currently serial and intended
+for expert comparison rather than as a faster replacement for the default beam
+solver.
 
 Multi-point results depend on the forecast available when each leg was
 calculated. A sailed line is historical planning context, not a recorded vessel

--- a/native/Navtool.RouterBridge/include/navtool_router_bridge.h
+++ b/native/Navtool.RouterBridge/include/navtool_router_bridge.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-#define NAVTOOL_ROUTER_BRIDGE_ABI_VERSION 5u
+#define NAVTOOL_ROUTER_BRIDGE_ABI_VERSION 6u
 
 enum {
     NAVTOOL_ROUTER_CAPABILITY_LAND_SEGMENT_CONSTRAINT_V1 = 1ull << 0
@@ -184,6 +184,77 @@ typedef void (*navtool_router_progress_callback_v5)(
     const navtool_router_progress_v5* progress,
     void* user_data);
 
+enum {
+    NAVTOOL_ROUTER_SOLVER_ISOCHRONE_BEAM_V6 = 0,
+    NAVTOOL_ROUTER_SOLVER_TIME_DEPENDENT_LATTICE_V6 = 1
+};
+
+typedef struct navtool_router_options_v6 {
+    int32_t solver;
+    int32_t heading_augmentation;
+    int32_t wind_sampling;
+    int32_t polar_angle_interpolation;
+    int32_t above_polar_range;
+    int32_t pruning_strategy;
+    int32_t destination_front_segment_policy;
+    int32_t lattice_search_algorithm;
+    int64_t tack_penalty_seconds;
+    int64_t gybe_penalty_seconds;
+    int64_t midpoint_wind_sampling_threshold_minutes;
+    int64_t lattice_time_bucket_minutes;
+    double downwind_true_wind_angle_degrees;
+    double maximum_true_wind_speed_knots;
+    double pruning_sector_degrees;
+    double destination_front_half_angle_degrees;
+    double lattice_corridor_width_nautical_miles;
+    uint64_t destination_front_minimum_secondary_segment_points;
+    uint64_t lattice_subdivision_level;
+    uint64_t lattice_refinement_levels;
+    uint64_t lattice_corridor_widening_retries;
+    uint64_t lattice_progress_every_n_expansions;
+    uint64_t flags;
+} navtool_router_options_v6;
+
+enum {
+    NAVTOOL_ROUTER_OPTIONS_HAS_MAXIMUM_TRUE_WIND_SPEED_V6 = 1ull << 0
+};
+
+typedef struct navtool_router_lattice_search_progress_v6 {
+    uint64_t settled_labels;
+    uint64_t queued_labels;
+    uint64_t relaxed_labels;
+    uint64_t refinement_index;
+    uint64_t subdivision_level;
+} navtool_router_lattice_search_progress_v6;
+
+typedef struct navtool_router_progress_v6 {
+    int32_t solver;
+    int32_t reserved;
+    int64_t progress_utc_epoch_seconds;
+    const navtool_router_coordinate_v1* contour_points;
+    uint64_t contour_point_count;
+    const navtool_router_contour_segment_v2* contour_segments;
+    uint64_t contour_segment_count;
+    const navtool_router_coordinate_v1* front_points;
+    uint64_t front_point_count;
+    const navtool_router_front_segment_v3* front_segments;
+    uint64_t front_segment_count;
+    const navtool_router_coordinate_v1* search_points;
+    uint64_t search_point_count;
+    const navtool_router_route_point_v1* provisional_route_points;
+    uint64_t provisional_route_point_count;
+    navtool_router_diagnostics_v1 diagnostics;
+    navtool_router_lattice_search_progress_v6 lattice_search;
+} navtool_router_progress_v6;
+
+/*
+ * Return nonzero to continue routing or zero to cancel. All views remain
+ * callback-scoped.
+ */
+typedef uint8_t (*navtool_router_progress_callback_v6)(
+    const navtool_router_progress_v6* progress,
+    void* user_data);
+
 NAVTOOL_ROUTER_BRIDGE_API uint32_t
 navtool_router_bridge_abi_version_v1(void);
 
@@ -304,6 +375,27 @@ navtool_router_calculate_route_streaming_v5(
     double destination_longitude_degrees,
     const int64_t* departure_utc_epoch_seconds,
     navtool_router_progress_callback_v5 on_progress,
+    void* progress_user_data,
+    navtool_router_segment_eligibility_callback_v1 is_segment_eligible,
+    void* segment_eligibility_user_data,
+    char** out_route_json_utf8,
+    size_t* out_route_json_length);
+
+/*
+ * Configuration-driven router-lib v0.4 entry point. Beam progress includes
+ * contours/fronts; lattice progress includes search points instead. Views are
+ * synchronous and callback-scoped.
+ */
+NAVTOOL_ROUTER_BRIDGE_API navtool_router_status_v1
+navtool_router_calculate_route_streaming_v6(
+    const navtool_router_forecast_v1* forecast,
+    double start_latitude_degrees,
+    double start_longitude_degrees,
+    double destination_latitude_degrees,
+    double destination_longitude_degrees,
+    const int64_t* departure_utc_epoch_seconds,
+    const navtool_router_options_v6* options,
+    navtool_router_progress_callback_v6 on_progress,
     void* progress_user_data,
     navtool_router_segment_eligibility_callback_v1 is_segment_eligible,
     void* segment_eligibility_user_data,

--- a/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
+++ b/native/Navtool.RouterBridge/src/navtool_router_bridge.cpp
@@ -224,6 +224,102 @@ navtool_router_diagnostics_v1 copy_diagnostics(
         static_cast<uint64_t>(diagnostics.time_steps)};
 }
 
+bool valid_v6_enum(int32_t value, int32_t maximum) noexcept {
+    return value >= 0 && value <= maximum;
+}
+
+bool fits_size_t(uint64_t value) noexcept {
+    return value <= static_cast<uint64_t>(
+        std::numeric_limits<std::size_t>::max());
+}
+
+navtool_router_status_v1 apply_options_v6(
+    const navtool_router_options_v6& source,
+    sailroute::RoutingOptions& target) {
+    if (!valid_v6_enum(source.solver, 1) ||
+        !valid_v6_enum(source.heading_augmentation, 3) ||
+        !valid_v6_enum(source.wind_sampling, 1) ||
+        !valid_v6_enum(source.polar_angle_interpolation, 1) ||
+        !valid_v6_enum(source.above_polar_range, 1) ||
+        !valid_v6_enum(source.pruning_strategy, 1) ||
+        !valid_v6_enum(source.destination_front_segment_policy, 1) ||
+        !valid_v6_enum(source.lattice_search_algorithm, 1) ||
+        (source.flags &
+         ~static_cast<uint64_t>(
+             NAVTOOL_ROUTER_OPTIONS_HAS_MAXIMUM_TRUE_WIND_SPEED_V6)) != 0ULL) {
+        return fail(
+            NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "routing options contain an unsupported enum or flag value");
+    }
+    if (!fits_size_t(
+            source.destination_front_minimum_secondary_segment_points) ||
+        !fits_size_t(source.lattice_subdivision_level) ||
+        !fits_size_t(source.lattice_refinement_levels) ||
+        !fits_size_t(source.lattice_corridor_widening_retries) ||
+        !fits_size_t(source.lattice_progress_every_n_expansions)) {
+        return fail(
+            NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "routing options exceed this platform's size limits");
+    }
+
+    target.solver = static_cast<sailroute::RoutingSolver>(source.solver);
+    target.maneuver.tack_penalty =
+        std::chrono::seconds{source.tack_penalty_seconds};
+    target.maneuver.gybe_penalty =
+        std::chrono::seconds{source.gybe_penalty_seconds};
+    target.maneuver.downwind_true_wind_angle_degrees =
+        source.downwind_true_wind_angle_degrees;
+    target.heading_augmentation =
+        static_cast<sailroute::HeadingAugmentation>(
+            source.heading_augmentation);
+    target.wind_sampling =
+        static_cast<sailroute::WindSampling>(source.wind_sampling);
+    target.midpoint_wind_sampling_threshold =
+        std::chrono::minutes{
+            source.midpoint_wind_sampling_threshold_minutes};
+    target.polar_angle_interpolation =
+        static_cast<sailroute::PolarAngleInterpolation>(
+            source.polar_angle_interpolation);
+    target.maximum_true_wind_speed_knots =
+        (source.flags &
+         NAVTOOL_ROUTER_OPTIONS_HAS_MAXIMUM_TRUE_WIND_SPEED_V6) != 0U
+            ? std::optional<double>{source.maximum_true_wind_speed_knots}
+            : std::nullopt;
+    target.above_polar_range =
+        static_cast<sailroute::AbovePolarRangePolicy>(
+            source.above_polar_range);
+    target.pruning_strategy =
+        static_cast<sailroute::PruningStrategy>(source.pruning_strategy);
+    target.pruning_sector_degrees = source.pruning_sector_degrees;
+    target.progress.destination_front.half_angle_degrees =
+        source.destination_front_half_angle_degrees;
+    target.progress.destination_front.segment_policy =
+        static_cast<sailroute::DestinationFrontSegmentPolicy>(
+            source.destination_front_segment_policy);
+    target.progress.destination_front.minimum_secondary_segment_points =
+        static_cast<std::size_t>(
+            source.destination_front_minimum_secondary_segment_points);
+    target.lattice.subdivision_level =
+        static_cast<std::size_t>(source.lattice_subdivision_level);
+    target.lattice.time_bucket =
+        std::chrono::minutes{source.lattice_time_bucket_minutes};
+    target.lattice.refinement_levels =
+        static_cast<std::size_t>(source.lattice_refinement_levels);
+    target.lattice.corridor_width_nautical_miles =
+        source.lattice_corridor_width_nautical_miles;
+    target.lattice.corridor_widening_retries =
+        static_cast<std::size_t>(
+            source.lattice_corridor_widening_retries);
+    target.lattice.progress_every_n_expansions =
+        static_cast<std::size_t>(
+            source.lattice_progress_every_n_expansions);
+    target.lattice.search_algorithm =
+        static_cast<sailroute::LatticeSearchAlgorithm>(
+            source.lattice_search_algorithm);
+    return static_cast<navtool_router_status_v1>(
+        NAVTOOL_ROUTER_STATUS_OK_V1);
+}
+
 navtool_router_status_v1 calculate_route(
     const navtool_router_forecast_v1* forecast,
     double start_latitude_degrees,
@@ -531,10 +627,12 @@ navtool_router_status_v1 calculate_route_with_display(
     double destination_latitude_degrees,
     double destination_longitude_degrees,
     const int64_t* departure_utc_epoch_seconds,
-    navtool_router_progress_callback_v5 on_progress,
+    navtool_router_progress_callback_v5 on_progress_v5,
+    navtool_router_progress_callback_v6 on_progress_v6,
     void* progress_user_data,
     navtool_router_segment_eligibility_callback_v1 is_segment_eligible,
     void* segment_eligibility_user_data,
+    const navtool_router_options_v6* bridge_options,
     char** out_route_json_utf8,
     size_t* out_route_json_length) {
     if (out_route_json_utf8 != nullptr) {
@@ -566,12 +664,25 @@ navtool_router_status_v1 calculate_route_with_display(
     if (departure_utc_epoch_seconds != nullptr) {
         request.departure_time = from_epoch(*departure_utc_epoch_seconds);
     }
+    if (bridge_options != nullptr) {
+        const auto status = apply_options_v6(
+            *bridge_options,
+            request.options);
+        if (status != NAVTOOL_ROUTER_STATUS_OK_V1) {
+            return status;
+        }
+    } else {
+        request.options.progress.destination_front.half_angle_degrees =
+            destination_front_half_angle_degrees;
+    }
     request.options.progress.payload =
-        sailroute::RoutingProgressPayload::display_contours |
-        sailroute::RoutingProgressPayload::destination_front |
-        sailroute::RoutingProgressPayload::provisional_route;
-    request.options.progress.destination_front.half_angle_degrees =
-        destination_front_half_angle_degrees;
+        request.options.solver ==
+            sailroute::RoutingSolver::time_dependent_lattice
+        ? sailroute::RoutingProgressPayload::search_points |
+            sailroute::RoutingProgressPayload::provisional_route
+        : sailroute::RoutingProgressPayload::display_contours |
+            sailroute::RoutingProgressPayload::destination_front |
+            sailroute::RoutingProgressPayload::provisional_route;
     if (is_segment_eligible != nullptr) {
         request.options.segment_eligibility =
             [is_segment_eligible, segment_eligibility_user_data](
@@ -586,10 +697,10 @@ navtool_router_status_v1 calculate_route_with_display(
             };
     }
 
-    sailroute::RoutingProgressViewCallback progress_callback;
-    if (on_progress != nullptr) {
+    sailroute::RoutingViewControlCallback progress_callback;
+    if (on_progress_v5 != nullptr || on_progress_v6 != nullptr) {
         progress_callback =
-            [on_progress, progress_user_data](
+            [on_progress_v5, on_progress_v6, progress_user_data](
                 const sailroute::RoutingProgressView& progress) {
                 std::vector<navtool_router_coordinate_v1> contour_points;
                 contour_points.reserve(progress.display_contours.points.size());
@@ -634,20 +745,65 @@ navtool_router_status_v1 calculate_route_with_display(
                     route_points.push_back(copy_route_point(point));
                 }
 
-                const navtool_router_progress_v5 bridge_progress{
-                    to_epoch(progress.time),
-                    contour_points.data(),
-                    static_cast<uint64_t>(contour_points.size()),
-                    contour_segments.data(),
-                    static_cast<uint64_t>(contour_segments.size()),
-                    front_points.data(),
-                    static_cast<uint64_t>(front_points.size()),
-                    front_segments.data(),
-                    static_cast<uint64_t>(front_segments.size()),
-                    route_points.data(),
-                    static_cast<uint64_t>(route_points.size()),
-                    copy_diagnostics(progress.diagnostics)};
-                on_progress(&bridge_progress, progress_user_data);
+                if (on_progress_v5 != nullptr) {
+                    const navtool_router_progress_v5 bridge_progress{
+                        to_epoch(progress.time),
+                        contour_points.data(),
+                        static_cast<uint64_t>(contour_points.size()),
+                        contour_segments.data(),
+                        static_cast<uint64_t>(contour_segments.size()),
+                        front_points.data(),
+                        static_cast<uint64_t>(front_points.size()),
+                        front_segments.data(),
+                        static_cast<uint64_t>(front_segments.size()),
+                        route_points.data(),
+                        static_cast<uint64_t>(route_points.size()),
+                        copy_diagnostics(progress.diagnostics)};
+                    on_progress_v5(&bridge_progress, progress_user_data);
+                }
+
+                if (on_progress_v6 != nullptr) {
+                    std::vector<navtool_router_coordinate_v1> search_points;
+                    search_points.reserve(progress.search_points.size());
+                    for (const sailroute::Coordinate point :
+                         progress.search_points) {
+                        search_points.push_back(copy_coordinate(point));
+                    }
+                    const navtool_router_progress_v6 bridge_progress{
+                        static_cast<int32_t>(progress.solver),
+                        0,
+                        to_epoch(progress.time),
+                        contour_points.data(),
+                        static_cast<uint64_t>(contour_points.size()),
+                        contour_segments.data(),
+                        static_cast<uint64_t>(contour_segments.size()),
+                        front_points.data(),
+                        static_cast<uint64_t>(front_points.size()),
+                        front_segments.data(),
+                        static_cast<uint64_t>(front_segments.size()),
+                        search_points.data(),
+                        static_cast<uint64_t>(search_points.size()),
+                        route_points.data(),
+                        static_cast<uint64_t>(route_points.size()),
+                        copy_diagnostics(progress.diagnostics),
+                        {
+                            static_cast<uint64_t>(
+                                progress.search.settled_labels),
+                            static_cast<uint64_t>(
+                                progress.search.queued_labels),
+                            static_cast<uint64_t>(
+                                progress.search.relaxed_labels),
+                            static_cast<uint64_t>(
+                                progress.search.refinement_index),
+                            static_cast<uint64_t>(
+                                progress.search.subdivision_level)}};
+                    if (on_progress_v6(
+                            &bridge_progress,
+                            progress_user_data) == 0U) {
+                        return sailroute::RoutingProgressDecision::cancel;
+                    }
+                }
+                return sailroute::RoutingProgressDecision::continue_routing;
             };
     }
 
@@ -1134,9 +1290,49 @@ navtool_router_status_v1 navtool_router_calculate_route_streaming_v5(
             destination_longitude_degrees,
             departure_utc_epoch_seconds,
             on_progress,
+            nullptr,
             progress_user_data,
             is_segment_eligible,
             segment_eligibility_user_data,
+            nullptr,
+            out_route_json_utf8,
+            out_route_json_length);
+    });
+}
+
+navtool_router_status_v1 navtool_router_calculate_route_streaming_v6(
+    const navtool_router_forecast_v1* forecast,
+    double start_latitude_degrees,
+    double start_longitude_degrees,
+    double destination_latitude_degrees,
+    double destination_longitude_degrees,
+    const int64_t* departure_utc_epoch_seconds,
+    const navtool_router_options_v6* options,
+    navtool_router_progress_callback_v6 on_progress,
+    void* progress_user_data,
+    navtool_router_segment_eligibility_callback_v1 is_segment_eligible,
+    void* segment_eligibility_user_data,
+    char** out_route_json_utf8,
+    size_t* out_route_json_length) {
+    return protect([&] {
+        if (options == nullptr) {
+            return fail(
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+                "routing options must not be null");
+        }
+        return calculate_route_with_display(
+            forecast,
+            start_latitude_degrees,
+            start_longitude_degrees,
+            destination_latitude_degrees,
+            destination_longitude_degrees,
+            departure_utc_epoch_seconds,
+            nullptr,
+            on_progress,
+            progress_user_data,
+            is_segment_eligible,
+            segment_eligibility_user_data,
+            options,
             out_route_json_utf8,
             out_route_json_length);
     });

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -16,6 +16,8 @@
 
 namespace {
 
+static_assert(sizeof(navtool_router_options_v6) == 152U);
+
 void require(bool condition, const char* message) {
     if (!condition) {
         throw std::runtime_error(message);
@@ -63,6 +65,14 @@ struct DisplayProgressCapture {
     int64_t previous_time{};
     uint64_t previous_time_steps{};
     bool valid{true};
+};
+
+struct V6ProgressCapture {
+    int32_t expected_solver{};
+    size_t count{};
+    bool valid{true};
+    bool saw_search_points{};
+    bool saw_lattice_counters{};
 };
 
 struct SegmentEligibilityCapture {
@@ -275,6 +285,87 @@ void capture_display_progress(
     capture->previous_time = progress->isochrone_utc_epoch_seconds;
     capture->previous_time_steps = progress->diagnostics.time_steps;
     ++capture->count;
+}
+
+uint8_t capture_v6_progress(
+    const navtool_router_progress_v6* progress,
+    void* user_data) {
+    auto* capture = static_cast<V6ProgressCapture*>(user_data);
+    if (capture == nullptr || progress == nullptr) {
+        return 0U;
+    }
+
+    const bool is_lattice =
+        capture->expected_solver ==
+        NAVTOOL_ROUTER_SOLVER_TIME_DEPENDENT_LATTICE_V6;
+    capture->saw_search_points =
+        capture->saw_search_points || progress->search_point_count > 0U;
+    capture->saw_lattice_counters =
+        capture->saw_lattice_counters ||
+        progress->lattice_search.settled_labels > 0U;
+    const int64_t route_end_time =
+        progress->provisional_route_point_count > 0U
+        ? progress->provisional_route_points[
+              progress->provisional_route_point_count - 1U]
+              .utc_epoch_seconds
+        : 0;
+    capture->valid =
+        capture->valid &&
+        progress->solver == capture->expected_solver &&
+        progress->provisional_route_points != nullptr &&
+        progress->provisional_route_point_count > 0U &&
+        (is_lattice
+             ? route_end_time <= progress->progress_utc_epoch_seconds
+             : route_end_time == progress->progress_utc_epoch_seconds) &&
+        (is_lattice
+             ? progress->contour_point_count == 0U &&
+                   progress->front_point_count == 0U &&
+                   (progress->search_point_count == 0U ||
+                    progress->search_points != nullptr)
+             : progress->contour_points != nullptr &&
+                   progress->contour_point_count > 0U &&
+                   progress->front_points != nullptr &&
+                   progress->front_point_count > 0U &&
+                   progress->search_point_count == 0U);
+    ++capture->count;
+    return 1U;
+}
+
+uint8_t cancel_v6_progress(
+    const navtool_router_progress_v6*,
+    void* user_data) {
+    auto* count = static_cast<size_t*>(user_data);
+    if (count != nullptr) {
+        ++*count;
+    }
+    return 0U;
+}
+
+navtool_router_options_v6 balanced_options_v6() {
+    return {
+        NAVTOOL_ROUTER_SOLVER_ISOCHRONE_BEAM_V6,
+        3,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        30,
+        150.0,
+        0.0,
+        2.0,
+        120.0,
+        450.0,
+        3,
+        4,
+        1,
+        2,
+        250,
+        0};
 }
 
 std::filesystem::path create_grib_with_missing_v_step() {
@@ -790,6 +881,136 @@ int main() {
             route_json_length == std::strlen(route_json),
             "combined display streaming route JSON length mismatch");
         navtool_router_bridge_free_v1(route_json);
+
+        route_json = nullptr;
+        route_json_length = 0U;
+        auto balanced_options = balanced_options_v6();
+        V6ProgressCapture beam_v6_capture{
+            NAVTOOL_ROUTER_SOLVER_ISOCHRONE_BEAM_V6};
+        require_ok(
+            navtool_router_calculate_route_streaming_v6(
+                forecast,
+                48.25,
+                -123.65,
+                48.25,
+                -123.35,
+                &departure,
+                &balanced_options,
+                capture_v6_progress,
+                &beam_v6_capture,
+                nullptr,
+                nullptr,
+                &route_json,
+                &route_json_length),
+            "calculate configured beam route");
+        require(
+            beam_v6_capture.count > 0U && beam_v6_capture.valid,
+            "configured beam progress was invalid");
+        require(
+            route_json != nullptr && route_json_length == std::strlen(route_json),
+            "configured beam route JSON was invalid");
+        require(
+            std::string{route_json}.find("\"latticeDiagnostics\"") ==
+                std::string::npos,
+            "beam route unexpectedly included lattice diagnostics");
+        navtool_router_bridge_free_v1(route_json);
+
+        route_json = nullptr;
+        route_json_length = 0U;
+        auto invalid_options = balanced_options;
+        invalid_options.flags = 1ULL << 63;
+        require(
+            navtool_router_calculate_route_streaming_v6(
+                forecast,
+                48.25,
+                -123.65,
+                48.25,
+                -123.35,
+                &departure,
+                &invalid_options,
+                nullptr,
+                nullptr,
+                nullptr,
+                nullptr,
+                &route_json,
+                &route_json_length) ==
+                NAVTOOL_ROUTER_STATUS_INVALID_ARGUMENT_V1,
+            "unsupported routing option flags were accepted");
+        require(
+            route_json == nullptr && route_json_length == 0U,
+            "invalid routing options populated route outputs");
+
+        auto lattice_options = balanced_options;
+        lattice_options.solver =
+            NAVTOOL_ROUTER_SOLVER_TIME_DEPENDENT_LATTICE_V6;
+        lattice_options.lattice_subdivision_level = 8U;
+        lattice_options.lattice_refinement_levels = 0U;
+        lattice_options.lattice_progress_every_n_expansions = 1U;
+        V6ProgressCapture lattice_v6_capture{
+            NAVTOOL_ROUTER_SOLVER_TIME_DEPENDENT_LATTICE_V6};
+        require_ok(
+            navtool_router_calculate_route_streaming_v6(
+                forecast,
+                48.0,
+                -123.75,
+                48.5,
+                -123.25,
+                &departure,
+                &lattice_options,
+                capture_v6_progress,
+                &lattice_v6_capture,
+                nullptr,
+                nullptr,
+                &route_json,
+                &route_json_length),
+            "calculate configured lattice route");
+        require(
+            lattice_v6_capture.count > 0U,
+            "configured lattice reported no progress");
+        require(
+            lattice_v6_capture.valid,
+            "configured lattice progress payload was invalid");
+        require(
+            lattice_v6_capture.saw_search_points,
+            "configured lattice reported no search points");
+        require(
+            lattice_v6_capture.saw_lattice_counters,
+            "configured lattice reported no settled labels");
+        require(
+            route_json != nullptr && route_json_length == std::strlen(route_json),
+            "configured lattice route JSON was invalid");
+        require(
+            std::string{route_json}.find("\"latticeDiagnostics\"") !=
+                std::string::npos,
+            "lattice route omitted lattice diagnostics");
+        navtool_router_bridge_free_v1(route_json);
+        route_json = nullptr;
+        route_json_length = 0U;
+
+        size_t cancellation_progress_count = 0U;
+        require(
+            navtool_router_calculate_route_streaming_v6(
+                forecast,
+                48.0,
+                -123.75,
+                48.5,
+                -123.25,
+                &departure,
+                &lattice_options,
+                cancel_v6_progress,
+                &cancellation_progress_count,
+                nullptr,
+                nullptr,
+                &route_json,
+                &route_json_length) ==
+                NAVTOOL_ROUTER_STATUS_NO_ROUTE_V1,
+            "cancelled lattice route did not stop");
+        require(
+            cancellation_progress_count == 1U,
+            "cancelled lattice route continued reporting progress");
+        require(
+            route_json == nullptr && route_json_length == 0U,
+            "cancelled lattice route populated route outputs");
 
 #if NAVTOOL_ROUTER_HAS_PROGRESS_CALLBACK
         route_json = nullptr;

--- a/src/Navtool.App/Services/DeferredNativeRouteEngine.cs
+++ b/src/Navtool.App/Services/DeferredNativeRouteEngine.cs
@@ -79,6 +79,19 @@ public sealed class DeferredNativeRouteEngine : IRouteEngine, IWeatherSampler, I
         CancellationToken cancellationToken) =>
         _engine.Value.CalculateAsync(request, forecast, progress, cancellationToken);
 
+    public ValueTask<RouteResult> CalculateAsync(
+        RouteRequest request,
+        ForecastAcquisition forecast,
+        RouteOptimizationOptions optimization,
+        IProgress<RouteCalculationProgress>? progress,
+        CancellationToken cancellationToken) =>
+        _engine.Value.CalculateAsync(
+            request,
+            forecast,
+            optimization,
+            progress,
+            cancellationToken);
+
     public ValueTask<ImmutableArray<ViewportWindSample>> SampleViewportAsync(
         ForecastAcquisition forecast,
         GeographicBounds bounds,

--- a/src/Navtool.App/Services/RouteMapLayers.cs
+++ b/src/Navtool.App/Services/RouteMapLayers.cs
@@ -48,6 +48,8 @@ public sealed class RouteMapLayers
     private readonly MemoryLayer _ecmwfHistoricalFronts = CreateHistoricalFrontLayer("ECMWF IFS isochrone fronts");
     private readonly MemoryLayer _noaaDestinationFront = CreateDestinationFrontLayer("NOAA GFS latest isochrone front");
     private readonly MemoryLayer _ecmwfDestinationFront = CreateDestinationFrontLayer("ECMWF IFS latest isochrone front");
+    private readonly MemoryLayer _noaaSearchPoints = CreateRouteLayer("NOAA GFS lattice search");
+    private readonly MemoryLayer _ecmwfSearchPoints = CreateRouteLayer("ECMWF IFS lattice search");
     private readonly MemoryLayer _noaaProvisionalRoute = CreateProvisionalRouteLayer(
         "NOAA GFS provisional route",
         NoaaColor);
@@ -83,6 +85,8 @@ public sealed class RouteMapLayers
         map.Layers.Add(_ecmwfHistoricalFronts);
         map.Layers.Add(_noaaDestinationFront);
         map.Layers.Add(_ecmwfDestinationFront);
+        map.Layers.Add(_noaaSearchPoints);
+        map.Layers.Add(_ecmwfSearchPoints);
         map.Layers.Add(_noaaProvisionalRoute);
         map.Layers.Add(_ecmwfProvisionalRoute);
         map.Layers.Add(_noaaRoutes);
@@ -121,6 +125,9 @@ public sealed class RouteMapLayers
 
     public bool HasProvisionalRoute(ForecastModel model) =>
         GetProvisionalRouteLayer(model).Features.Any();
+
+    public bool HasSearchPoint(ForecastModel model) =>
+        GetSearchPointLayer(model).Features.Any();
 
     public void SetRoutes(IEnumerable<RouteResult> routes)
     {
@@ -267,6 +274,12 @@ public sealed class RouteMapLayers
         var destinationFrontLayer = GetDestinationFrontLayer(model);
         destinationFrontLayer.Features = frontFeatures;
         destinationFrontLayer.FeaturesWereModified();
+
+        var searchPointLayer = GetSearchPointLayer(model);
+        searchPointLayer.Features = snapshot.SearchPoints
+            .Select(point => CreateSearchPoint(point, model, snapshot))
+            .ToArray();
+        searchPointLayer.FeaturesWereModified();
 
         var provisionalLayer = GetProvisionalRouteLayer(model);
         var provisionalRoute = CreateRouteFeature(snapshot.ProvisionalRoute, snapshot);
@@ -658,6 +671,13 @@ public sealed class RouteMapLayers
         _ => throw new ArgumentOutOfRangeException(nameof(model))
     };
 
+    private MemoryLayer GetSearchPointLayer(ForecastModel model) => model switch
+    {
+        ForecastModel.NoaaGfs => _noaaSearchPoints,
+        ForecastModel.EcmwfIfs => _ecmwfSearchPoints,
+        _ => throw new ArgumentOutOfRangeException(nameof(model))
+    };
+
     private void ClearCalculationOverlay(ForecastModel model, bool refresh)
     {
         var features = GetHistoricalFrontFeatures(model);
@@ -668,6 +688,9 @@ public sealed class RouteMapLayers
         var destinationFrontLayer = GetDestinationFrontLayer(model);
         destinationFrontLayer.Features = Array.Empty<IFeature>();
         destinationFrontLayer.FeaturesWereModified();
+        var searchPointLayer = GetSearchPointLayer(model);
+        searchPointLayer.Features = Array.Empty<IFeature>();
+        searchPointLayer.FeaturesWereModified();
         var provisionalLayer = GetProvisionalRouteLayer(model);
         provisionalLayer.Features = Array.Empty<IFeature>();
         provisionalLayer.FeaturesWereModified();
@@ -675,6 +698,25 @@ public sealed class RouteMapLayers
         {
             Map.Refresh(ChangeType.Discrete);
         }
+    }
+
+    private static IFeature CreateSearchPoint(
+        CoreCoordinate coordinate,
+        ForecastModel model,
+        RouteCalculationSnapshot snapshot)
+    {
+        var point = MapProjection.ToMapPoint(coordinate);
+        var feature = new GeometryFeature(new Point(point.X, point.Y))
+        {
+            Data = snapshot
+        };
+        feature.Styles.Add(new LabelStyle
+        {
+            Text = "●",
+            Font = new Font { Size = 18, Bold = true },
+            ForeColor = model == ForecastModel.NoaaGfs ? NoaaColor : EcmwfColor
+        });
+        return feature;
     }
 
     private static IFeature CreateWindCell(

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -89,6 +89,88 @@ public partial class MainViewModel : ViewModelBase
     private int _passageHours;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsProfessionalBeamRouting))]
+    [NotifyPropertyChangedFor(nameof(IsProfessionalLatticeRouting))]
+    private bool _enableProfessionalRouting;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsProfessionalBeamRouting))]
+    [NotifyPropertyChangedFor(nameof(IsProfessionalLatticeRouting))]
+    private RouteSolver _selectedRouteSolver = RouteSolver.IsochroneBeam;
+
+    [ObservableProperty]
+    private int _tackPenaltySeconds;
+
+    [ObservableProperty]
+    private int _gybePenaltySeconds;
+
+    [ObservableProperty]
+    private double _downwindTrueWindAngleDegrees = 150;
+
+    [ObservableProperty]
+    private RouteHeadingAugmentation _headingAugmentation =
+        RouteHeadingAugmentation.DestinationBearingAndVelocityMadeGood;
+
+    [ObservableProperty]
+    private RouteWindSampling _windSampling = RouteWindSampling.Midpoint;
+
+    [ObservableProperty]
+    private int _midpointWindSamplingThresholdMinutes;
+
+    [ObservableProperty]
+    private RoutePolarAngleInterpolation _polarAngleInterpolation =
+        RoutePolarAngleInterpolation.MonotoneCubic;
+
+    [ObservableProperty]
+    private bool _useMaximumTrueWindSpeed;
+
+    [ObservableProperty]
+    private double _maximumTrueWindSpeedKnots = 45;
+
+    [ObservableProperty]
+    private RouteAbovePolarRangePolicy _abovePolarRange =
+        RouteAbovePolarRangePolicy.Clamp;
+
+    [ObservableProperty]
+    private RoutePruningStrategy _pruningStrategy =
+        RoutePruningStrategy.DestinationDistanceGrid;
+
+    [ObservableProperty]
+    private double _pruningSectorDegrees = 2;
+
+    [ObservableProperty]
+    private double _destinationFrontHalfAngleDegrees = 120;
+
+    [ObservableProperty]
+    private RouteDestinationFrontSegmentPolicy _destinationFrontSegmentPolicy =
+        RouteDestinationFrontSegmentPolicy.ProvisionalComponent;
+
+    [ObservableProperty]
+    private int _destinationFrontMinimumSecondarySegmentPoints = 3;
+
+    [ObservableProperty]
+    private int _latticeSubdivisionLevel = 4;
+
+    [ObservableProperty]
+    private int _latticeTimeBucketMinutes = 30;
+
+    [ObservableProperty]
+    private int _latticeRefinementLevels = 1;
+
+    [ObservableProperty]
+    private double _latticeCorridorWidthNauticalMiles = 450;
+
+    [ObservableProperty]
+    private int _latticeCorridorWideningRetries = 2;
+
+    [ObservableProperty]
+    private int _latticeProgressEveryExpansions = 250;
+
+    [ObservableProperty]
+    private RouteLatticeSearchAlgorithm _latticeSearchAlgorithm =
+        RouteLatticeSearchAlgorithm.AStar;
+
+    [ObservableProperty]
     private ForecastInputMode _forecastInputMode;
 
     [ObservableProperty]
@@ -380,6 +462,38 @@ public partial class MainViewModel : ViewModelBase
     public bool IsDownloadForecast => ForecastInputMode == ForecastInputMode.Download;
 
     public bool IsLocalForecast => ForecastInputMode == ForecastInputMode.LocalFile;
+
+    public bool IsProfessionalBeamRouting =>
+        EnableProfessionalRouting &&
+        SelectedRouteSolver == RouteSolver.IsochroneBeam;
+
+    public bool IsProfessionalLatticeRouting =>
+        EnableProfessionalRouting &&
+        SelectedRouteSolver == RouteSolver.TimeDependentLattice;
+
+    public IReadOnlyList<RouteSolver> RouteSolverOptions { get; } =
+        Enum.GetValues<RouteSolver>();
+
+    public IReadOnlyList<RouteHeadingAugmentation> HeadingAugmentationOptions { get; } =
+        Enum.GetValues<RouteHeadingAugmentation>();
+
+    public IReadOnlyList<RouteWindSampling> WindSamplingOptions { get; } =
+        Enum.GetValues<RouteWindSampling>();
+
+    public IReadOnlyList<RoutePolarAngleInterpolation> PolarInterpolationOptions { get; } =
+        Enum.GetValues<RoutePolarAngleInterpolation>();
+
+    public IReadOnlyList<RouteAbovePolarRangePolicy> AbovePolarRangeOptions { get; } =
+        Enum.GetValues<RouteAbovePolarRangePolicy>();
+
+    public IReadOnlyList<RoutePruningStrategy> PruningStrategyOptions { get; } =
+        Enum.GetValues<RoutePruningStrategy>();
+
+    public IReadOnlyList<RouteDestinationFrontSegmentPolicy> DestinationFrontPolicyOptions { get; } =
+        Enum.GetValues<RouteDestinationFrontSegmentPolicy>();
+
+    public IReadOnlyList<RouteLatticeSearchAlgorithm> LatticeSearchAlgorithmOptions { get; } =
+        Enum.GetValues<RouteLatticeSearchAlgorithm>();
 
     public bool IsSettingStart => InteractionMode == MapInteractionMode.SetStart;
 
@@ -842,7 +956,8 @@ public partial class MainViewModel : ViewModelBase
                 request.Route.DepartureTime,
                 request.Route.LatestArrivalTime,
                 request.Selections,
-                request.RefreshPolicy);
+                request.RefreshPolicy,
+                request.Optimization);
         }
 
         var generation = Interlocked.Increment(ref _calculationGeneration);
@@ -1526,15 +1641,71 @@ public partial class MainViewModel : ViewModelBase
             return false;
         }
 
+        if (!TryBuildOptimizationOptions(out var optimization, out error))
+        {
+            return false;
+        }
+
         request = new RoutingWorkflowRequest(
             route,
             selections,
             ForecastCorridor.Create(route.Origin, route.Destination),
             UseNewestWeatherData
                 ? ForecastRefreshPolicy.LatestAvailable
-                : ForecastRefreshPolicy.PreferCache);
+                : ForecastRefreshPolicy.PreferCache,
+            optimization);
         error = null;
         return true;
+    }
+
+    private bool TryBuildOptimizationOptions(
+        out RouteOptimizationOptions optimization,
+        [NotNullWhen(false)] out string? error)
+    {
+        if (!EnableProfessionalRouting)
+        {
+            optimization = RouteOptimizationOptions.Balanced;
+            error = null;
+            return true;
+        }
+
+        try
+        {
+            optimization = new RouteOptimizationOptions(
+                SelectedRouteSolver,
+                new RouteManeuverOptions(
+                    TimeSpan.FromSeconds(TackPenaltySeconds),
+                    TimeSpan.FromSeconds(GybePenaltySeconds),
+                    DownwindTrueWindAngleDegrees),
+                HeadingAugmentation,
+                WindSampling,
+                TimeSpan.FromMinutes(MidpointWindSamplingThresholdMinutes),
+                PolarAngleInterpolation,
+                UseMaximumTrueWindSpeed ? MaximumTrueWindSpeedKnots : null,
+                AbovePolarRange,
+                PruningStrategy,
+                PruningSectorDegrees,
+                new RouteDestinationFrontOptions(
+                    DestinationFrontHalfAngleDegrees,
+                    DestinationFrontSegmentPolicy,
+                    DestinationFrontMinimumSecondarySegmentPoints),
+                new RouteLatticeOptions(
+                    LatticeSubdivisionLevel,
+                    TimeSpan.FromMinutes(LatticeTimeBucketMinutes),
+                    LatticeRefinementLevels,
+                    LatticeCorridorWidthNauticalMiles,
+                    LatticeCorridorWideningRetries,
+                    LatticeProgressEveryExpansions,
+                    LatticeSearchAlgorithm));
+            error = null;
+            return true;
+        }
+        catch (ArgumentException exception)
+        {
+            optimization = RouteOptimizationOptions.Balanced;
+            error = $"Professional routing settings are invalid: {exception.Message}";
+            return false;
+        }
     }
 
     private void ApplyWorkflowResult(

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -215,6 +215,129 @@
                         <Border Classes="card">
                             <StackPanel Spacing="8">
                                 <TextBlock Classes="section-title"
+                                           Text="ROUTING ENGINE" />
+                                <CheckBox x:Name="ProfessionalRoutingToggle"
+                                          Content="Professional routing features"
+                                          IsChecked="{Binding EnableProfessionalRouting}"
+                                          IsEnabled="{Binding !IsCalculating}" />
+                                <TextBlock Classes="muted"
+                                           Text="Off uses Navtool's balanced beam profile: destination and VMG headings, midpoint wind, and monotone-cubic polar interpolation."
+                                           TextWrapping="Wrap" />
+                                <StackPanel IsVisible="{Binding EnableProfessionalRouting}"
+                                            IsEnabled="{Binding !IsCalculating}"
+                                            Spacing="8">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label" Text="Solver" />
+                                        <ComboBox x:Name="RouteSolverSelector"
+                                                  ItemsSource="{Binding RouteSolverOptions}"
+                                                  SelectedItem="{Binding SelectedRouteSolver}" />
+                                    </StackPanel>
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Tack penalty (s)" />
+                                            <NumericUpDown Minimum="0" Maximum="3600"
+                                                           Value="{Binding TackPenaltySeconds}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Gybe penalty (s)" />
+                                            <NumericUpDown Minimum="0" Maximum="3600"
+                                                           Value="{Binding GybePenaltySeconds}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label" Text="Downwind threshold (° TWA)" />
+                                        <NumericUpDown Minimum="0" Maximum="180" Increment="1"
+                                                       Value="{Binding DownwindTrueWindAngleDegrees}" />
+                                    </StackPanel>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label" Text="Heading augmentation" />
+                                        <ComboBox ItemsSource="{Binding HeadingAugmentationOptions}"
+                                                  SelectedItem="{Binding HeadingAugmentation}" />
+                                    </StackPanel>
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Wind sampling" />
+                                            <ComboBox ItemsSource="{Binding WindSamplingOptions}"
+                                                      SelectedItem="{Binding WindSampling}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Midpoint threshold (min)" />
+                                            <NumericUpDown Minimum="0" Maximum="1440"
+                                                           Value="{Binding MidpointWindSamplingThresholdMinutes}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label" Text="Polar interpolation" />
+                                        <ComboBox ItemsSource="{Binding PolarInterpolationOptions}"
+                                                  SelectedItem="{Binding PolarAngleInterpolation}" />
+                                    </StackPanel>
+                                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                                        <CheckBox Content="Maximum wind (kt)"
+                                                  IsChecked="{Binding UseMaximumTrueWindSpeed}" />
+                                        <NumericUpDown Grid.Column="1" Minimum="1" Maximum="200"
+                                                       IsEnabled="{Binding UseMaximumTrueWindSpeed}"
+                                                       Value="{Binding MaximumTrueWindSpeedKnots}" />
+                                    </Grid>
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="field-label" Text="Above polar range" />
+                                        <ComboBox ItemsSource="{Binding AbovePolarRangeOptions}"
+                                                  SelectedItem="{Binding AbovePolarRange}" />
+                                    </StackPanel>
+                                    <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Pruning" />
+                                            <ComboBox ItemsSource="{Binding PruningStrategyOptions}"
+                                                      SelectedItem="{Binding PruningStrategy}" />
+                                        </StackPanel>
+                                        <StackPanel Grid.Column="1" Spacing="4">
+                                            <TextBlock Classes="field-label" Text="Sector width (°)" />
+                                            <NumericUpDown Minimum="0.1" Maximum="180" Increment="0.5"
+                                                           Value="{Binding PruningSectorDegrees}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <StackPanel IsVisible="{Binding IsProfessionalBeamRouting}"
+                                                Spacing="8">
+                                        <TextBlock Classes="field-label" Text="Destination front" />
+                                        <ComboBox ItemsSource="{Binding DestinationFrontPolicyOptions}"
+                                                  SelectedItem="{Binding DestinationFrontSegmentPolicy}" />
+                                        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <NumericUpDown Minimum="1" Maximum="180"
+                                                           Value="{Binding DestinationFrontHalfAngleDegrees}" />
+                                            <NumericUpDown Grid.Column="1" Minimum="1" Maximum="1000"
+                                                           Value="{Binding DestinationFrontMinimumSecondarySegmentPoints}" />
+                                        </Grid>
+                                    </StackPanel>
+                                    <StackPanel IsVisible="{Binding IsProfessionalLatticeRouting}"
+                                                Spacing="8">
+                                        <TextBlock Classes="field-label" Text="Lattice search" />
+                                        <ComboBox ItemsSource="{Binding LatticeSearchAlgorithmOptions}"
+                                                  SelectedItem="{Binding LatticeSearchAlgorithm}" />
+                                        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <NumericUpDown Minimum="0" Maximum="8"
+                                                           Value="{Binding LatticeSubdivisionLevel}" />
+                                            <NumericUpDown Grid.Column="1" Minimum="0" Maximum="8"
+                                                           Value="{Binding LatticeRefinementLevels}" />
+                                        </Grid>
+                                        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <NumericUpDown Minimum="1" Maximum="1440"
+                                                           Value="{Binding LatticeTimeBucketMinutes}" />
+                                            <NumericUpDown Grid.Column="1" Minimum="1" Maximum="5000"
+                                                           Value="{Binding LatticeCorridorWidthNauticalMiles}" />
+                                        </Grid>
+                                        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <NumericUpDown Minimum="0" Maximum="20"
+                                                           Value="{Binding LatticeCorridorWideningRetries}" />
+                                            <NumericUpDown Grid.Column="1" Minimum="1" Maximum="1000000"
+                                                           Value="{Binding LatticeProgressEveryExpansions}" />
+                                        </Grid>
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Classes="card">
+                            <StackPanel Spacing="8">
+                                <TextBlock Classes="section-title"
                                            Text="CURRENT POSITION &amp; PROGRESS" />
                                 <TextBlock Classes="muted"
                                            Text="Mark completed legs as sailed, choose the active leg to resume from, and place the vessel's current position for a mid-leg reroute."

--- a/src/Navtool.Core/RouteOptimizationOptions.cs
+++ b/src/Navtool.Core/RouteOptimizationOptions.cs
@@ -1,0 +1,312 @@
+namespace Navtool.Core;
+
+public enum RouteSolver
+{
+    IsochroneBeam,
+    TimeDependentLattice
+}
+
+public enum RouteHeadingAugmentation
+{
+    None,
+    DestinationBearing,
+    VelocityMadeGood,
+    DestinationBearingAndVelocityMadeGood
+}
+
+public enum RouteWindSampling
+{
+    SegmentStart,
+    Midpoint
+}
+
+public enum RoutePolarAngleInterpolation
+{
+    Linear,
+    MonotoneCubic
+}
+
+public enum RouteAbovePolarRangePolicy
+{
+    Clamp,
+    NoSpeed
+}
+
+public enum RoutePruningStrategy
+{
+    DestinationDistanceGrid,
+    BearingSectors
+}
+
+public enum RouteDestinationFrontSegmentPolicy
+{
+    ProvisionalComponent,
+    AllMeaningfulComponents
+}
+
+public enum RouteLatticeSearchAlgorithm
+{
+    AStar,
+    Dijkstra
+}
+
+public sealed record RouteManeuverOptions
+{
+    public RouteManeuverOptions(
+        TimeSpan tackPenalty,
+        TimeSpan gybePenalty,
+        double downwindTrueWindAngleDegrees = 150)
+    {
+        if (tackPenalty < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tackPenalty));
+        }
+
+        if (gybePenalty < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(gybePenalty));
+        }
+
+        if (!double.IsFinite(downwindTrueWindAngleDegrees) ||
+            downwindTrueWindAngleDegrees is < 0 or > 180)
+        {
+            throw new ArgumentOutOfRangeException(nameof(downwindTrueWindAngleDegrees));
+        }
+
+        TackPenalty = tackPenalty;
+        GybePenalty = gybePenalty;
+        DownwindTrueWindAngleDegrees = downwindTrueWindAngleDegrees;
+    }
+
+    public TimeSpan TackPenalty { get; }
+
+    public TimeSpan GybePenalty { get; }
+
+    public double DownwindTrueWindAngleDegrees { get; }
+
+    public static RouteManeuverOptions None { get; } = new(TimeSpan.Zero, TimeSpan.Zero);
+}
+
+public sealed record RouteDestinationFrontOptions
+{
+    public RouteDestinationFrontOptions(
+        double halfAngleDegrees = 120,
+        RouteDestinationFrontSegmentPolicy segmentPolicy =
+            RouteDestinationFrontSegmentPolicy.ProvisionalComponent,
+        int minimumSecondarySegmentPoints = 3)
+    {
+        if (!double.IsFinite(halfAngleDegrees) || halfAngleDegrees is <= 0 or > 180)
+        {
+            throw new ArgumentOutOfRangeException(nameof(halfAngleDegrees));
+        }
+
+        if (!Enum.IsDefined(segmentPolicy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(segmentPolicy));
+        }
+
+        if (minimumSecondarySegmentPoints <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minimumSecondarySegmentPoints));
+        }
+
+        HalfAngleDegrees = halfAngleDegrees;
+        SegmentPolicy = segmentPolicy;
+        MinimumSecondarySegmentPoints = minimumSecondarySegmentPoints;
+    }
+
+    public double HalfAngleDegrees { get; }
+
+    public RouteDestinationFrontSegmentPolicy SegmentPolicy { get; }
+
+    public int MinimumSecondarySegmentPoints { get; }
+}
+
+public sealed record RouteLatticeOptions
+{
+    public const int MaximumCombinedSubdivisionLevel = 8;
+
+    public RouteLatticeOptions(
+        int subdivisionLevel = 4,
+        TimeSpan? timeBucket = null,
+        int refinementLevels = 1,
+        double corridorWidthNauticalMiles = 450,
+        int corridorWideningRetries = 2,
+        int progressEveryExpansions = 250,
+        RouteLatticeSearchAlgorithm searchAlgorithm = RouteLatticeSearchAlgorithm.AStar)
+    {
+        var effectiveTimeBucket = timeBucket ?? TimeSpan.FromMinutes(30);
+        if (subdivisionLevel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(subdivisionLevel));
+        }
+
+        if (refinementLevels < 0 ||
+            subdivisionLevel + refinementLevels > MaximumCombinedSubdivisionLevel)
+        {
+            throw new ArgumentOutOfRangeException(nameof(refinementLevels));
+        }
+
+        if (effectiveTimeBucket <= TimeSpan.Zero ||
+            effectiveTimeBucket.Ticks % TimeSpan.TicksPerMinute != 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeBucket));
+        }
+
+        if (!double.IsFinite(corridorWidthNauticalMiles) ||
+            corridorWidthNauticalMiles <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(corridorWidthNauticalMiles));
+        }
+
+        if (corridorWideningRetries < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(corridorWideningRetries));
+        }
+
+        if (progressEveryExpansions <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(progressEveryExpansions));
+        }
+
+        if (!Enum.IsDefined(searchAlgorithm))
+        {
+            throw new ArgumentOutOfRangeException(nameof(searchAlgorithm));
+        }
+
+        SubdivisionLevel = subdivisionLevel;
+        TimeBucket = effectiveTimeBucket;
+        RefinementLevels = refinementLevels;
+        CorridorWidthNauticalMiles = corridorWidthNauticalMiles;
+        CorridorWideningRetries = corridorWideningRetries;
+        ProgressEveryExpansions = progressEveryExpansions;
+        SearchAlgorithm = searchAlgorithm;
+    }
+
+    public int SubdivisionLevel { get; }
+
+    public TimeSpan TimeBucket { get; }
+
+    public int RefinementLevels { get; }
+
+    public double CorridorWidthNauticalMiles { get; }
+
+    public int CorridorWideningRetries { get; }
+
+    public int ProgressEveryExpansions { get; }
+
+    public RouteLatticeSearchAlgorithm SearchAlgorithm { get; }
+}
+
+public sealed record RouteOptimizationOptions
+{
+    public RouteOptimizationOptions(
+        RouteSolver solver = RouteSolver.IsochroneBeam,
+        RouteManeuverOptions? maneuver = null,
+        RouteHeadingAugmentation headingAugmentation =
+            RouteHeadingAugmentation.DestinationBearingAndVelocityMadeGood,
+        RouteWindSampling windSampling = RouteWindSampling.Midpoint,
+        TimeSpan? midpointWindSamplingThreshold = null,
+        RoutePolarAngleInterpolation polarAngleInterpolation =
+            RoutePolarAngleInterpolation.MonotoneCubic,
+        double? maximumTrueWindSpeedKnots = null,
+        RouteAbovePolarRangePolicy abovePolarRange = RouteAbovePolarRangePolicy.Clamp,
+        RoutePruningStrategy pruningStrategy = RoutePruningStrategy.DestinationDistanceGrid,
+        double pruningSectorDegrees = 2,
+        RouteDestinationFrontOptions? destinationFront = null,
+        RouteLatticeOptions? lattice = null)
+    {
+        if (!Enum.IsDefined(solver))
+        {
+            throw new ArgumentOutOfRangeException(nameof(solver));
+        }
+
+        if (!Enum.IsDefined(headingAugmentation))
+        {
+            throw new ArgumentOutOfRangeException(nameof(headingAugmentation));
+        }
+
+        if (!Enum.IsDefined(windSampling))
+        {
+            throw new ArgumentOutOfRangeException(nameof(windSampling));
+        }
+
+        if (!Enum.IsDefined(polarAngleInterpolation))
+        {
+            throw new ArgumentOutOfRangeException(nameof(polarAngleInterpolation));
+        }
+
+        if (!Enum.IsDefined(abovePolarRange))
+        {
+            throw new ArgumentOutOfRangeException(nameof(abovePolarRange));
+        }
+
+        if (!Enum.IsDefined(pruningStrategy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(pruningStrategy));
+        }
+
+        var effectiveThreshold = midpointWindSamplingThreshold ?? TimeSpan.Zero;
+        if (effectiveThreshold < TimeSpan.Zero ||
+            effectiveThreshold.Ticks % TimeSpan.TicksPerMinute != 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(midpointWindSamplingThreshold));
+        }
+
+        if (maximumTrueWindSpeedKnots is { } maximumWind &&
+            (!double.IsFinite(maximumWind) || maximumWind <= 0))
+        {
+            throw new ArgumentOutOfRangeException(nameof(maximumTrueWindSpeedKnots));
+        }
+
+        if (!double.IsFinite(pruningSectorDegrees) ||
+            pruningSectorDegrees is <= 0 or > 180)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pruningSectorDegrees));
+        }
+
+        Solver = solver;
+        Maneuver = maneuver ?? RouteManeuverOptions.None;
+        HeadingAugmentation = headingAugmentation;
+        WindSampling = windSampling;
+        MidpointWindSamplingThreshold = effectiveThreshold;
+        PolarAngleInterpolation = polarAngleInterpolation;
+        MaximumTrueWindSpeedKnots = maximumTrueWindSpeedKnots;
+        AbovePolarRange = abovePolarRange;
+        PruningStrategy = pruningStrategy;
+        PruningSectorDegrees = pruningSectorDegrees;
+        DestinationFront = destinationFront ?? new RouteDestinationFrontOptions();
+        Lattice = lattice ?? new RouteLatticeOptions();
+    }
+
+    public RouteSolver Solver { get; }
+
+    public RouteManeuverOptions Maneuver { get; }
+
+    public RouteHeadingAugmentation HeadingAugmentation { get; }
+
+    public RouteWindSampling WindSampling { get; }
+
+    public TimeSpan MidpointWindSamplingThreshold { get; }
+
+    public RoutePolarAngleInterpolation PolarAngleInterpolation { get; }
+
+    public double? MaximumTrueWindSpeedKnots { get; }
+
+    public RouteAbovePolarRangePolicy AbovePolarRange { get; }
+
+    public RoutePruningStrategy PruningStrategy { get; }
+
+    public double PruningSectorDegrees { get; }
+
+    public RouteDestinationFrontOptions DestinationFront { get; }
+
+    public RouteLatticeOptions Lattice { get; }
+
+    public static RouteOptimizationOptions Balanced { get; } = new();
+
+    public static RouteOptimizationOptions UpstreamCompatible { get; } = new(
+        headingAugmentation: RouteHeadingAugmentation.None,
+        windSampling: RouteWindSampling.SegmentStart,
+        polarAngleInterpolation: RoutePolarAngleInterpolation.Linear);
+}

--- a/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutePlanRoutingWorkflow.cs
@@ -11,7 +11,8 @@ public sealed record RoutePlanRoutingRequest
         DateTimeOffset departureTime,
         DateTimeOffset forecastCutoff,
         IEnumerable<ForecastSelection> selections,
-        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache,
+        RouteOptimizationOptions? optimization = null)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(selections);
@@ -52,6 +53,7 @@ public sealed record RoutePlanRoutingRequest
         Selections = immutableSelections;
         Models = immutableSelections.Select(selection => selection.Model).ToImmutableArray();
         RefreshPolicy = refreshPolicy;
+        Optimization = optimization ?? RouteOptimizationOptions.Balanced;
         StartLegIndex = plan.ActiveLegIndex;
         StartOrigin = plan.CurrentPosition?.Coordinate ??
             plan.Waypoints[StartLegIndex].Coordinate;
@@ -68,6 +70,8 @@ public sealed record RoutePlanRoutingRequest
     public ImmutableArray<ForecastModel> Models { get; }
 
     public ForecastRefreshPolicy RefreshPolicy { get; }
+
+    public RouteOptimizationOptions Optimization { get; }
 
     /// <summary>
     /// The index of the leg routing should resume from: <see cref="RoutePlan.ActiveLegIndex"/> at
@@ -250,7 +254,8 @@ public sealed class RoutePlanRoutingWorkflow
                         route,
                         [modelState.Selection],
                         ForecastCorridor.Create(route.Origin, route.Destination),
-                        request.RefreshPolicy);
+                        request.RefreshPolicy,
+                        request.Optimization);
                     var legProgress = new InlineProgress<RoutingProgress>(value =>
                         progressState.Report(
                             value.Model,

--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -329,6 +329,93 @@ public sealed record RouteDiagnostics
     public TimeSpan? CalculationDuration { get; }
 }
 
+public sealed record RouteLatticeSearchProgress
+{
+    public RouteLatticeSearchProgress(
+        long settledLabels,
+        long queuedLabels,
+        long relaxedLabels,
+        int refinementIndex,
+        int subdivisionLevel)
+    {
+        if (settledLabels < 0 || queuedLabels < 0 || relaxedLabels < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(settledLabels));
+        }
+
+        if (refinementIndex < 0 || subdivisionLevel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(refinementIndex));
+        }
+
+        SettledLabels = settledLabels;
+        QueuedLabels = queuedLabels;
+        RelaxedLabels = relaxedLabels;
+        RefinementIndex = refinementIndex;
+        SubdivisionLevel = subdivisionLevel;
+    }
+
+    public long SettledLabels { get; }
+
+    public long QueuedLabels { get; }
+
+    public long RelaxedLabels { get; }
+
+    public int RefinementIndex { get; }
+
+    public int SubdivisionLevel { get; }
+}
+
+public sealed record RouteLatticeDiagnostics
+{
+    public RouteLatticeDiagnostics(
+        long settledLabels,
+        long queuedLabels,
+        long relaxedLabels,
+        long waitTransitions,
+        int refinementRuns,
+        int acceptedRefinements,
+        int subdivisionLevel,
+        bool refinementFallback)
+    {
+        if (settledLabels < 0 || queuedLabels < 0 || relaxedLabels < 0 ||
+            waitTransitions < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(settledLabels));
+        }
+
+        if (refinementRuns < 0 || acceptedRefinements < 0 || subdivisionLevel < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(refinementRuns));
+        }
+
+        SettledLabels = settledLabels;
+        QueuedLabels = queuedLabels;
+        RelaxedLabels = relaxedLabels;
+        WaitTransitions = waitTransitions;
+        RefinementRuns = refinementRuns;
+        AcceptedRefinements = acceptedRefinements;
+        SubdivisionLevel = subdivisionLevel;
+        RefinementFallback = refinementFallback;
+    }
+
+    public long SettledLabels { get; }
+
+    public long QueuedLabels { get; }
+
+    public long RelaxedLabels { get; }
+
+    public long WaitTransitions { get; }
+
+    public int RefinementRuns { get; }
+
+    public int AcceptedRefinements { get; }
+
+    public int SubdivisionLevel { get; }
+
+    public bool RefinementFallback { get; }
+}
+
 public sealed record RouteCalculationFrontSegment
 {
     public RouteCalculationFrontSegment(IEnumerable<Coordinate> points)
@@ -380,23 +467,50 @@ public sealed record RouteCalculationSnapshot
         IEnumerable<RouteCalculationFrontSegment> frontSegments,
         IEnumerable<RoutePoint> provisionalRoute,
         RouteDiagnostics diagnostics)
+        : this(
+            frontierTime,
+            RouteSolver.IsochroneBeam,
+            envelopeSegments,
+            frontSegments,
+            Array.Empty<Coordinate>(),
+            provisionalRoute,
+            diagnostics,
+            null)
+    {
+    }
+
+    public RouteCalculationSnapshot(
+        DateTimeOffset frontierTime,
+        RouteSolver solver,
+        IEnumerable<RouteCalculationEnvelopeSegment> envelopeSegments,
+        IEnumerable<RouteCalculationFrontSegment> frontSegments,
+        IEnumerable<Coordinate> searchPoints,
+        IEnumerable<RoutePoint> provisionalRoute,
+        RouteDiagnostics diagnostics,
+        RouteLatticeSearchProgress? latticeSearch)
     {
         ArgumentNullException.ThrowIfNull(envelopeSegments);
         ArgumentNullException.ThrowIfNull(frontSegments);
+        ArgumentNullException.ThrowIfNull(searchPoints);
         ArgumentNullException.ThrowIfNull(provisionalRoute);
         ArgumentNullException.ThrowIfNull(diagnostics);
+        if (!Enum.IsDefined(solver))
+        {
+            throw new ArgumentOutOfRangeException(nameof(solver));
+        }
 
         var immutableEnvelopeSegments = envelopeSegments.ToImmutableArray();
         var immutableFrontSegments = frontSegments.ToImmutableArray();
+        var immutableSearchPoints = searchPoints.ToImmutableArray();
         var immutableRoute = provisionalRoute.ToImmutableArray();
-        if (immutableEnvelopeSegments.IsEmpty)
+        if (solver == RouteSolver.IsochroneBeam && immutableEnvelopeSegments.IsEmpty)
         {
             throw new ArgumentException(
                 "A routing snapshot must contain at least one reachability envelope segment.",
                 nameof(envelopeSegments));
         }
 
-        if (immutableFrontSegments.IsEmpty)
+        if (solver == RouteSolver.IsochroneBeam && immutableFrontSegments.IsEmpty)
         {
             throw new ArgumentException(
                 "A routing snapshot must contain at least one isochrone front segment.",
@@ -409,13 +523,13 @@ public sealed record RouteCalculationSnapshot
         }
 
         var utcFrontierTime = frontierTime.ToUniversalTime();
-        if (immutableRoute[^1].Timestamp != utcFrontierTime)
+        if (solver == RouteSolver.IsochroneBeam &&
+            immutableRoute[^1].Timestamp != utcFrontierTime)
         {
             throw new ArgumentException(
                 "The provisional route must end at the frontier time.",
                 nameof(provisionalRoute));
         }
-
         for (var index = 1; index < immutableRoute.Length; index++)
         {
             if (immutableRoute[index].Timestamp < immutableRoute[index - 1].Timestamp ||
@@ -429,21 +543,36 @@ public sealed record RouteCalculationSnapshot
         }
 
         FrontierTime = utcFrontierTime;
+        Solver = solver;
         EnvelopeSegments = immutableEnvelopeSegments;
         FrontSegments = immutableFrontSegments;
+        SearchPoints = immutableSearchPoints;
         ProvisionalRoute = immutableRoute;
         Diagnostics = diagnostics;
+        LatticeSearch = latticeSearch;
+        if ((solver == RouteSolver.TimeDependentLattice) != (latticeSearch is not null))
+        {
+            throw new ArgumentException(
+                "Lattice progress is required only for the lattice solver.",
+                nameof(latticeSearch));
+        }
     }
 
     public DateTimeOffset FrontierTime { get; }
+
+    public RouteSolver Solver { get; }
 
     public ImmutableArray<RouteCalculationEnvelopeSegment> EnvelopeSegments { get; }
 
     public ImmutableArray<RouteCalculationFrontSegment> FrontSegments { get; }
 
+    public ImmutableArray<Coordinate> SearchPoints { get; }
+
     public ImmutableArray<RoutePoint> ProvisionalRoute { get; }
 
     public RouteDiagnostics Diagnostics { get; }
+
+    public RouteLatticeSearchProgress? LatticeSearch { get; }
 }
 
 public enum RouteCompletion
@@ -523,7 +652,9 @@ public sealed record RouteResult
         IEnumerable<RoutePoint> points,
         RouteDiagnostics diagnostics,
         RouteCompletion completion,
-        RouteLandAvoidance? landAvoidance)
+        RouteLandAvoidance? landAvoidance,
+        RouteSolver solver = RouteSolver.IsochroneBeam,
+        RouteLatticeDiagnostics? latticeDiagnostics = null)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(points);
@@ -532,6 +663,17 @@ public sealed record RouteResult
         if (!Enum.IsDefined(completion))
         {
             throw new ArgumentOutOfRangeException(nameof(completion));
+        }
+        if (!Enum.IsDefined(solver))
+        {
+            throw new ArgumentOutOfRangeException(nameof(solver));
+        }
+        if (solver != RouteSolver.TimeDependentLattice &&
+            latticeDiagnostics is not null)
+        {
+            throw new ArgumentException(
+                "Lattice diagnostics are valid only for lattice results.",
+                nameof(latticeDiagnostics));
         }
 
         var immutablePoints = points.ToImmutableArray();
@@ -570,6 +712,8 @@ public sealed record RouteResult
         Diagnostics = diagnostics;
         Completion = completion;
         LandAvoidance = landAvoidance ?? RouteLandAvoidance.NotEvaluated;
+        Solver = solver;
+        LatticeDiagnostics = latticeDiagnostics;
     }
 
     public RouteRequest Request { get; }
@@ -583,6 +727,10 @@ public sealed record RouteResult
     public RouteCompletion Completion { get; }
 
     public RouteLandAvoidance LandAvoidance { get; }
+
+    public RouteSolver Solver { get; }
+
+    public RouteLatticeDiagnostics? LatticeDiagnostics { get; }
 
     public DateTimeOffset ArrivalTime => Points[^1].Timestamp;
 
@@ -604,7 +752,9 @@ public sealed record RouteResult
             Points,
             Diagnostics,
             Completion,
-            landAvoidance);
+            landAvoidance,
+            Solver,
+            LatticeDiagnostics);
     }
 }
 
@@ -639,4 +789,12 @@ public interface IRouteEngine
         ForecastAcquisition forecast,
         IProgress<RouteCalculationProgress>? progress,
         CancellationToken cancellationToken);
+
+    ValueTask<RouteResult> CalculateAsync(
+        RouteRequest request,
+        ForecastAcquisition forecast,
+        RouteOptimizationOptions optimization,
+        IProgress<RouteCalculationProgress>? progress,
+        CancellationToken cancellationToken) =>
+        CalculateAsync(request, forecast, progress, cancellationToken);
 }

--- a/src/Navtool.Core/RoutingWorkflow.cs
+++ b/src/Navtool.Core/RoutingWorkflow.cs
@@ -8,12 +8,14 @@ public sealed record RoutingWorkflowRequest
         RouteRequest route,
         IEnumerable<ForecastModel> models,
         GeographicBounds? forecastBounds = null,
-        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache,
+        RouteOptimizationOptions? optimization = null)
         : this(
             route,
             CreateDownloadSelections(models),
             forecastBounds,
-            refreshPolicy)
+            refreshPolicy,
+            optimization)
     {
     }
 
@@ -21,7 +23,8 @@ public sealed record RoutingWorkflowRequest
         RouteRequest route,
         IEnumerable<ForecastSelection> selections,
         GeographicBounds? forecastBounds = null,
-        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache)
+        ForecastRefreshPolicy refreshPolicy = ForecastRefreshPolicy.PreferCache,
+        RouteOptimizationOptions? optimization = null)
     {
         ArgumentNullException.ThrowIfNull(route);
         ArgumentNullException.ThrowIfNull(selections);
@@ -61,6 +64,7 @@ public sealed record RoutingWorkflowRequest
         ForecastBounds = forecastBounds ?? GeographicBounds.FromCoordinates(
             new[] { route.Origin, route.Destination });
         RefreshPolicy = refreshPolicy;
+        Optimization = optimization ?? RouteOptimizationOptions.Balanced;
     }
 
     public RouteRequest Route { get; }
@@ -72,6 +76,8 @@ public sealed record RoutingWorkflowRequest
     public GeographicBounds ForecastBounds { get; }
 
     public ForecastRefreshPolicy RefreshPolicy { get; }
+
+    public RouteOptimizationOptions Optimization { get; }
 
     private static IEnumerable<ForecastSelection> CreateDownloadSelections(
         IEnumerable<ForecastModel> models)
@@ -326,7 +332,12 @@ public sealed class RoutingWorkflow
                     value.Snapshot));
 
             var route = await _routeEngine
-                .CalculateAsync(request.Route, acquisition, routeProgress, cancellationToken)
+                .CalculateAsync(
+                    request.Route,
+                    acquisition,
+                    request.Optimization,
+                    routeProgress,
+                    cancellationToken)
                 .ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -15,7 +15,7 @@ namespace Navtool.Infrastructure;
 
 public sealed record NativeRouterBridgeOptions
 {
-    public const uint SupportedAbiVersion = 5;
+    public const uint SupportedAbiVersion = 6;
 
     public int MaximumTextBytes { get; init; } = 64 * 1024 * 1024;
 
@@ -315,6 +315,7 @@ public sealed class NativeRouterBridge
             forecast,
             request,
             model,
+            RouteOptimizationOptions.Balanced,
             null,
             null,
             cancellationToken);
@@ -331,6 +332,7 @@ public sealed class NativeRouterBridge
             forecast,
             request,
             model,
+            RouteOptimizationOptions.Balanced,
             null,
             isSegmentEligible,
             cancellationToken);
@@ -348,6 +350,7 @@ public sealed class NativeRouterBridge
             forecast,
             request,
             model,
+            RouteOptimizationOptions.Balanced,
             onProgress,
             null,
             cancellationToken);
@@ -367,6 +370,27 @@ public sealed class NativeRouterBridge
             forecast,
             request,
             model,
+            RouteOptimizationOptions.Balanced,
+            onProgress,
+            isSegmentEligible,
+            cancellationToken);
+    }
+
+    public RouteResult CalculateRoute(
+        NativeForecast forecast,
+        RouteRequest request,
+        ForecastModel model,
+        RouteOptimizationOptions optimization,
+        Action<RouteCalculationSnapshot>? onProgress,
+        Func<Coordinate, Coordinate, bool>? isSegmentEligible,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(optimization);
+        return CalculateRouteCore(
+            forecast,
+            request,
+            model,
+            optimization,
             onProgress,
             isSegmentEligible,
             cancellationToken);
@@ -376,12 +400,14 @@ public sealed class NativeRouterBridge
         NativeForecast forecast,
         RouteRequest request,
         ForecastModel model,
+        RouteOptimizationOptions optimization,
         Action<RouteCalculationSnapshot>? onProgress,
         Func<Coordinate, Coordinate, bool>? isSegmentEligible,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(forecast);
         ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(optimization);
         _ = model.Provider();
         ThrowIfDisposed(forecast);
         if (isSegmentEligible is not null && !LandConstraintAvailable)
@@ -392,6 +418,7 @@ public sealed class NativeRouterBridge
 
         cancellationToken.ThrowIfCancellationRequested();
         var departure = request.DepartureTime.ToUnixTimeSeconds();
+        var nativeOptions = NativeRoutingOptions.From(optimization);
         var stopwatch = Stopwatch.StartNew();
         ExceptionDispatchInfo? callbackFailure = null;
         NativeMethods.RoutingProgressCallback callback;
@@ -404,7 +431,7 @@ public sealed class NativeRouterBridge
         {
             if (callbackFailure is not null)
             {
-                return;
+                return 0;
             }
 
             try
@@ -415,6 +442,7 @@ public sealed class NativeRouterBridge
                 {
                     onProgress(lastSnapshot);
                 }
+                cancellationToken.ThrowIfCancellationRequested();
             }
             catch (Exception exception)
             {
@@ -423,6 +451,7 @@ public sealed class NativeRouterBridge
                     ExceptionDispatchInfo.Capture(exception),
                     null);
             }
+            return callbackFailure is null ? (byte)1 : (byte)0;
         };
         if (isSegmentEligible is not null)
         {
@@ -468,6 +497,7 @@ public sealed class NativeRouterBridge
                 request.Destination.Latitude,
                 request.Destination.Longitude,
                 ref departure,
+                ref nativeOptions,
                 callback,
                 IntPtr.Zero,
                 eligibilityCallback,
@@ -506,7 +536,9 @@ public sealed class NativeRouterBridge
                         lastSnapshot.Diagnostics.RetainedCandidates,
                         lastSnapshot.Diagnostics.TimeSteps,
                         stopwatch.Elapsed),
-                    RouteCompletion.ForecastExhausted);
+                    RouteCompletion.ForecastExhausted,
+                    landAvoidance: null,
+                    optimization.Solver);
                 EnsureWithinForecastHorizon(partial, forecast.Metadata);
                 return ApplyLandAvoidanceCapability(
                     partial,
@@ -521,7 +553,12 @@ public sealed class NativeRouterBridge
 
         var json = CopyUtf8(routePointer, routeLength, _options.MaximumTextBytes, "route JSON");
         cancellationToken.ThrowIfCancellationRequested();
-        var result = NativeRouteJsonParser.Parse(json, request, model, stopwatch.Elapsed);
+        var result = NativeRouteJsonParser.Parse(
+            json,
+            request,
+            model,
+            stopwatch.Elapsed,
+            optimization.Solver);
         EnsureWithinForecastHorizon(result, forecast.Metadata);
         return ApplyLandAvoidanceCapability(
             result,
@@ -588,14 +625,23 @@ public sealed class NativeRouterBridge
         }
 
         var progress = Marshal.PtrToStructure<NativeRoutingProgress>(progressPointer);
+        var solver = progress.Solver switch
+        {
+            0 => RouteSolver.IsochroneBeam,
+            1 => RouteSolver.TimeDependentLattice,
+            _ => throw new NativeRouteFormatException(
+                "Native progress contained an unsupported solver.")
+        };
         var contourPoints = CopyArray<NativeCoordinate>(
             progress.ContourPoints,
             progress.ContourPointCount,
-            "contour points");
+            "contour points",
+            allowEmpty: true);
         var nativeContourSegments = CopyArray<NativeContourSegment>(
             progress.ContourSegments,
             progress.ContourSegmentCount,
-            "contour segments");
+            "contour segments",
+            allowEmpty: true);
         var envelopeSegments = ImmutableArray.CreateBuilder<RouteCalculationEnvelopeSegment>(
             nativeContourSegments.Length);
         foreach (var segment in nativeContourSegments)
@@ -629,11 +675,13 @@ public sealed class NativeRouterBridge
         var frontPoints = CopyArray<NativeCoordinate>(
             progress.FrontPoints,
             progress.FrontPointCount,
-            "front points");
+            "front points",
+            allowEmpty: true);
         var nativeSegments = CopyArray<NativeFrontSegment>(
             progress.FrontSegments,
             progress.FrontSegmentCount,
-            "front segments");
+            "front segments",
+            allowEmpty: true);
         var frontSegments = ImmutableArray.CreateBuilder<RouteCalculationFrontSegment>(
             nativeSegments.Length);
         foreach (var segment in nativeSegments)
@@ -662,6 +710,14 @@ public sealed class NativeRouterBridge
                 segmentPoints.MoveToImmutable()));
         }
 
+        var searchPoints = CopyArray<NativeCoordinate>(
+                progress.SearchPoints,
+                progress.SearchPointCount,
+                "search points",
+                allowEmpty: true)
+            .Select(point => new Coordinate(
+                point.LatitudeDegrees,
+                point.LongitudeDegrees));
         var provisionalRoute = CopyArray<NativeRoutePoint>(
                 progress.ProvisionalRoutePoints,
                 progress.ProvisionalRoutePointCount,
@@ -681,22 +737,39 @@ public sealed class NativeRouterBridge
             checked((long)progress.Diagnostics.GeneratedCandidates),
             checked((long)progress.Diagnostics.RetainedCandidates),
             checked((int)progress.Diagnostics.TimeSteps));
+        var latticeSearch = solver == RouteSolver.TimeDependentLattice
+            ? new RouteLatticeSearchProgress(
+                checked((long)progress.LatticeSearch.SettledLabels),
+                checked((long)progress.LatticeSearch.QueuedLabels),
+                checked((long)progress.LatticeSearch.RelaxedLabels),
+                checked((int)progress.LatticeSearch.RefinementIndex),
+                checked((int)progress.LatticeSearch.SubdivisionLevel))
+            : null;
         return new RouteCalculationSnapshot(
-            DateTimeOffset.FromUnixTimeSeconds(progress.IsochroneUtcEpochSeconds),
+            DateTimeOffset.FromUnixTimeSeconds(progress.ProgressUtcEpochSeconds),
+            solver,
             envelopeSegments.MoveToImmutable(),
             frontSegments.MoveToImmutable(),
+            searchPoints,
             provisionalRoute,
-            diagnostics);
+            diagnostics,
+            latticeSearch);
     }
 
     private ImmutableArray<T> CopyArray<T>(
         IntPtr pointer,
         ulong count,
-        string description)
+        string description,
+        bool allowEmpty = false)
         where T : struct
     {
         if (count == 0)
         {
+            if (allowEmpty)
+            {
+                return [];
+            }
+
             throw new NativeRouteFormatException($"Native progress {description} must not be empty.");
         }
 
@@ -903,14 +976,28 @@ public sealed class NativeRouteEngine : IRouteEngine
 
     public bool LandAvoidanceAvailable => _bridge.LandConstraintAvailable;
 
+    public ValueTask<RouteResult> CalculateAsync(
+        RouteRequest request,
+        ForecastAcquisition forecast,
+        IProgress<RouteCalculationProgress>? progress,
+        CancellationToken cancellationToken) =>
+        CalculateAsync(
+            request,
+            forecast,
+            RouteOptimizationOptions.Balanced,
+            progress,
+            cancellationToken);
+
     public async ValueTask<RouteResult> CalculateAsync(
         RouteRequest request,
         ForecastAcquisition forecast,
+        RouteOptimizationOptions optimization,
         IProgress<RouteCalculationProgress>? progress,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
         ArgumentNullException.ThrowIfNull(forecast);
+        ArgumentNullException.ThrowIfNull(optimization);
         cancellationToken.ThrowIfCancellationRequested();
         if (!LandAvoidanceAvailable)
         {
@@ -947,57 +1034,34 @@ public sealed class NativeRouteEngine : IRouteEngine
             cancellationToken.ThrowIfCancellationRequested();
             progress?.Report(new RouteCalculationProgress(0.2, "Optimizing route"));
             RouteResult result;
-            if (progress is null)
+            Action<RouteCalculationSnapshot>? reportSnapshot = null;
+            if (progress is not null)
             {
-                result = isSegmentEligible is null
-                    ? _bridge.CalculateRoute(
-                        loaded,
-                        request,
-                        forecast.Request.Model,
-                        cancellationToken)
-                    : _bridge.CalculateRoute(
-                        loaded,
-                        request,
-                        forecast.Request.Model,
-                        isSegmentEligible,
-                        cancellationToken);
-            }
-            else
-            {
-                Action<RouteCalculationSnapshot> reportSnapshot = snapshot =>
+                var reportedElapsed = TimeSpan.Zero;
+                reportSnapshot = snapshot =>
                 {
-                    var requestedDuration =
-                        request.LatestArrivalTime - request.DepartureTime;
-                    var elapsed =
-                        snapshot.FrontierTime - request.DepartureTime;
-                    var fraction = requestedDuration <= TimeSpan.Zero
-                        ? 0
-                        : Math.Clamp(
-                            elapsed.TotalSeconds /
-                            requestedDuration.TotalSeconds,
-                            0,
-                            1);
+                    var fraction = AdvanceProgressFraction(
+                        request,
+                        snapshot,
+                        ref reportedElapsed);
                     progress.Report(new RouteCalculationProgress(
                         0.2 + (fraction * 0.79),
-                        $"Step {snapshot.Diagnostics.TimeSteps:N0} · " +
-                        $"{snapshot.Diagnostics.RetainedCandidates:N0} retained",
+                        snapshot.Solver == RouteSolver.TimeDependentLattice
+                            ? $"{snapshot.LatticeSearch!.SettledLabels:N0} settled · " +
+                              $"refinement {snapshot.LatticeSearch.RefinementIndex:N0}"
+                            : $"Step {snapshot.Diagnostics.TimeSteps:N0} · " +
+                              $"{snapshot.Diagnostics.RetainedCandidates:N0} retained",
                         snapshot));
                 };
-                result = isSegmentEligible is null
-                    ? _bridge.CalculateRoute(
-                        loaded,
-                        request,
-                        forecast.Request.Model,
-                        reportSnapshot,
-                        cancellationToken)
-                    : _bridge.CalculateRoute(
-                    loaded,
-                    request,
-                    forecast.Request.Model,
-                    reportSnapshot,
-                    isSegmentEligible,
-                    cancellationToken);
             }
+            result = _bridge.CalculateRoute(
+                loaded,
+                request,
+                forecast.Request.Model,
+                optimization,
+                reportSnapshot,
+                isSegmentEligible,
+                cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             progress?.Report(new RouteCalculationProgress(1, "Route complete"));
             result = ApplyLandData(result, landData);
@@ -1019,6 +1083,34 @@ public sealed class NativeRouteEngine : IRouteEngine
                 forecast.Artifact.Path);
             throw;
         }
+    }
+
+    internal static double AdvanceProgressFraction(
+        RouteRequest request,
+        RouteCalculationSnapshot snapshot,
+        ref TimeSpan reportedElapsed)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var requestedDuration =
+            request.LatestArrivalTime - request.DepartureTime;
+        var progressTime = snapshot.Solver == RouteSolver.TimeDependentLattice
+            ? snapshot.ProvisionalRoute[^1].Timestamp
+            : snapshot.FrontierTime;
+        var elapsed = progressTime - request.DepartureTime;
+        if (elapsed > reportedElapsed)
+        {
+            reportedElapsed = elapsed;
+        }
+
+        return requestedDuration <= TimeSpan.Zero
+            ? 0
+            : Math.Clamp(
+                reportedElapsed.TotalSeconds /
+                requestedDuration.TotalSeconds,
+                0,
+                1);
     }
 
     private static RouteResult ApplyLandData(
@@ -1098,9 +1190,11 @@ internal static class NativeRouteJsonParser
         string json,
         RouteRequest request,
         ForecastModel model,
-        TimeSpan calculationDuration)
+        TimeSpan calculationDuration,
+        RouteSolver solver = RouteSolver.IsochroneBeam)
     {
         RouteDiagnostics diagnostics;
+        RouteLatticeDiagnostics? latticeDiagnostics = null;
         RouteCompletion completion;
         var raw = ImmutableArray.CreateBuilder<RawRoutePoint>();
 
@@ -1128,6 +1222,24 @@ internal static class NativeRouteJsonParser
                 RequiredInt64(diagnosticsElement, "retainedCandidates"),
                 RequiredInt32(diagnosticsElement, "timeSteps"),
                 calculationDuration);
+            if (root.TryGetProperty("latticeDiagnostics", out var latticeElement))
+            {
+                RequireKind(latticeElement, JsonValueKind.Object, "latticeDiagnostics");
+                latticeDiagnostics = new RouteLatticeDiagnostics(
+                    RequiredInt64(latticeElement, "settledLabels"),
+                    RequiredInt64(latticeElement, "queuedLabels"),
+                    RequiredInt64(latticeElement, "relaxedLabels"),
+                    RequiredInt64(latticeElement, "waitTransitions"),
+                    RequiredInt32(latticeElement, "refinementRuns"),
+                    RequiredInt32(latticeElement, "acceptedRefinements"),
+                    RequiredInt32(latticeElement, "subdivisionLevel"),
+                    RequiredBoolean(latticeElement, "refinementFallback"));
+            }
+            if (solver == RouteSolver.IsochroneBeam && latticeDiagnostics is not null)
+            {
+                throw new NativeRouteFormatException(
+                    "Native beam route JSON unexpectedly included lattice diagnostics.");
+            }
 
             var pointsElement = Required(root, "points", JsonValueKind.Array);
             foreach (var element in pointsElement.EnumerateArray())
@@ -1193,7 +1305,10 @@ internal static class NativeRouteJsonParser
                 model,
                 points.ToImmutable(),
                 diagnostics,
-                completion);
+                completion,
+                landAvoidance: null,
+                solver,
+                latticeDiagnostics);
         }
         catch (ArgumentException exception)
         {
@@ -1228,6 +1343,18 @@ internal static class NativeRouteJsonParser
         Required(parent, name, JsonValueKind.String).GetString() ??
         throw new NativeRouteFormatException(
             $"Native route JSON field '{name}' must not be null.");
+
+    private static bool RequiredBoolean(JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var value) ||
+            value.ValueKind is not (JsonValueKind.True or JsonValueKind.False))
+        {
+            throw new NativeRouteFormatException(
+                $"Native route JSON field '{name}' must be Boolean.");
+        }
+
+        return value.GetBoolean();
+    }
 
     private static void RequireKind(JsonElement element, JsonValueKind kind, string name)
     {
@@ -1385,9 +1512,80 @@ internal struct NativeRoutingDiagnostics
 }
 
 [StructLayout(LayoutKind.Sequential)]
+internal struct NativeRoutingOptions
+{
+    public int Solver;
+    public int HeadingAugmentation;
+    public int WindSampling;
+    public int PolarAngleInterpolation;
+    public int AbovePolarRange;
+    public int PruningStrategy;
+    public int DestinationFrontSegmentPolicy;
+    public int LatticeSearchAlgorithm;
+    public long TackPenaltySeconds;
+    public long GybePenaltySeconds;
+    public long MidpointWindSamplingThresholdMinutes;
+    public long LatticeTimeBucketMinutes;
+    public double DownwindTrueWindAngleDegrees;
+    public double MaximumTrueWindSpeedKnots;
+    public double PruningSectorDegrees;
+    public double DestinationFrontHalfAngleDegrees;
+    public double LatticeCorridorWidthNauticalMiles;
+    public ulong DestinationFrontMinimumSecondarySegmentPoints;
+    public ulong LatticeSubdivisionLevel;
+    public ulong LatticeRefinementLevels;
+    public ulong LatticeCorridorWideningRetries;
+    public ulong LatticeProgressEveryExpansions;
+    public ulong Flags;
+
+    public static NativeRoutingOptions From(RouteOptimizationOptions options) => new()
+    {
+        Solver = (int)options.Solver,
+        HeadingAugmentation = (int)options.HeadingAugmentation,
+        WindSampling = (int)options.WindSampling,
+        PolarAngleInterpolation = (int)options.PolarAngleInterpolation,
+        AbovePolarRange = (int)options.AbovePolarRange,
+        PruningStrategy = (int)options.PruningStrategy,
+        DestinationFrontSegmentPolicy = (int)options.DestinationFront.SegmentPolicy,
+        LatticeSearchAlgorithm = (int)options.Lattice.SearchAlgorithm,
+        TackPenaltySeconds = checked((long)options.Maneuver.TackPenalty.TotalSeconds),
+        GybePenaltySeconds = checked((long)options.Maneuver.GybePenalty.TotalSeconds),
+        MidpointWindSamplingThresholdMinutes =
+            checked((long)options.MidpointWindSamplingThreshold.TotalMinutes),
+        LatticeTimeBucketMinutes = checked((long)options.Lattice.TimeBucket.TotalMinutes),
+        DownwindTrueWindAngleDegrees = options.Maneuver.DownwindTrueWindAngleDegrees,
+        MaximumTrueWindSpeedKnots = options.MaximumTrueWindSpeedKnots ?? 0,
+        PruningSectorDegrees = options.PruningSectorDegrees,
+        DestinationFrontHalfAngleDegrees = options.DestinationFront.HalfAngleDegrees,
+        LatticeCorridorWidthNauticalMiles = options.Lattice.CorridorWidthNauticalMiles,
+        DestinationFrontMinimumSecondarySegmentPoints =
+            checked((ulong)options.DestinationFront.MinimumSecondarySegmentPoints),
+        LatticeSubdivisionLevel = checked((ulong)options.Lattice.SubdivisionLevel),
+        LatticeRefinementLevels = checked((ulong)options.Lattice.RefinementLevels),
+        LatticeCorridorWideningRetries =
+            checked((ulong)options.Lattice.CorridorWideningRetries),
+        LatticeProgressEveryExpansions =
+            checked((ulong)options.Lattice.ProgressEveryExpansions),
+        Flags = options.MaximumTrueWindSpeedKnots.HasValue ? 1UL : 0UL
+    };
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeLatticeSearchProgress
+{
+    public ulong SettledLabels;
+    public ulong QueuedLabels;
+    public ulong RelaxedLabels;
+    public ulong RefinementIndex;
+    public ulong SubdivisionLevel;
+}
+
+[StructLayout(LayoutKind.Sequential)]
 internal struct NativeRoutingProgress
 {
-    public long IsochroneUtcEpochSeconds;
+    public int Solver;
+    private int _reserved;
+    public long ProgressUtcEpochSeconds;
     public IntPtr ContourPoints;
     public ulong ContourPointCount;
     public IntPtr ContourSegments;
@@ -1396,9 +1594,12 @@ internal struct NativeRoutingProgress
     public ulong FrontPointCount;
     public IntPtr FrontSegments;
     public ulong FrontSegmentCount;
+    public IntPtr SearchPoints;
+    public ulong SearchPointCount;
     public IntPtr ProvisionalRoutePoints;
     public ulong ProvisionalRoutePointCount;
     public NativeRoutingDiagnostics Diagnostics;
+    public NativeLatticeSearchProgress LatticeSearch;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -1471,7 +1672,7 @@ internal static class NativeMethods
         out nuint routeJsonLength);
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    internal delegate void RoutingProgressCallback(
+    internal delegate byte RoutingProgressCallback(
         IntPtr progress,
         IntPtr userData);
 
@@ -1481,7 +1682,7 @@ internal static class NativeMethods
         ref NativeCoordinate candidate,
         IntPtr userData);
 
-    [DllImport(LibraryName, EntryPoint = "navtool_router_calculate_route_streaming_v5", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(LibraryName, EntryPoint = "navtool_router_calculate_route_streaming_v6", CallingConvention = CallingConvention.Cdecl)]
     internal static extern NativeRouterStatus CalculateRouteStreaming(
         NativeForecastSafeHandle forecast,
         double startLatitude,
@@ -1489,6 +1690,7 @@ internal static class NativeMethods
         double destinationLatitude,
         double destinationLongitude,
         ref long departureEpochSeconds,
+        ref NativeRoutingOptions options,
         RoutingProgressCallback onProgress,
         IntPtr progressUserData,
         SegmentEligibilityCallback? isSegmentEligible,

--- a/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
+++ b/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Navtool.Core;
 
@@ -14,9 +15,21 @@ public sealed class RoutePlanSchemaMigrator : IRoutePlanSchemaMigrator
 {
     public JsonDocument MigrateToCurrent(JsonDocument document, int fromVersion, int currentVersion)
     {
-        if (fromVersion == 1 && currentVersion == 2)
+        if (currentVersion != RoutePlanJsonRepository.CurrentSchemaVersion)
         {
-            return MigrateV1ToV2(document);
+            throw new InvalidDataException(
+                $"Route plan schema version {fromVersion} is not supported by this application version.");
+        }
+
+        if (fromVersion == 2)
+        {
+            return MigrateV2ToV3(document);
+        }
+
+        if (fromVersion == 1)
+        {
+            using var versionTwo = MigrateV1ToV2(document);
+            return MigrateV2ToV3(versionTwo);
         }
 
         throw new InvalidDataException(
@@ -40,6 +53,36 @@ public sealed class RoutePlanSchemaMigrator : IRoutePlanSchemaMigrator
 
         stream.Position = 0;
         return JsonDocument.Parse(stream.ToArray());
+    }
+
+    private static JsonDocument MigrateV2ToV3(JsonDocument document)
+    {
+        var root = JsonNode.Parse(document.RootElement.GetRawText()) as JsonObject ??
+                   throw new InvalidDataException("A route plan document must be a JSON object.");
+        root["schemaVersion"] = 3;
+        if (root["plan"]?["results"] is JsonArray results)
+        {
+            foreach (var result in results.OfType<JsonObject>())
+            {
+                if (result["legs"] is not JsonArray legs)
+                {
+                    continue;
+                }
+
+                foreach (var leg in legs.OfType<JsonObject>())
+                {
+                    if (leg["route"] is not JsonObject route)
+                    {
+                        continue;
+                    }
+
+                    route["solver"] = nameof(RouteSolver.IsochroneBeam);
+                    route["latticeDiagnostics"] = null;
+                }
+            }
+        }
+
+        return JsonDocument.Parse(root.ToJsonString());
     }
 
     private static void WriteMigratedEnvelope(Utf8JsonWriter writer, JsonElement root)
@@ -88,7 +131,7 @@ public sealed class RoutePlanSchemaMigrator : IRoutePlanSchemaMigrator
 
 public sealed class RoutePlanJsonRepository : IRoutePlanRepository
 {
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = 3;
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
     {
         WriteIndented = true,
@@ -447,7 +490,19 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
             new RouteLandAvoidanceDto(
                 route.LandAvoidance.Status,
                 route.LandAvoidance.Warning,
-                route.LandAvoidance.Attribution));
+                route.LandAvoidance.Attribution),
+            route.Solver,
+            route.LatticeDiagnostics is null
+                ? null
+                : new RouteLatticeDiagnosticsDto(
+                    route.LatticeDiagnostics.SettledLabels,
+                    route.LatticeDiagnostics.QueuedLabels,
+                    route.LatticeDiagnostics.RelaxedLabels,
+                    route.LatticeDiagnostics.WaitTransitions,
+                    route.LatticeDiagnostics.RefinementRuns,
+                    route.LatticeDiagnostics.AcceptedRefinements,
+                    route.LatticeDiagnostics.SubdivisionLevel,
+                    route.LatticeDiagnostics.RefinementFallback));
 
     private static RoutePlan FromDto(RoutePlanDto dto)
     {
@@ -569,10 +624,23 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
             dto.Request.LatestArrivalTime);
         if (!Enum.IsDefined(dto.Model) ||
             !Enum.IsDefined(dto.Completion) ||
-            !Enum.IsDefined(dto.LandAvoidance.Status))
+            !Enum.IsDefined(dto.LandAvoidance.Status) ||
+            !Enum.IsDefined(dto.Solver))
         {
             throw new InvalidDataException("A stored route result contains an unknown enum value.");
         }
+
+        var latticeDiagnostics = dto.LatticeDiagnostics is null
+            ? null
+            : new RouteLatticeDiagnostics(
+                dto.LatticeDiagnostics.SettledLabels,
+                dto.LatticeDiagnostics.QueuedLabels,
+                dto.LatticeDiagnostics.RelaxedLabels,
+                dto.LatticeDiagnostics.WaitTransitions,
+                dto.LatticeDiagnostics.RefinementRuns,
+                dto.LatticeDiagnostics.AcceptedRefinements,
+                dto.LatticeDiagnostics.SubdivisionLevel,
+                dto.LatticeDiagnostics.RefinementFallback);
 
         return new RouteResult(
             request,
@@ -597,7 +665,9 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
             new RouteLandAvoidance(
                 dto.LandAvoidance.Status,
                 dto.LandAvoidance.Warning,
-                dto.LandAvoidance.Attribution));
+                dto.LandAvoidance.Attribution),
+            dto.Solver,
+            latticeDiagnostics);
     }
 
     private sealed record RoutePlanEnvelope(int SchemaVersion, RoutePlanDto? Plan);
@@ -648,7 +718,9 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
         RoutePointDto[] Points,
         RouteDiagnosticsDto Diagnostics,
         RouteCompletion Completion,
-        RouteLandAvoidanceDto LandAvoidance);
+        RouteLandAvoidanceDto LandAvoidance,
+        RouteSolver Solver,
+        RouteLatticeDiagnosticsDto? LatticeDiagnostics);
 
     private sealed record RouteRequestDto(
         string RouteId,
@@ -680,4 +752,14 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
         LandAvoidanceStatus Status,
         string? Warning,
         string? Attribution);
+
+    private sealed record RouteLatticeDiagnosticsDto(
+        long SettledLabels,
+        long QueuedLabels,
+        long RelaxedLabels,
+        long WaitTransitions,
+        int RefinementRuns,
+        int AcceptedRefinements,
+        int SubdivisionLevel,
+        bool RefinementFallback);
 }

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -15,6 +15,74 @@ public sealed class MainViewModelWorkflowTests
         new(2026, 7, 14, 16, 0, 0, TimeSpan.Zero);
 
     [Fact]
+    public void Professional_routing_defaults_off_and_filters_solver_specific_controls()
+    {
+        var viewModel = new MainViewModel(
+            null,
+            null,
+            new FixedTimeProvider(Now),
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+
+        Assert.False(viewModel.EnableProfessionalRouting);
+        Assert.False(viewModel.IsProfessionalBeamRouting);
+        Assert.False(viewModel.IsProfessionalLatticeRouting);
+
+        viewModel.EnableProfessionalRouting = true;
+        Assert.True(viewModel.IsProfessionalBeamRouting);
+        Assert.False(viewModel.IsProfessionalLatticeRouting);
+
+        viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
+        Assert.False(viewModel.IsProfessionalBeamRouting);
+        Assert.True(viewModel.IsProfessionalLatticeRouting);
+    }
+
+    [Fact]
+    public async Task Standard_mode_always_routes_with_balanced_options()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateRoutingViewModel(noaa, engine);
+        viewModel.EnableProfessionalRouting = false;
+        viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
+        viewModel.TackPenaltySeconds = 600;
+
+        viewModel.SetStartAt(new Coordinate(34, -64));
+        viewModel.SetDestinationAt(new Coordinate(39, -52));
+        await WaitForAsync(() => viewModel.SuccessfulRouteCount == 1);
+
+        Assert.Same(RouteOptimizationOptions.Balanced, engine.LastOptimization);
+    }
+
+    [Fact]
+    public async Task Professional_mode_routes_with_an_immutable_lattice_configuration()
+    {
+        var noaa = new DelegateForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(request, forecast.Request.Model)));
+        var viewModel = CreateRoutingViewModel(noaa, engine);
+        viewModel.EnableProfessionalRouting = true;
+        viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
+        viewModel.TackPenaltySeconds = 120;
+        viewModel.LatticeSearchAlgorithm = RouteLatticeSearchAlgorithm.Dijkstra;
+
+        viewModel.SetStartAt(new Coordinate(34, -64));
+        viewModel.SetDestinationAt(new Coordinate(39, -52));
+        await WaitForAsync(() => viewModel.SuccessfulRouteCount == 1);
+
+        Assert.Equal(RouteSolver.TimeDependentLattice, engine.LastOptimization!.Solver);
+        Assert.Equal(TimeSpan.FromSeconds(120), engine.LastOptimization.Maneuver.TackPenalty);
+        Assert.Equal(
+            RouteLatticeSearchAlgorithm.Dijkstra,
+            engine.LastOptimization.Lattice.SearchAlgorithm);
+    }
+
+    [Fact]
     public void DirectContextualEndpointAssignmentPreservesInteractionWorkflow()
     {
         var viewModel = new MainViewModel(
@@ -1670,6 +1738,17 @@ public sealed class MainViewModelWorkflowTests
         return viewModel;
     }
 
+    private static MainViewModel CreateRoutingViewModel(
+        IForecastProvider provider,
+        IRouteEngine engine) =>
+        new(
+            new RoutingWorkflow(new[] { provider }, engine),
+            new DelegateWeatherSampler((_, _, _, _, _, _) =>
+                ValueTask.FromResult(ImmutableArray<ViewportWindSample>.Empty)),
+            new FixedTimeProvider(Now),
+            TimeZoneInfo.Utc,
+            new OsmTileOptions(Enabled: false));
+
     private static async Task WaitForAsync(Func<bool> predicate)
     {
         var timeout = DateTime.UtcNow.AddSeconds(2);
@@ -1859,6 +1938,8 @@ public sealed class MainViewModelWorkflowTests
         Func<RouteRequest, ForecastAcquisition, CancellationToken, ValueTask<RouteResult>> calculate)
         : IRouteEngine
     {
+        public RouteOptimizationOptions? LastOptimization { get; private set; }
+
         public async ValueTask<RouteResult> CalculateAsync(
             RouteRequest request,
             ForecastAcquisition forecast,
@@ -1868,6 +1949,17 @@ public sealed class MainViewModelWorkflowTests
             var route = await calculate(request, forecast, cancellationToken);
             progress?.Report(new RouteCalculationProgress(1, "fake route"));
             return route;
+        }
+
+        public ValueTask<RouteResult> CalculateAsync(
+            RouteRequest request,
+            ForecastAcquisition forecast,
+            RouteOptimizationOptions optimization,
+            IProgress<RouteCalculationProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            LastOptimization = optimization;
+            return CalculateAsync(request, forecast, progress, cancellationToken);
         }
     }
 

--- a/tests/Navtool.App.Tests/MapRenderingTests.cs
+++ b/tests/Navtool.App.Tests/MapRenderingTests.cs
@@ -164,6 +164,8 @@ public sealed class MapRenderingTests
                 "ECMWF IFS isochrone fronts",
                 "NOAA GFS latest isochrone front",
                 "ECMWF IFS latest isochrone front",
+                "NOAA GFS lattice search",
+                "ECMWF IFS lattice search",
                 "NOAA GFS provisional route",
                 "ECMWF IFS provisional route",
                 "NOAA GFS routes",
@@ -342,6 +344,45 @@ public sealed class MapRenderingTests
 
         Assert.Equal(0, layers.GetIsochroneFrontCount(ForecastModel.NoaaGfs));
         Assert.False(layers.HasLatestIsochroneFront(ForecastModel.NoaaGfs));
+        Assert.False(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
+    }
+
+    [Fact]
+    public void LatticeStreamingRendersSearchPointAndRouteWithoutBeamGeometry()
+    {
+        var map = new Map();
+        var layers = new RouteMapLayers(map);
+        var timestamp = new DateTimeOffset(2026, 7, 15, 2, 0, 0, TimeSpan.Zero);
+        var searchPoint = new Coordinate(10.5, 171.5);
+        var snapshot = new RouteCalculationSnapshot(
+            timestamp,
+            RouteSolver.TimeDependentLattice,
+            Array.Empty<RouteCalculationEnvelopeSegment>(),
+            Array.Empty<RouteCalculationFrontSegment>(),
+            new[] { searchPoint },
+            new[]
+            {
+                new RoutePoint(new Coordinate(10, 170), timestamp.AddHours(-1), 90, 6, 15, 180, 0),
+                new RoutePoint(searchPoint, timestamp, 90, 6, 15, 180, 10)
+            },
+            new RouteDiagnostics(10, 20, 5, 1),
+            new RouteLatticeSearchProgress(12, 7, 30, 1, 2));
+
+        layers.AddCalculationSnapshot(ForecastModel.NoaaGfs, snapshot);
+
+        Assert.True(layers.HasSearchPoint(ForecastModel.NoaaGfs));
+        Assert.True(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
+        Assert.False(layers.HasLatestIsochroneFront(ForecastModel.NoaaGfs));
+        Assert.Equal(0, layers.GetIsochroneFrontCount(ForecastModel.NoaaGfs));
+        var search = Assert.IsType<MemoryLayer>(
+            map.Layers.Single(layer => layer.Name == "NOAA GFS lattice search"));
+        var feature = Assert.IsType<GeometryFeature>(Assert.Single(search.Features));
+        Assert.IsType<Point>(feature.Geometry);
+        Assert.Same(snapshot, feature.Data);
+
+        layers.ClearCalculationOverlay(ForecastModel.NoaaGfs);
+
+        Assert.False(layers.HasSearchPoint(ForecastModel.NoaaGfs));
         Assert.False(layers.HasProvisionalRoute(ForecastModel.NoaaGfs));
     }
 

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -213,6 +213,57 @@ public sealed class NativeBridgeContractTests
     }
 
     [Fact]
+    public void Lattice_snapshot_accepts_search_progress_ahead_of_provisional_route()
+    {
+        var progressTime = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var routeTime = progressTime.AddMinutes(-30);
+        var search = new Coordinate(42.5, -59.5);
+        var snapshot = new RouteCalculationSnapshot(
+            progressTime,
+            RouteSolver.TimeDependentLattice,
+            Array.Empty<RouteCalculationEnvelopeSegment>(),
+            Array.Empty<RouteCalculationFrontSegment>(),
+            new[] { search },
+            new[]
+            {
+                new RoutePoint(new Coordinate(41, -61), routeTime.AddHours(-1), 90, 7, 20, 180, 0),
+                new RoutePoint(new Coordinate(42, -60), routeTime, 90, 7, 20, 180, 7)
+            },
+            new RouteDiagnostics(100, 400, 80, 3),
+            new RouteLatticeSearchProgress(50, 20, 120, 1, 5));
+
+        Assert.Equal(RouteSolver.TimeDependentLattice, snapshot.Solver);
+        Assert.Equal(search, Assert.Single(snapshot.SearchPoints));
+        Assert.Empty(snapshot.EnvelopeSegments);
+        Assert.Empty(snapshot.FrontSegments);
+        Assert.Equal(routeTime, snapshot.ProvisionalRoute[^1].Timestamp);
+        Assert.NotNull(snapshot.LatticeSearch);
+    }
+
+    [Fact]
+    public void Lattice_snapshot_accepts_provisional_route_ahead_of_search_progress()
+    {
+        var progressTime = new DateTimeOffset(2026, 7, 15, 3, 0, 0, TimeSpan.Zero);
+        var routeTime = progressTime.AddMinutes(30);
+        var snapshot = new RouteCalculationSnapshot(
+            progressTime,
+            RouteSolver.TimeDependentLattice,
+            Array.Empty<RouteCalculationEnvelopeSegment>(),
+            Array.Empty<RouteCalculationFrontSegment>(),
+            new[] { new Coordinate(42.5, -59.5) },
+            new[]
+            {
+                new RoutePoint(new Coordinate(41, -61), progressTime.AddHours(-1), 90, 7, 20, 180, 0),
+                new RoutePoint(new Coordinate(42, -60), routeTime, 90, 7, 20, 180, 7)
+            },
+            new RouteDiagnostics(100, 400, 80, 3),
+            new RouteLatticeSearchProgress(50, 20, 120, 1, 5));
+
+        Assert.Equal(routeTime, snapshot.ProvisionalRoute[^1].Timestamp);
+        Assert.Equal(progressTime, snapshot.FrontierTime);
+    }
+
+    [Fact]
     public void Route_result_accepts_arrival_after_the_requested_passage_target()
     {
         var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);

--- a/tests/Navtool.Core.Tests/RouteOptimizationOptionsTests.cs
+++ b/tests/Navtool.Core.Tests/RouteOptimizationOptionsTests.cs
@@ -1,0 +1,53 @@
+namespace Navtool.Core.Tests;
+
+public sealed class RouteOptimizationOptionsTests
+{
+    [Fact]
+    public void Balanced_profile_enables_quality_improvements_without_operational_policy()
+    {
+        var options = RouteOptimizationOptions.Balanced;
+
+        Assert.Equal(RouteSolver.IsochroneBeam, options.Solver);
+        Assert.Equal(
+            RouteHeadingAugmentation.DestinationBearingAndVelocityMadeGood,
+            options.HeadingAugmentation);
+        Assert.Equal(RouteWindSampling.Midpoint, options.WindSampling);
+        Assert.Equal(TimeSpan.Zero, options.MidpointWindSamplingThreshold);
+        Assert.Equal(RoutePolarAngleInterpolation.MonotoneCubic, options.PolarAngleInterpolation);
+        Assert.Equal(TimeSpan.Zero, options.Maneuver.TackPenalty);
+        Assert.Equal(TimeSpan.Zero, options.Maneuver.GybePenalty);
+        Assert.Null(options.MaximumTrueWindSpeedKnots);
+        Assert.Equal(RouteAbovePolarRangePolicy.Clamp, options.AbovePolarRange);
+        Assert.Equal(RoutePruningStrategy.DestinationDistanceGrid, options.PruningStrategy);
+        Assert.Equal(
+            RouteDestinationFrontSegmentPolicy.ProvisionalComponent,
+            options.DestinationFront.SegmentPolicy);
+    }
+
+    [Fact]
+    public void Upstream_compatible_profile_keeps_legacy_accuracy_settings()
+    {
+        var options = RouteOptimizationOptions.UpstreamCompatible;
+
+        Assert.Equal(RouteHeadingAugmentation.None, options.HeadingAugmentation);
+        Assert.Equal(RouteWindSampling.SegmentStart, options.WindSampling);
+        Assert.Equal(RoutePolarAngleInterpolation.Linear, options.PolarAngleInterpolation);
+    }
+
+    [Fact]
+    public void Options_reject_invalid_ranges_and_lattice_combinations()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteManeuverOptions(TimeSpan.FromSeconds(-1), TimeSpan.Zero));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteDestinationFrontOptions(halfAngleDegrees: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteLatticeOptions(subdivisionLevel: 8, refinementLevels: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteLatticeOptions(timeBucket: TimeSpan.FromSeconds(30)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteOptimizationOptions(maximumTrueWindSpeedKnots: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new RouteOptimizationOptions(pruningSectorDegrees: 181));
+    }
+}

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -304,6 +304,31 @@ public sealed class RoutingWorkflowTests
         Assert.Single(result.SuccessfulRoutes);
     }
 
+    [Fact]
+    public async Task Workflow_passes_the_same_optimization_snapshot_to_route_engine()
+    {
+        var provider = new StubForecastProvider(
+            ForecastModel.NoaaGfs,
+            (request, _, _) => ValueTask.FromResult(CreateAcquisition(request)));
+        var engine = new StubRouteEngine((request, acquisition, _, _) =>
+            ValueTask.FromResult(CreateRoute(request, acquisition.Request.Model)));
+        var optimization = new RouteOptimizationOptions(
+            solver: RouteSolver.TimeDependentLattice,
+            maneuver: new RouteManeuverOptions(
+                TimeSpan.FromMinutes(2),
+                TimeSpan.FromMinutes(3)),
+            lattice: new RouteLatticeOptions(searchAlgorithm: RouteLatticeSearchAlgorithm.Dijkstra));
+        var workflow = new RoutingWorkflow(new[] { provider }, engine);
+        var request = new RoutingWorkflowRequest(
+            CreateRouteRequest(),
+            new[] { ForecastModel.NoaaGfs },
+            optimization: optimization);
+
+        await workflow.ExecuteAsync(request);
+
+        Assert.Same(optimization, engine.LastOptimization);
+    }
+
     private static RoutingWorkflowRequest CreateWorkflowRequest() =>
         new(
             CreateRouteRequest(),
@@ -388,6 +413,19 @@ public sealed class RoutingWorkflowTests
             IProgress<RouteCalculationProgress>? progress,
             CancellationToken cancellationToken) =>
             calculate(request, forecast, progress, cancellationToken);
+
+        public RouteOptimizationOptions? LastOptimization { get; private set; }
+
+        public ValueTask<RouteResult> CalculateAsync(
+            RouteRequest request,
+            ForecastAcquisition forecast,
+            RouteOptimizationOptions optimization,
+            IProgress<RouteCalculationProgress>? progress,
+            CancellationToken cancellationToken)
+        {
+            LastOptimization = optimization;
+            return calculate(request, forecast, progress, cancellationToken);
+        }
     }
 
     private sealed class InlineProgress<T>(Action<T> report) : IProgress<T>

--- a/tests/Navtool.Infrastructure.Tests/NativeRouteEngineTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouteEngineTests.cs
@@ -1,0 +1,49 @@
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+public sealed class NativeRouteEngineTests
+{
+    [Fact]
+    public void Lattice_progress_fraction_does_not_regress_when_provisional_route_time_moves_back()
+    {
+        var departure = new DateTimeOffset(2026, 7, 15, 0, 0, 0, TimeSpan.Zero);
+        var request = new RouteRequest(
+            "lattice-progress",
+            new Coordinate(41, -61),
+            new Coordinate(45, -55),
+            departure,
+            departure.AddHours(10));
+        var reportedElapsed = TimeSpan.Zero;
+
+        var first = NativeRouteEngine.AdvanceProgressFraction(
+            request,
+            CreateLatticeSnapshot(departure.AddHours(5), departure.AddHours(7)),
+            ref reportedElapsed);
+        var second = NativeRouteEngine.AdvanceProgressFraction(
+            request,
+            CreateLatticeSnapshot(departure.AddHours(8), departure.AddHours(4)),
+            ref reportedElapsed);
+
+        Assert.Equal(0.7, first);
+        Assert.Equal(first, second);
+    }
+
+    private static RouteCalculationSnapshot CreateLatticeSnapshot(
+        DateTimeOffset progressTime,
+        DateTimeOffset routeTime) =>
+        new(
+            progressTime,
+            RouteSolver.TimeDependentLattice,
+            Array.Empty<RouteCalculationEnvelopeSegment>(),
+            Array.Empty<RouteCalculationFrontSegment>(),
+            new[] { new Coordinate(42, -60) },
+            new[]
+            {
+                new RoutePoint(new Coordinate(41, -61), routeTime.AddHours(-1), 90, 7, 20, 180, 0),
+                new RoutePoint(new Coordinate(42, -60), routeTime, 90, 7, 20, 180, 7)
+            },
+            new RouteDiagnostics(100, 400, 80, 3),
+            new RouteLatticeSearchProgress(50, 20, 120, 1, 5));
+}

--- a/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouteJsonParserTests.cs
@@ -89,6 +89,49 @@ public sealed class NativeRouteJsonParserTests
     }
 
     [Fact]
+    public void Parse_preserves_lattice_solver_and_diagnostics()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var json = AddLatticeDiagnostics(BuildJson(
+            (Departure, 40, -60, 0),
+            (Departure.AddHours(8), 44, -56, 35)));
+
+        var result = NativeRouteJsonParser.Parse(
+            json,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1),
+            RouteSolver.TimeDependentLattice);
+
+        Assert.Equal(RouteSolver.TimeDependentLattice, result.Solver);
+        Assert.Equal(100, result.LatticeDiagnostics!.SettledLabels);
+        Assert.Equal(4, result.LatticeDiagnostics.WaitTransitions);
+        Assert.True(result.LatticeDiagnostics.RefinementFallback);
+    }
+
+    [Fact]
+    public void Parse_rejects_partial_or_solver_incompatible_lattice_diagnostics()
+    {
+        var request = CreateRequest(TimeSpan.FromHours(10));
+        var json = AddLatticeDiagnostics(BuildJson(
+            (Departure, 40, -60, 0),
+            (Departure.AddHours(8), 44, -56, 35)));
+
+        Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            json.Replace("\"waitTransitions\": 4,", string.Empty),
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1),
+            RouteSolver.TimeDependentLattice));
+        Assert.Throws<NativeRouteFormatException>(() => NativeRouteJsonParser.Parse(
+            json,
+            request,
+            ForecastModel.NoaaGfs,
+            TimeSpan.FromSeconds(1),
+            RouteSolver.IsochroneBeam));
+    }
+
+    [Fact]
     public void Parse_throws_format_error_for_malformed_json()
     {
         var request = CreateRequest(TimeSpan.FromHours(10));
@@ -234,4 +277,22 @@ public sealed class NativeRouteJsonParserTests
         360,
         false,
         "test-forecast");
+
+    private static string AddLatticeDiagnostics(string json) =>
+        json.Replace(
+            "\"points\":",
+            """
+            "latticeDiagnostics": {
+              "settledLabels": 100,
+              "queuedLabels": 20,
+              "relaxedLabels": 250,
+              "waitTransitions": 4,
+              "refinementRuns": 2,
+              "acceptedRefinements": 1,
+              "subdivisionLevel": 5,
+              "refinementFallback": true
+            },
+            "points":
+            """,
+            StringComparison.Ordinal);
 }

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
@@ -33,7 +33,7 @@ public sealed class NativeRouterBridgeIntegrationTests
         }
 
         using var forecast = bridge.LoadForecast(sample);
-        Assert.Equal(5u, bridge.AbiVersion);
+        Assert.Equal(6u, bridge.AbiVersion);
         Assert.True(bridge.LandConstraintAvailable);
         Assert.True(forecast.Metadata.LatitudeCount > 0);
         Assert.True(forecast.Metadata.FirstValidAt < forecast.Metadata.LastValidAt);
@@ -104,6 +104,55 @@ public sealed class NativeRouterBridgeIntegrationTests
         {
             Assert.Empty(snapshots);
         }
+
+        var latticeRequest = new RouteRequest(
+            "native-lattice-integration",
+            new Coordinate(48, -123.75),
+            new Coordinate(48.5, -123.25),
+            forecast.Metadata.FirstValidAt,
+            forecast.Metadata.FirstValidAt.AddHours(10));
+        var latticeOptions = new RouteOptimizationOptions(
+            solver: RouteSolver.TimeDependentLattice,
+            lattice: new RouteLatticeOptions(
+                subdivisionLevel: 8,
+                refinementLevels: 0,
+                progressEveryExpansions: 1));
+        var latticeSnapshots = new List<RouteCalculationSnapshot>();
+        var latticeRoute = bridge.CalculateRoute(
+            forecast,
+            latticeRequest,
+            ForecastModel.NoaaGfs,
+            latticeOptions,
+            latticeSnapshots.Add,
+            null);
+        Assert.Equal(RouteSolver.TimeDependentLattice, latticeRoute.Solver);
+        Assert.NotNull(latticeRoute.LatticeDiagnostics);
+        Assert.NotEmpty(latticeSnapshots);
+        Assert.All(latticeSnapshots, snapshot =>
+        {
+            Assert.Equal(RouteSolver.TimeDependentLattice, snapshot.Solver);
+            Assert.Empty(snapshot.EnvelopeSegments);
+            Assert.Empty(snapshot.FrontSegments);
+            Assert.NotEmpty(snapshot.SearchPoints);
+            Assert.NotNull(snapshot.LatticeSearch);
+        });
+
+        using var cancellation = new CancellationTokenSource();
+        var cancellationProgressCount = 0;
+        Assert.Throws<OperationCanceledException>(() =>
+            bridge.CalculateRoute(
+                forecast,
+                latticeRequest,
+                ForecastModel.NoaaGfs,
+                latticeOptions,
+                _ =>
+                {
+                    cancellationProgressCount++;
+                    cancellation.Cancel();
+                },
+                null,
+                cancellation.Token));
+        Assert.Equal(1, cancellationProgressCount);
 
         Assert.All(route.Points, point =>
         {

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterInteropLayoutTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterInteropLayoutTests.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+using Navtool.Core;
+using Navtool.Infrastructure;
+
+namespace Navtool.Infrastructure.Tests;
+
+public sealed class NativeRouterInteropLayoutTests
+{
+    [Fact]
+    public void Abi_v6_struct_layouts_match_native_contract()
+    {
+        Assert.Equal(152, Marshal.SizeOf<NativeRoutingOptions>());
+        Assert.Equal(184, Marshal.SizeOf<NativeRoutingProgress>());
+        Assert.Equal(40, Marshal.SizeOf<NativeLatticeSearchProgress>());
+        Assert.Equal(
+            144,
+            Marshal.OffsetOf<NativeRoutingProgress>(nameof(NativeRoutingProgress.LatticeSearch)).ToInt32());
+    }
+
+    [Fact]
+    public void Native_options_preserve_balanced_and_optional_wind_limit_values()
+    {
+        var balanced = NativeRoutingOptions.From(RouteOptimizationOptions.Balanced);
+        Assert.Equal((int)RouteSolver.IsochroneBeam, balanced.Solver);
+        Assert.Equal(
+            (int)RouteHeadingAugmentation.DestinationBearingAndVelocityMadeGood,
+            balanced.HeadingAugmentation);
+        Assert.Equal((int)RouteWindSampling.Midpoint, balanced.WindSampling);
+        Assert.Equal((int)RoutePolarAngleInterpolation.MonotoneCubic, balanced.PolarAngleInterpolation);
+        Assert.Equal(0UL, balanced.Flags);
+
+        var limited = NativeRoutingOptions.From(new RouteOptimizationOptions(
+            maximumTrueWindSpeedKnots: 35));
+        Assert.Equal(1UL, limited.Flags);
+        Assert.Equal(35, limited.MaximumTrueWindSpeedKnots);
+    }
+}

--- a/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
@@ -40,8 +40,11 @@ public sealed class RoutePlanJsonRepositoryTests
             expectedRoute.Points.Select(point => point.Location),
             loadedRoute.Points.Select(point => point.Location));
         Assert.Equal(expectedRoute.Diagnostics.CalculationDuration, loadedRoute.Diagnostics.CalculationDuration);
+        Assert.Equal(expectedRoute.Solver, loadedRoute.Solver);
+        Assert.Equal(expectedRoute.LatticeDiagnostics, loadedRoute.LatticeDiagnostics);
         Assert.NotEqual(plan.Id, copy.Id);
         Assert.Equal("Return passage", copy.Name);
+        Assert.Equal(expectedRoute.Solver, copy.Results[0].Legs[0].Route!.Solver);
         Assert.Equal(2, summaries.Length);
         Assert.Empty(Directory.EnumerateFiles(repository.RootDirectory, "*.tmp"));
 
@@ -187,6 +190,58 @@ public sealed class RoutePlanJsonRepositoryTests
     }
 
     [Fact]
+    public async Task Version_two_results_are_migrated_to_beam_attribution()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var plan = WithResult(CreatePlan());
+        await repository.SaveAsync(plan);
+        var path = Path.Combine(repository.RootDirectory, $"{plan.Id}.route.json");
+        var root = System.Text.Json.Nodes.JsonNode.Parse(await File.ReadAllTextAsync(path))!;
+        root["schemaVersion"] = 2;
+        foreach (var result in root["plan"]!["results"]!.AsArray())
+        {
+            foreach (var leg in result!["legs"]!.AsArray())
+            {
+                leg!["route"]!.AsObject().Remove("solver");
+                leg["route"]!.AsObject().Remove("latticeDiagnostics");
+            }
+        }
+
+        await File.WriteAllTextAsync(path, root.ToJsonString());
+
+        var loaded = await repository.OpenAsync(plan.Id);
+
+        Assert.All(
+            loaded.Results.SelectMany(result => result.Legs),
+            leg =>
+            {
+                Assert.Equal(RouteSolver.IsochroneBeam, leg.Route!.Solver);
+                Assert.Null(leg.Route.LatticeDiagnostics);
+            });
+    }
+
+    [Fact]
+    public async Task Lattice_solver_and_diagnostics_round_trip()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var diagnostics = new RouteLatticeDiagnostics(100, 20, 300, 4, 2, 1, 3, true);
+        var plan = WithResult(CreatePlan(), RouteSolver.TimeDependentLattice, diagnostics);
+
+        await repository.SaveAsync(plan);
+        var loaded = await repository.OpenAsync(plan.Id);
+
+        Assert.All(
+            loaded.Results.SelectMany(result => result.Legs),
+            leg =>
+            {
+                Assert.Equal(RouteSolver.TimeDependentLattice, leg.Route!.Solver);
+                Assert.Equal(diagnostics, leg.Route.LatticeDiagnostics);
+            });
+    }
+
+    [Fact]
     public async Task Current_position_and_active_leg_round_trip_through_save_and_open()
     {
         using var directory = new TestDirectory();
@@ -235,7 +290,10 @@ public sealed class RoutePlanJsonRepositoryTests
         return plan.MarkSailed(plan.Legs[0].Id);
     }
 
-    private static RoutePlan WithResult(RoutePlan plan)
+    private static RoutePlan WithResult(
+        RoutePlan plan,
+        RouteSolver solver = RouteSolver.IsochroneBeam,
+        RouteLatticeDiagnostics? latticeDiagnostics = null)
     {
         var now = new DateTimeOffset(2026, 8, 1, 18, 0, 0, TimeSpan.Zero);
         var session = new RouteCalculationSession(plan.Id, ForecastModel.NoaaGfs, now)
@@ -259,7 +317,9 @@ public sealed class RoutePlanJsonRepositoryTests
                 ],
                 new RouteDiagnostics(1, 2, 1, 1, TimeSpan.FromSeconds(2)),
                 RouteCompletion.DestinationReached,
-                new RouteLandAvoidance(LandAvoidanceStatus.Applied, Attribution: "Test"));
+                new RouteLandAvoidance(LandAvoidanceStatus.Applied, Attribution: "Test"),
+                solver,
+                latticeDiagnostics);
             return new RouteLegResult(
                 leg.Id,
                 RouteLegOutcomeState.Succeeded,


### PR DESCRIPTION
## Why

Navtool already builds router-lib v0.4, but it could not configure the new routing behavior or use the time-dependent lattice solver. This exposes those capabilities while making the improved beam solver the standard experience and keeping professional controls temporary and opt-in.

## What changed

- Enables a balanced enhanced beam profile by default with destination-bearing and VMG heading augmentation, midpoint wind sampling, and monotone-cubic polar interpolation.
- Adds a session-only **Professional routing features** toggle for solver selection and expert v0.4 tuning; these inputs are intentionally not persisted.
- Adds additive native bridge ABI v6 configuration, solver-specific progress payloads, and cooperative callback cancellation while preserving ABI v1-v5.
- Supports lattice routing end to end through managed workflows, diagnostics, progress labels, and map search-point overlays.
- Persists solver attribution and optional lattice diagnostics in route-plan schema v3 with v1/v2 migration.
- Keeps lattice progress monotonic without assuming temporal ordering between the active search label and globally closest provisional route.

## Validation

- `./scripts/build-native.sh`
- `dotnet test Navtool.sln --no-restore --verbosity minimal`
- `./scripts/run.sh` launch smoke test