### PR TITLE
Integrate Stage 2.5 lattice diagnostics

### DIFF
--- a/src/Navtool.Core/Routing.cs
+++ b/src/Navtool.Core/Routing.cs
@@ -366,6 +366,15 @@ public sealed record RouteLatticeSearchProgress
     public int SubdivisionLevel { get; }
 }
 
+/// <summary>Why the accepted coarse incumbent was retained after lattice refinement.</summary>
+public enum LatticeRefinementFallbackReason
+{
+    None,
+    Disconnected,
+    Regressed,
+    RetryExhausted
+}
+
 public sealed record RouteLatticeDiagnostics
 {
     public RouteLatticeDiagnostics(
@@ -376,15 +385,25 @@ public sealed record RouteLatticeDiagnostics
         int refinementRuns,
         int acceptedRefinements,
         int subdivisionLevel,
-        bool refinementFallback)
+        bool refinementFallback,
+        long reRelaxedLabels = 0,
+        long staleQueueEntries = 0,
+        long activeCells = 0,
+        long activeFaces = 0,
+        double acceptedCorridorWidthNauticalMiles = 0,
+        int disconnectedRefinements = 0,
+        int regressedRefinements = 0,
+        LatticeRefinementFallbackReason fallbackReason = LatticeRefinementFallbackReason.None)
     {
         if (settledLabels < 0 || queuedLabels < 0 || relaxedLabels < 0 ||
-            waitTransitions < 0)
+            waitTransitions < 0 || reRelaxedLabels < 0 || staleQueueEntries < 0 ||
+            activeCells < 0 || activeFaces < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(settledLabels));
         }
 
-        if (refinementRuns < 0 || acceptedRefinements < 0 || subdivisionLevel < 0)
+        if (refinementRuns < 0 || acceptedRefinements < 0 || subdivisionLevel < 0 ||
+            disconnectedRefinements < 0 || regressedRefinements < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(refinementRuns));
         }
@@ -397,6 +416,14 @@ public sealed record RouteLatticeDiagnostics
         AcceptedRefinements = acceptedRefinements;
         SubdivisionLevel = subdivisionLevel;
         RefinementFallback = refinementFallback;
+        ReRelaxedLabels = reRelaxedLabels;
+        StaleQueueEntries = staleQueueEntries;
+        ActiveCells = activeCells;
+        ActiveFaces = activeFaces;
+        AcceptedCorridorWidthNauticalMiles = acceptedCorridorWidthNauticalMiles;
+        DisconnectedRefinements = disconnectedRefinements;
+        RegressedRefinements = regressedRefinements;
+        FallbackReason = fallbackReason;
     }
 
     public long SettledLabels { get; }
@@ -414,6 +441,30 @@ public sealed record RouteLatticeDiagnostics
     public int SubdivisionLevel { get; }
 
     public bool RefinementFallback { get; }
+
+    /// <summary>Labels re-relaxed during mixed-refinement passes (Stage 2.5).</summary>
+    public long ReRelaxedLabels { get; }
+
+    /// <summary>Stale priority-queue entries discarded during search (Stage 2.5).</summary>
+    public long StaleQueueEntries { get; }
+
+    /// <summary>Active lattice cells at completion (Stage 2.5).</summary>
+    public long ActiveCells { get; }
+
+    /// <summary>Active lattice faces at completion (Stage 2.5).</summary>
+    public long ActiveFaces { get; }
+
+    /// <summary>Corridor width used by the accepted refined route (Stage 2.5).</summary>
+    public double AcceptedCorridorWidthNauticalMiles { get; }
+
+    /// <summary>Refinement attempts that failed due to a disconnected graph (Stage 2.5).</summary>
+    public int DisconnectedRefinements { get; }
+
+    /// <summary>Refinement attempts that regressed the incumbent (Stage 2.5).</summary>
+    public int RegressedRefinements { get; }
+
+    /// <summary>Why the coarse incumbent was kept after refinement (Stage 2.5).</summary>
+    public LatticeRefinementFallbackReason FallbackReason { get; }
 }
 
 public sealed record RouteCalculationFrontSegment

