### PR TITLE
Synchronize route clicks with wind forecasts

### DIFF
--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -72,6 +72,7 @@ public partial class MainViewModel : ViewModelBase
     private RoutePlanId? _activeCalculationPlanId;
     private long _activeCalculationRevision;
     private long _weatherGeneration;
+    private bool _applyingRoutePointSelection;
     private bool _updatingTimelinePosition;
     private ImmutableArray<RouteLegVisualization> _visualizationLegs = [];
     private string? _selectedStopoverLabel;
@@ -785,19 +786,29 @@ public partial class MainViewModel : ViewModelBase
     public void SelectRoutePoint(RouteMapSelection selection, bool focus = true)
     {
         ArgumentNullException.ThrowIfNull(selection);
-        if (selection.Leg is { } leg)
+        _applyingRoutePointSelection = true;
+        try
         {
-            ActiveRouteModel = leg.Key.Model;
-            SelectLegGeometry(leg.Key);
+            _selectedStopoverLabel = null;
+            ActiveRouteModel = selection.Route.Model;
+            if (selection.Leg is { } leg)
+            {
+                SelectLegGeometry(leg.Key);
+            }
+
+            if (_timeline is not null && _timeline.Model == selection.Route.Model)
+            {
+                SetTimelineUtc(selection.TimelineTimestamp);
+            }
+
+            SelectedRoutePoint = selection;
+        }
+        finally
+        {
+            _applyingRoutePointSelection = false;
         }
 
-        if (_timeline is not null && _timeline.Model == selection.Route.Model)
-        {
-            SetTimelineUtc(selection.TimelineTimestamp);
-        }
-
-        SelectedRoutePoint = selection;
-        _selectedStopoverLabel = null;
+        OnPropertyChanged(nameof(TimelineDisplay));
         UpdateWeatherAvailability();
         if (focus)
         {
@@ -1404,8 +1415,8 @@ public partial class MainViewModel : ViewModelBase
         var selectedLegId = SelectedLeg?.Key.LegId;
         OnPropertyChanged(nameof(IsNoaaRouteActive));
         OnPropertyChanged(nameof(IsEcmwfRouteActive));
-        BuildTimeline(value);
-        if (value is { } model)
+        BuildTimeline(value, initializeSelection: !_applyingRoutePointSelection);
+        if (!_applyingRoutePointSelection && value is { } model)
         {
             var sameLeg = selectedLegId is { } legId
                 ? _visualizationLegs.FirstOrDefault(leg =>
@@ -1423,7 +1434,10 @@ public partial class MainViewModel : ViewModelBase
             }
         }
 
-        UpdateWeatherAvailability();
+        if (!_applyingRoutePointSelection)
+        {
+            UpdateWeatherAvailability();
+        }
     }
 
     private void ApplyPlanWorkflowResult(
@@ -2045,7 +2059,7 @@ public partial class MainViewModel : ViewModelBase
             : string.Join(Environment.NewLine, warnings);
     }
 
-    private void BuildTimeline(ForecastModel? model)
+    private void BuildTimeline(ForecastModel? model, bool initializeSelection = true)
     {
         var legs = model is null
             ? []
@@ -2070,6 +2084,11 @@ public partial class MainViewModel : ViewModelBase
 
         _timeline = SharedRouteTimeline.Create(model!.Value, legs);
         HasTimeline = true;
+        if (!initializeSelection)
+        {
+            return;
+        }
+
         SetTimelineUtc(_timeline.Start);
         ApplyTimelineSelection();
     }

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1641,6 +1641,113 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
+    public async Task RouteClicksSynchronizePopupAndWindOverlayToTheSelectedForecast()
+    {
+        var providers = new[]
+        {
+            new DelegateForecastProvider(
+                ForecastModel.NoaaGfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request))),
+            new DelegateForecastProvider(
+                ForecastModel.EcmwfIfs,
+                (request, _) => ValueTask.FromResult(CreateAcquisition(request)))
+        };
+        var engine = new DelegateRouteEngine((request, forecast, _) =>
+            ValueTask.FromResult(CreateRoute(
+                request,
+                forecast.Request.Model,
+                midpointLatitudeOffset: forecast.Request.Model == ForecastModel.EcmwfIfs ? 4 : -4,
+                trueWindSpeedKnots: forecast.Request.Model == ForecastModel.EcmwfIfs ? 24 : 12,
+                trueWindDirectionDegrees: forecast.Request.Model == ForecastModel.EcmwfIfs ? 210 : 60)));
+        var weatherCalls = new List<(ForecastModel Model, DateTimeOffset ValidAt)>();
+        var weatherCallsGate = new object();
+        var sampler = new DelegateWeatherSampler(
+            (forecast, bounds, _, _, validAt, _) =>
+            {
+                lock (weatherCallsGate)
+                {
+                    weatherCalls.Add((forecast.Request.Model, validAt));
+                }
+
+                return ValueTask.FromResult(
+                    ImmutableArray.Create(CreateWind(bounds, validAt, 8)));
+            });
+        var viewModel = CreateViewModel(
+            new RoutingWorkflow(providers, engine),
+            sampler);
+        var initialViewportCenter = MapProjection.ToMapPoint(new Coordinate(36.5, -56));
+        viewModel.Map.Navigator.SetViewport(new Mapsui.Viewport(
+            initialViewportCenter.X,
+            initialViewportCenter.Y,
+            10_000,
+            0,
+            1280,
+            800));
+        viewModel.UseEcmwf = true;
+        await viewModel.CalculateRoutesAsync();
+        await WaitForAsync(() =>
+        {
+            lock (weatherCallsGate)
+            {
+                return weatherCalls.Count > 0;
+            }
+        });
+
+        foreach (var expectedModel in new[] { ForecastModel.EcmwfIfs, ForecastModel.NoaaGfs })
+        {
+            lock (weatherCallsGate)
+            {
+                weatherCalls.Clear();
+            }
+
+            var route = viewModel.SuccessfulRoutes.Single(candidate => candidate.Model == expectedModel);
+            var clickedPoint = route.Points[1];
+            var worldPoint = MapProjection.ToMapPoint(clickedPoint.Location);
+            viewModel.Map.Navigator.SetViewport(new Mapsui.Viewport(
+                worldPoint.X,
+                worldPoint.Y,
+                10_000,
+                0,
+                1280,
+                800));
+            var screenPoint = viewModel.Map.Navigator.Viewport.WorldToScreen(worldPoint);
+
+            Assert.True(viewModel.InspectRouteAt(
+                worldPoint,
+                new ScreenPoint(screenPoint.X, screenPoint.Y),
+                focus: false));
+            await WaitForAsync(() =>
+            {
+                lock (weatherCallsGate)
+                {
+                    return weatherCalls.Count > 0;
+                }
+            });
+
+            (ForecastModel Model, DateTimeOffset ValidAt)[] calls;
+            lock (weatherCallsGate)
+            {
+                calls = weatherCalls.ToArray();
+            }
+
+            Assert.All(calls, call =>
+            {
+                Assert.Equal(expectedModel, call.Model);
+                Assert.Equal(clickedPoint.Timestamp, call.ValidAt);
+            });
+            Assert.Same(route, viewModel.SelectedRoutePoint!.Route);
+            Assert.Same(clickedPoint, viewModel.SelectedRoutePoint.Point);
+            Assert.Equal(clickedPoint.Timestamp, viewModel.SelectedTimelineUtc);
+            Assert.Equal(expectedModel, viewModel.ActiveRouteModel);
+            Assert.Equal(expectedModel, viewModel.ActiveWeatherModel);
+            Assert.Contains(
+                $"{clickedPoint.TrueWindSpeedKnots:0.0} kt @ " +
+                $"{clickedPoint.TrueWindDirectionDegrees:0}°",
+                viewModel.SelectedRouteDetails);
+        }
+    }
+
+    [Fact]
     public async Task WeatherRefreshSuppressesStaleSamples()
     {
         var provider = new DelegateForecastProvider(
@@ -1787,7 +1894,9 @@ public sealed class MainViewModelWorkflowTests
         ForecastModel model,
         int stepHours = 3,
         RouteLandAvoidance? landAvoidance = null,
-        double midpointLatitudeOffset = 0)
+        double midpointLatitudeOffset = 0,
+        double trueWindSpeedKnots = 16,
+        double trueWindDirectionDegrees = 120)
     {
         var midpoint = new Coordinate(
             ((request.Origin.Latitude + request.Destination.Latitude) / 2) +
@@ -1798,9 +1907,24 @@ public sealed class MainViewModelWorkflowTests
             model,
             new[]
             {
-                CreatePoint(request.Origin, request.DepartureTime, 0),
-                CreatePoint(midpoint, request.DepartureTime.AddHours(stepHours), 50),
-                CreatePoint(request.Destination, request.DepartureTime.AddHours(stepHours * 2), 100)
+                CreatePoint(
+                    request.Origin,
+                    request.DepartureTime,
+                    0,
+                    trueWindSpeedKnots,
+                    trueWindDirectionDegrees),
+                CreatePoint(
+                    midpoint,
+                    request.DepartureTime.AddHours(stepHours),
+                    50,
+                    trueWindSpeedKnots,
+                    trueWindDirectionDegrees),
+                CreatePoint(
+                    request.Destination,
+                    request.DepartureTime.AddHours(stepHours * 2),
+                    100,
+                    trueWindSpeedKnots,
+                    trueWindDirectionDegrees)
             },
             new RouteDiagnostics(1, 2, 1, 3),
             landAvoidance);
@@ -1810,14 +1934,16 @@ public sealed class MainViewModelWorkflowTests
     private static RoutePoint CreatePoint(
         Coordinate coordinate,
         DateTimeOffset timestamp,
-        double distance) =>
+        double distance,
+        double trueWindSpeedKnots = 16,
+        double trueWindDirectionDegrees = 120) =>
         new(
             coordinate,
             timestamp,
             headingDegrees: 75,
             boatSpeedKnots: 7.5,
-            trueWindSpeedKnots: 16,
-            trueWindDirectionDegrees: 120,
+            trueWindSpeedKnots,
+            trueWindDirectionDegrees,
             cumulativeDistanceNauticalMiles: distance);
 
     private static ViewportWindSample CreateWind(


### PR DESCRIPTION
Selecting a NOAA or ECMWF route point could briefly apply a default timeline selection before the clicked point, allowing popup telemetry and map wind arrows to become out of sync.

This change makes route-point selection transactional: the route model, exact timeline point, selected leg, popup data, and compatible weather model are finalized before refreshing the map-wide wind overlay. Existing cancellation and generation checks continue to prevent stale forecast samples from replacing the newly selected model.

Regression coverage clicks distinct NOAA and ECMWF routes in both directions and verifies the selected route point, popup-facing wind values, active model, forecast timestamp, and weather sampler stay aligned.

**Validation**
- `dotnet test tests/Navtool.App.Tests/Navtool.App.Tests.csproj --no-restore`
- `./scripts/run.sh` native bridge and application smoke check