### PR TITLE
Center picker labels and add one-shot weather refresh toggle

### DIFF
--- a/src/Navtool.App/Services/RadialMenuPlacement.cs
+++ b/src/Navtool.App/Services/RadialMenuPlacement.cs
@@ -8,7 +8,7 @@ public enum RadialMenuAction
     SetStart,
     SetDestination,
     CalculateRoute,
-    Inspect
+    RefreshWeather
 }
 
 public enum RadialMenuLayout
@@ -60,9 +60,9 @@ public static class RadialMenuPlacement
     private static readonly ImmutableArray<RadialMenuAction> ActionOrder =
     [
         RadialMenuAction.SetStart,
-        RadialMenuAction.SetDestination,
         RadialMenuAction.CalculateRoute,
-        RadialMenuAction.Inspect
+        RadialMenuAction.SetDestination,
+        RadialMenuAction.RefreshWeather
     ];
 
     public static RadialMenuPlacementResult Calculate(

--- a/src/Navtool.App/Themes/AppStyles.axaml
+++ b/src/Navtool.App/Themes/AppStyles.axaml
@@ -36,6 +36,9 @@
 
         <x:Double x:Key="DatePickerThemeMinWidth">0</x:Double>
         <x:Double x:Key="TimePickerThemeMinWidth">0</x:Double>
+        <Thickness x:Key="DatePickerHostPadding">0</Thickness>
+        <Thickness x:Key="DatePickerHostMonthPadding">0</Thickness>
+        <Thickness x:Key="TimePickerHostPadding">0</Thickness>
 
         <StaticResource x:Key="ButtonForeground" ResourceKey="AppControlForegroundBrush" />
         <StaticResource x:Key="ButtonForegroundPointerOver" ResourceKey="AppControlForegroundBrush" />
@@ -427,12 +430,18 @@
     </Style>
     <Style Selector="DatePicker /template/ Button#PART_FlyoutButton TextBlock">
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="TextAlignment" Value="Center" />
     </Style>
     <Style Selector="DatePicker:disabled /template/ Button#PART_FlyoutButton TextBlock">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />
     </Style>
     <Style Selector="TimePicker /template/ Button#PART_FlyoutButton TextBlock">
         <Setter Property="Foreground" Value="{DynamicResource TextPrimaryColor}" />
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="TextAlignment" Value="Center" />
     </Style>
     <Style Selector="TimePicker:disabled /template/ Button#PART_FlyoutButton TextBlock">
         <Setter Property="Foreground" Value="{DynamicResource DisabledTextColor}" />

--- a/src/Navtool.App/ViewModels/MainViewModel.cs
+++ b/src/Navtool.App/ViewModels/MainViewModel.cs
@@ -974,6 +974,10 @@ public partial class MainViewModel : ViewModelBase
         InitializeCalculationPresentation(request, planRequest);
         WarningMessage = departureWarning;
         IsCalculating = true;
+        if (request.RefreshPolicy == ForecastRefreshPolicy.LatestAvailable)
+        {
+            UseNewestWeatherData = false;
+        }
         ProgressFraction = 0;
         StatusMessage = "Starting forecast acquisition and route calculations…";
         _mapLayers.ClearCalculationOverlays();

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -911,14 +911,18 @@
                                TextAlignment="Center"
                                LineHeight="16" />
                 </Button>
-                <Button x:Name="InspectRadialButton"
-                        Classes="radial-action"
-                        Click="OnInspectRadialClicked"
-                        ToolTip.Tip="Inspect the captured route point"
-                        AutomationProperties.Name="Inspect route point"
-                        Content="Inspect"
-                        HorizontalContentAlignment="Center"
-                        VerticalContentAlignment="Center" />
+                <ToggleButton x:Name="RefreshWeatherRadialToggle"
+                              Classes="radial-action"
+                              IsChecked="{Binding UseNewestWeatherData, Mode=TwoWay}"
+                              IsEnabled="{Binding IsDownloadForecast}"
+                              ToolTip.Tip="Download the newest weather data on the next calculation"
+                              AutomationProperties.Name="Refresh weather on next calculation"
+                              HorizontalContentAlignment="Center"
+                              VerticalContentAlignment="Center">
+                    <TextBlock Text="Refresh&#x0a;weather"
+                               TextAlignment="Center"
+                               LineHeight="16" />
+                </ToggleButton>
             </Canvas>
         </Grid>
 

--- a/src/Navtool.App/Views/MainWindow.axaml.cs
+++ b/src/Navtool.App/Views/MainWindow.axaml.cs
@@ -60,7 +60,7 @@ public partial class MainWindow : Window
     private Button? _setStartRadialButton;
     private Button? _setDestinationRadialButton;
     private Button? _calculateRadialButton;
-    private Button? _inspectRadialButton;
+    private ToggleButton? _refreshWeatherRadialToggle;
     private Line? _radialConnector;
     private Ellipse? _radialAnchor;
     private Canvas? _routeTelemetryLayer;
@@ -72,7 +72,6 @@ public partial class MainWindow : Window
     private MPoint? _routeTelemetryProjection;
     private ScreenPoint? _lastPointerPosition;
     private MPoint? _capturedWorldPoint;
-    private RouteMapSelection? _capturedRouteSelection;
     private DrawerSide? _lastOpenedDrawer;
 
     public MainWindow() : this(GetDefaultThemeService())
@@ -129,7 +128,8 @@ public partial class MainWindow : Window
         _setStartRadialButton = this.FindControl<Button>("SetStartRadialButton")!;
         _setDestinationRadialButton = this.FindControl<Button>("SetDestinationRadialButton")!;
         _calculateRadialButton = this.FindControl<Button>("CalculateRadialButton")!;
-        _inspectRadialButton = this.FindControl<Button>("InspectRadialButton")!;
+        _refreshWeatherRadialToggle =
+            this.FindControl<ToggleButton>("RefreshWeatherRadialToggle")!;
         _radialConnector = this.FindControl<Line>("RadialConnector")!;
         _radialAnchor = this.FindControl<Ellipse>("RadialAnchor")!;
         _routeTelemetryLayer = this.FindControl<Canvas>("RouteTelemetryLayer")!;
@@ -255,7 +255,9 @@ public partial class MainWindow : Window
 
     private void OnWindowPointerPressed(object? sender, PointerPressedEventArgs e)
     {
-        if (!IsRadialMenuOpen || IsRadialActionSource(e.Source))
+        if (!IsRadialMenuOpen ||
+            IsRadialActionSource(e.Source) ||
+            IsRadialActionPointer(e))
         {
             return;
         }
@@ -266,20 +268,36 @@ public partial class MainWindow : Window
 
     private bool IsRadialActionSource(object? source)
     {
-        if (source is Button button)
+        if (source is not Visual visual)
         {
-            return button == _setStartRadialButton ||
-                   button == _setDestinationRadialButton ||
-                   button == _calculateRadialButton ||
-                   button == _inspectRadialButton;
+            return false;
         }
 
-        return source is Visual visual &&
-               visual.GetVisualAncestors().OfType<Button>().Any(button =>
-                   button == _setStartRadialButton ||
-                   button == _setDestinationRadialButton ||
-                   button == _calculateRadialButton ||
-                   button == _inspectRadialButton);
+        return IsRadialAction(visual) ||
+               visual.GetVisualAncestors().Any(IsRadialAction);
+    }
+
+    private bool IsRadialAction(Visual visual) =>
+        visual == _setStartRadialButton ||
+        visual == _setDestinationRadialButton ||
+        visual == _calculateRadialButton ||
+        visual == _refreshWeatherRadialToggle;
+
+    private bool IsRadialActionPointer(PointerEventArgs e)
+    {
+        if (_radialMenuLayer is null)
+        {
+            return false;
+        }
+
+        var position = e.GetPosition(_radialMenuLayer);
+        return new Control?[]
+        {
+            _setStartRadialButton,
+            _setDestinationRadialButton,
+            _calculateRadialButton,
+            _refreshWeatherRadialToggle
+        }.Any(control => control?.Bounds.Contains(position) is true);
     }
 
     private void OnWindowKeyDown(object? sender, KeyEventArgs e)
@@ -337,7 +355,7 @@ public partial class MainWindow : Window
             _setStartRadialButton is null ||
             _setDestinationRadialButton is null ||
             _calculateRadialButton is null ||
-            _inspectRadialButton is null ||
+            _refreshWeatherRadialToggle is null ||
             _radialConnector is null ||
             _radialAnchor is null ||
             DataContext is not MainViewModel viewModel ||
@@ -349,8 +367,6 @@ public partial class MainWindow : Window
 
         _lastPointerPosition = screenPoint;
         _capturedWorldPoint = worldPoint;
-        _capturedRouteSelection = viewModel.FindRouteAt(worldPoint, screenPoint);
-        _inspectRadialButton.IsEnabled = _capturedRouteSelection is not null;
 
         var placement = RadialMenuPlacement.Calculate(
             new ScreenRect(0, 0, _mapControl.Bounds.Width, _mapControl.Bounds.Height),
@@ -368,8 +384,8 @@ public partial class MainWindow : Window
             _calculateRadialButton,
             GetActionBounds(placement, RadialMenuAction.CalculateRoute));
         PositionRadialAction(
-            _inspectRadialButton,
-            GetActionBounds(placement, RadialMenuAction.Inspect));
+            _refreshWeatherRadialToggle,
+            GetActionBounds(placement, RadialMenuAction.RefreshWeather));
         ApplyConnector(placement);
         _radialMenuLayer.IsVisible = true;
         _setStartRadialButton.Focus();
@@ -432,18 +448,6 @@ public partial class MainWindow : Window
         CloseRadialMenu();
     }
 