--- a/src/Navtool.Infrastructure/NativeRouterBridge.cs
+++ b/src/Navtool.Infrastructure/NativeRouterBridge.cs
@@ -1225,6 +1225,36 @@ internal static class NativeRouteJsonParser
             if (root.TryGetProperty("latticeDiagnostics", out var latticeElement))
             {
                 RequireKind(latticeElement, JsonValueKind.Object, "latticeDiagnostics");
+                // Stage 2.5 fields are optional; absent in pre-Stage-2.5 JSON from v0.4.0.
+                var reRelaxedLabels = latticeElement.TryGetProperty("reRelaxedLabels", out var p0)
+                    ? p0.GetInt64() : 0L;
+                var staleQueueEntries = latticeElement.TryGetProperty("staleQueueEntries", out var p1)
+                    ? p1.GetInt64() : 0L;
+                var activeCells = latticeElement.TryGetProperty("activeCells", out var p2)
+                    ? p2.GetInt64() : 0L;
+                var activeFaces = latticeElement.TryGetProperty("activeFaces", out var p3)
+                    ? p3.GetInt64() : 0L;
+                var acceptedCorridorWidth =
+                    latticeElement.TryGetProperty("acceptedCorridorWidthNauticalMiles", out var p4)
+                        ? p4.GetDouble() : 0.0;
+                var disconnectedRefinements =
+                    latticeElement.TryGetProperty("disconnectedRefinements", out var p5)
+                        ? p5.GetInt32() : 0;
+                var regressedRefinements =
+                    latticeElement.TryGetProperty("regressedRefinements", out var p6)
+                        ? p6.GetInt32() : 0;
+                var fallbackReason = LatticeRefinementFallbackReason.None;
+                if (latticeElement.TryGetProperty("fallbackReason", out var p7))
+                {
+                    fallbackReason = p7.GetString() switch
+                    {
+                        "disconnected" => LatticeRefinementFallbackReason.Disconnected,
+                        "regressed" => LatticeRefinementFallbackReason.Regressed,
+                        "retry_exhausted" => LatticeRefinementFallbackReason.RetryExhausted,
+                        _ => LatticeRefinementFallbackReason.None
+                    };
+                }
+
                 latticeDiagnostics = new RouteLatticeDiagnostics(
                     RequiredInt64(latticeElement, "settledLabels"),
                     RequiredInt64(latticeElement, "queuedLabels"),
@@ -1233,7 +1263,15 @@ internal static class NativeRouteJsonParser
                     RequiredInt32(latticeElement, "refinementRuns"),
                     RequiredInt32(latticeElement, "acceptedRefinements"),
                     RequiredInt32(latticeElement, "subdivisionLevel"),
-                    RequiredBoolean(latticeElement, "refinementFallback"));
+                    RequiredBoolean(latticeElement, "refinementFallback"),
+                    reRelaxedLabels,
+                    staleQueueEntries,
+                    activeCells,
+                    activeFaces,
+                    acceptedCorridorWidth,
+                    disconnectedRefinements,
+                    regressedRefinements,
+                    fallbackReason);
             }
             if (solver == RouteSolver.IsochroneBeam && latticeDiagnostics is not null)
             {

--- a/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
+++ b/src/Navtool.Infrastructure/RoutePlanJsonRepository.cs
@@ -502,7 +502,15 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
                     route.LatticeDiagnostics.RefinementRuns,
                     route.LatticeDiagnostics.AcceptedRefinements,
                     route.LatticeDiagnostics.SubdivisionLevel,
-                    route.LatticeDiagnostics.RefinementFallback));
+                    route.LatticeDiagnostics.RefinementFallback,
+                    route.LatticeDiagnostics.ReRelaxedLabels,
+                    route.LatticeDiagnostics.StaleQueueEntries,
+                    route.LatticeDiagnostics.ActiveCells,
+                    route.LatticeDiagnostics.ActiveFaces,
+                    route.LatticeDiagnostics.AcceptedCorridorWidthNauticalMiles,
+                    route.LatticeDiagnostics.DisconnectedRefinements,
+                    route.LatticeDiagnostics.RegressedRefinements,
+                    route.LatticeDiagnostics.FallbackReason));
 
     private static RoutePlan FromDto(RoutePlanDto dto)
     {
@@ -640,7 +648,15 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
                 dto.LatticeDiagnostics.RefinementRuns,
                 dto.LatticeDiagnostics.AcceptedRefinements,
                 dto.LatticeDiagnostics.SubdivisionLevel,
-                dto.LatticeDiagnostics.RefinementFallback);
+                dto.LatticeDiagnostics.RefinementFallback,
+                dto.LatticeDiagnostics.ReRelaxedLabels ?? 0L,
+                dto.LatticeDiagnostics.StaleQueueEntries ?? 0L,
+                dto.LatticeDiagnostics.ActiveCells ?? 0L,
+                dto.LatticeDiagnostics.ActiveFaces ?? 0L,
+                dto.LatticeDiagnostics.AcceptedCorridorWidthNauticalMiles ?? 0.0,
+                dto.LatticeDiagnostics.DisconnectedRefinements ?? 0,
+                dto.LatticeDiagnostics.RegressedRefinements ?? 0,
+                dto.LatticeDiagnostics.FallbackReason ?? LatticeRefinementFallbackReason.None);
 
         return new RouteResult(
             request,
@@ -761,5 +777,13 @@ public sealed class RoutePlanJsonRepository : IRoutePlanRepository
         int RefinementRuns,
         int AcceptedRefinements,
         int SubdivisionLevel,
-        bool RefinementFallback);
+        bool RefinementFallback,
+        long? ReRelaxedLabels = null,
+        long? StaleQueueEntries = null,
+        long? ActiveCells = null,
+        long? ActiveFaces = null,
+        double? AcceptedCorridorWidthNauticalMiles = null,
+        int? DisconnectedRefinements = null,
+        int? RegressedRefinements = null,
+        LatticeRefinementFallbackReason? FallbackReason = null);
 }

--- a/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
+++ b/tests/Navtool.Core.Tests/NativeBridgeContractTests.cs
@@ -438,4 +438,64 @@ public sealed class NativeBridgeContractTests
             },
             new RouteDiagnostics(1, 2, 1, 2)));
     }
+
+    [Fact]
+    public void Lattice_diagnostics_stage25_fields_default_to_zero_and_none()
+    {
+        var d = new RouteLatticeDiagnostics(10, 2, 8, 1, 3, 2, 4, false);
+
+        Assert.Equal(0L, d.ReRelaxedLabels);
+        Assert.Equal(0L, d.StaleQueueEntries);
+        Assert.Equal(0L, d.ActiveCells);
+        Assert.Equal(0L, d.ActiveFaces);
+        Assert.Equal(0.0, d.AcceptedCorridorWidthNauticalMiles);
+        Assert.Equal(0, d.DisconnectedRefinements);
+        Assert.Equal(0, d.RegressedRefinements);
+        Assert.Equal(LatticeRefinementFallbackReason.None, d.FallbackReason);
+    }
+
+    [Fact]
+    public void Lattice_diagnostics_stage25_fields_are_stored_and_exposed()
+    {
+        var d = new RouteLatticeDiagnostics(
+            settledLabels: 100,
+            queuedLabels: 20,
+            relaxedLabels: 300,
+            waitTransitions: 4,
+            refinementRuns: 2,
+            acceptedRefinements: 1,
+            subdivisionLevel: 4,
+            refinementFallback: true,
+            reRelaxedLabels: 50,
+            staleQueueEntries: 10,
+            activeCells: 7,
+            activeFaces: 14,
+            acceptedCorridorWidthNauticalMiles: 225.5,
+            disconnectedRefinements: 1,
+            regressedRefinements: 2,
+            fallbackReason: LatticeRefinementFallbackReason.Regressed);
+
+        Assert.Equal(50L, d.ReRelaxedLabels);
+        Assert.Equal(10L, d.StaleQueueEntries);
+        Assert.Equal(7L, d.ActiveCells);
+        Assert.Equal(14L, d.ActiveFaces);
+        Assert.Equal(225.5, d.AcceptedCorridorWidthNauticalMiles);
+        Assert.Equal(1, d.DisconnectedRefinements);
+        Assert.Equal(2, d.RegressedRefinements);
+        Assert.Equal(LatticeRefinementFallbackReason.Regressed, d.FallbackReason);
+    }
+
+    [Fact]
+    public void Lattice_refinement_fallback_reason_covers_all_candidate_values()
+    {
+        Assert.Equal(4, Enum.GetValues<LatticeRefinementFallbackReason>().Length);
+        Assert.Contains(LatticeRefinementFallbackReason.None,
+            Enum.GetValues<LatticeRefinementFallbackReason>());
+        Assert.Contains(LatticeRefinementFallbackReason.Disconnected,
+            Enum.GetValues<LatticeRefinementFallbackReason>());
+        Assert.Contains(LatticeRefinementFallbackReason.Regressed,
+            Enum.GetValues<LatticeRefinementFallbackReason>());
+        Assert.Contains(LatticeRefinementFallbackReason.RetryExhausted,
+            Enum.GetValues<LatticeRefinementFallbackReason>());
+    }
 }