-    private void OnInspectRadialClicked(object? sender, RoutedEventArgs e)
-    {
-        e.Handled = true;
-        if (_capturedRouteSelection is { } selection &&
-            DataContext is MainViewModel viewModel)
-        {
-            viewModel.SelectRoutePoint(selection);
-        }
-
-        CloseRadialMenu();
-    }
-
     private void OnCalculateRadialClicked(object? sender, RoutedEventArgs e)
     {
         CloseRadialMenu();
@@ -458,7 +462,6 @@ public partial class MainWindow : Window
 
         _radialMenuLayer.IsVisible = false;
         _capturedWorldPoint = null;
-        _capturedRouteSelection = null;
         _mapControl?.Focus();
     }
 

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Avalonia.Headless.XUnit;
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Navtool.App.Models;
@@ -332,7 +333,7 @@ public sealed class MainViewModelWorkflowTests
     }
 
     [Fact]
-    public async Task Newest_weather_control_propagates_refresh_policy()
+    public async Task Newest_weather_control_is_consumed_by_the_next_calculation()
     {
         ForecastRefreshPolicy? observedPolicy = null;
         var noaa = new DelegateForecastProvider(
@@ -353,6 +354,7 @@ public sealed class MainViewModelWorkflowTests
         await viewModel.CalculateRoutesAsync();
 
         Assert.Equal(ForecastRefreshPolicy.LatestAvailable, observedPolicy);
+        Assert.False(viewModel.UseNewestWeatherData);
     }
 
     [Fact]
@@ -1354,7 +1356,7 @@ public sealed class MainViewModelWorkflowTests
         Assert.False(viewModel.IsCalculating);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public async Task CalculationProgressCombinesConcurrentModelStages()
     {
         var ecmwfForecastStarted = new TaskCompletionSource(

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
 using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Mapsui.Extensions;
@@ -201,7 +202,8 @@ public sealed class MainWindowLayoutTests
                 Assert.IsType<Button>(window.FindControl<Button>("SetStartRadialButton")),
                 Assert.IsType<Button>(window.FindControl<Button>("SetDestinationRadialButton")),
                 Assert.IsType<Button>(window.FindControl<Button>("CalculateRadialButton")),
-                Assert.IsType<Button>(window.FindControl<Button>("InspectRadialButton"))
+                Assert.IsType<ToggleButton>(
+                    window.FindControl<ToggleButton>("RefreshWeatherRadialToggle"))
             };
             Assert.Equal(buttons, layer.Children.OfType<Button>());
             Assert.All(buttons, button =>
@@ -215,10 +217,30 @@ public sealed class MainWindowLayoutTests
             var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
             Assert.Same(viewModel.ForceRecalculateCommand, buttons[2].Command);
             Assert.True(buttons[2].IsEffectivelyEnabled);
-            Assert.False(buttons[3].IsEnabled);
+            var refreshWeather = Assert.IsType<ToggleButton>(buttons[3]);
+            Assert.True(refreshWeather.IsEffectivelyEnabled);
+            Assert.False(refreshWeather.IsChecked);
+            var refreshPoint = refreshWeather.TranslatePoint(
+                new Point(refreshWeather.Bounds.Width / 2, refreshWeather.Bounds.Height / 2),
+                window);
+            Assert.NotNull(refreshPoint);
+            window.MouseDown(refreshPoint.Value, MouseButton.Left, RawInputModifiers.None);
+            window.MouseUp(refreshPoint.Value, MouseButton.Left, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(window.IsRadialMenuOpen);
+            refreshWeather.IsChecked = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(refreshWeather.IsChecked);
+            Assert.True(viewModel.UseNewestWeatherData);
+            viewModel.UseNewestWeatherData = false;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(refreshWeather.IsChecked);
+            Assert.True(Canvas.GetLeft(buttons[2]) > Canvas.GetLeft(buttons[0]));
+            Assert.True(Canvas.GetTop(buttons[1]) > Canvas.GetTop(buttons[2]));
             viewModel.ForecastInputMode = ForecastInputMode.LocalFile;
             Dispatcher.UIThread.RunJobs();
             Assert.False(buttons[2].IsEffectivelyEnabled);
+            Assert.False(refreshWeather.IsEffectivelyEnabled);
             Assert.Equal(
                 HorizontalAlignment.Center,
                 Assert.IsType<ToggleButton>(
@@ -727,6 +749,15 @@ public sealed class MainWindowLayoutTests
                 timePicker,
                 "PART_HourTextBlock",
                 "PART_MinuteTextBlock");
+            AssertPickerTextIsCentered(
+                datePicker,
+                "PART_DayTextBlock",
+                "PART_MonthTextBlock",
+                "PART_YearTextBlock");
+            AssertPickerTextIsCentered(
+                timePicker,
+                "PART_HourTextBlock",
+                "PART_MinuteTextBlock");
         }
         finally
         {
@@ -805,6 +836,36 @@ public sealed class MainWindowLayoutTests
             Assert.True(
                 origin.Value.X + part.Bounds.Width <= flyoutButton.Bounds.Width + 0.5,
                 $"{part.Name} must end inside the picker.");
+        }
+    }
+
+    private static void AssertPickerTextIsCentered(
+        TemplatedControl picker,
+        params string[] partNames)
+    {
+        var descendants = picker.GetVisualDescendants().ToArray();
+        var flyoutButton = descendants
+            .OfType<Button>()
+            .Single(control => control.Name == "PART_FlyoutButton");
+        var textParts = descendants
+            .OfType<TextBlock>()
+            .Where(part => partNames.Contains(part.Name))
+            .ToArray();
+
+        Assert.Equal(partNames.Length, textParts.Length);
+        foreach (var part in textParts)
+        {
+            Assert.Equal(HorizontalAlignment.Center, part.HorizontalAlignment);
+            Assert.Equal(VerticalAlignment.Center, part.VerticalAlignment);
+            if (picker is TimePicker)
+            {
+                Assert.Equal(TextAlignment.Center, part.TextAlignment);
+            }
+            Assert.Equal(default, part.Padding);
+            var origin = part.TranslatePoint(default, flyoutButton);
+            Assert.NotNull(origin);
+            var center = origin.Value.Y + (part.Bounds.Height / 2);
+            Assert.InRange(Math.Abs(center - (flyoutButton.Bounds.Height / 2)), 0, 0.5);
         }
     }
 

--- a/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
+++ b/tests/Navtool.App.Tests/RadialMenuPlacementTests.cs
@@ -21,9 +21,9 @@ public sealed class RadialMenuPlacementTests
         Assert.Equal(
             [
                 RadialMenuAction.SetStart,
-                RadialMenuAction.SetDestination,
                 RadialMenuAction.CalculateRoute,
-                RadialMenuAction.Inspect
+                RadialMenuAction.SetDestination,
+                RadialMenuAction.RefreshWeather
             ],
             result.Actions.Select(action => action.Action));
         Assert.True(result.Actions[0].Center.Y < result.Center.Y);


### PR DESCRIPTION
PR #58 landed before the unit test suite finished, and it left `CalculationProgressCombinesConcurrentModelStages` failing on `main`. This PR fixes that test and picks up the follow-up UI polish requests that came out of reviewing the merged work: picker segment labels that still were not centered, a radial menu whose two most-used actions sat in awkward positions, and a radial Inspect action nobody used.

### Test fix

The progress test raced because `MainViewModel` posts progress updates through the UI dispatcher, but the test ran as a plain `[Fact]` with no synchronization context, so `CalculationStageLabel` updates arrived out of order. Switching it to `[AvaloniaFact]` gives it a real dispatcher and makes the ordering deterministic. Stress-ran 50x clean.

### Centered picker labels

The date and time picker segment text (day / month / year, hour / minute) was left-biased because the Fluent template applies padding through the `DatePickerHostPadding`, `DatePickerHostMonthPadding`, and `TimePickerHostPadding` dynamic resources. A `<Setter Property="Padding" .../>` silently loses to the template's dynamic resource lookup, so the only way to zero it is to override those resource keys in `Styles.Resources`. This is the same pattern as the `*ThemeMinWidth` overrides from #58, and worth knowing about for any future picker styling.

### Radial menu changes

`RadialMenuPlacement.ActionOrder` is the single source of truth for radial geometry, so swapping Set destination and Calculate route is a one-line change there plus a test expectation update.

The Inspect action becomes a Refresh weather toggle. Rather than introducing new state, it binds two-way to the existing `MainViewModel.UseNewestWeatherData` property, which already maps to `ForecastRefreshPolicy.LatestAvailable`. `CalculateRoutesAsync` clears the flag once it commits to the refresh, so the toggle visually resets itself after the refresh is consumed. It is disabled unless forecasts are being downloaded.

One non-obvious fix came out of live testing: clicking the new ToggleButton was dismissing the radial menu. The dismissal check only matched `Button`, and in the headless harness `PointerPressedEvent` tunneling reports the *window* as `e.Source` rather than the clicked control, so an ancestry check alone cannot protect radial controls. The fix hit-tests the pointer position against each radial control's canvas bounds instead.

### Verification

Full Release suite passes 142/142. UI changes were confirmed visually via `./scripts/run.sh` with the bridge preflight succeeding and no `Routing engine unavailable` banner.

Worth a careful look: the radial toggle test asserts click-does-not-dismiss separately from the binding behavior, because synthetic headless clicks did not reliably flip `IsChecked`. That is a harness limitation, not a product bug - the live app click behaves correctly.