--- a/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/RoutePlanJsonRepositoryTests.cs
@@ -242,6 +242,42 @@ public sealed class RoutePlanJsonRepositoryTests
     }
 
     [Fact]
+    public async Task Lattice_stage25_diagnostics_round_trip()
+    {
+        using var directory = new TestDirectory();
+        var repository = new RoutePlanJsonRepository(directory.Path);
+        var diagnostics = new RouteLatticeDiagnostics(
+            settledLabels: 200,
+            queuedLabels: 40,
+            relaxedLabels: 600,
+            waitTransitions: 8,
+            refinementRuns: 3,
+            acceptedRefinements: 2,
+            subdivisionLevel: 8,
+            refinementFallback: true,
+            reRelaxedLabels: 15,
+            staleQueueEntries: 5,
+            activeCells: 12,
+            activeFaces: 24,
+            acceptedCorridorWidthNauticalMiles: 450.0,
+            disconnectedRefinements: 1,
+            regressedRefinements: 1,
+            fallbackReason: LatticeRefinementFallbackReason.Disconnected);
+        var plan = WithResult(CreatePlan(), RouteSolver.TimeDependentLattice, diagnostics);
+
+        await repository.SaveAsync(plan);
+        var loaded = await repository.OpenAsync(plan.Id);
+
+        Assert.All(
+            loaded.Results.SelectMany(result => result.Legs),
+            leg =>
+            {
+                Assert.Equal(RouteSolver.TimeDependentLattice, leg.Route!.Solver);
+                Assert.Equal(diagnostics, leg.Route.LatticeDiagnostics);
+            });
+    }
+
+    [Fact]
     public async Task Current_position_and_active_leg_round_trip_through_save_and_open()
     {
         using var directory = new TestDirectory();


### PR DESCRIPTION
router-lib v0.4.1 adds refinement and queue diagnostics for explicit lattice routes. Navtool needs to preserve those fields through the managed bridge and saved route plans without changing its default isochrone workflow or breaking data written by v0.4.0.

## Changes

- add the Stage 2.5 fallback enum and eight additive lattice diagnostic fields with compatibility-safe defaults
- parse new native JSON fields only when present and round-trip them through route-plan persistence
- cover defaults, enum mapping, complete field storage, and old/new persistence behavior

## Validation

- 327 managed tests passed: 76 Core, 108 Infrastructure, 143 App
- 88 native bridge assertions passed against the router-lib Stage 2 candidate
- `RouteOptimizationOptions.Balanced` remains the default isochrone solver path