### PR TITLE
Pin router-lib v0.4.1 and verify opt-in lattice UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ bridge launch guidance and automated validation.
   augmentation, midpoint wind sampling, and monotone-cubic polar interpolation
   by default. A temporary professional panel exposes the time-dependent lattice
   solver and advanced routing controls.
+- **Stage 2.5 lattice integration:** Native builds now use the released
+  router-lib `v0.4.1`, keep the isochrone beam as the standard/default route,
+  and expose lattice routing only after explicit professional solver selection.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ validation, and use `scripts/publish.sh` or `scripts/publish.ps1` for
 distributable artifacts. For a custom bridge location, set
 `NAVTOOL_ROUTER_BRIDGE_PATH` to the shared library or its directory. Packaged
 applications discover their bridge under `runtimes/<RID>/native`. Native builds
-fetch and compile the immutable `router-lib` release `v0.4.0` by default. Set
+fetch and compile the immutable `router-lib` Stage 2.5 release `v0.4.1` by
+default. Set
 `SAILROUTE_SOURCE_DIR` to a local `router-lib` checkout when testing other
 revisions.
 
@@ -127,7 +128,7 @@ interpolation. It intentionally adds no tack or gybe delay, no hard maximum-wind
 cutoff, and clamps wind above the polar's tabulated range.
 
 Enable **Professional routing features** in the planning drawer to reveal the
-temporary router-lib v0.4 controls. Professional mode can select either the
+temporary `router-lib` Stage 2.5 controls. Professional mode can select either the
 isochrone beam or deterministic time-dependent lattice solver and configure
 maneuver penalties, heading augmentation, wind sampling, polar interpolation,
 wind limits, pruning, and solver-specific settings. The toggle and edited values
@@ -224,7 +225,7 @@ also be installed or packaged according to the target platform.
 | --- | --- |
 | `NAVTOOL_ROUTER_BRIDGE_PATH` | Native bridge file or directory |
 | `SAILROUTE_SOURCE_DIR` | Optional `router-lib` checkout override for native build/run scripts |
-| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.4.0`) |
+| `NAVTOOL_ROUTER_LIB_RELEASE_TAG` | Immutable `router-lib` revision or release tag used when `SAILROUTE_SOURCE_DIR` is unset (default `v0.4.1`) |
 | `NAVTOOL_ROUTER_LIB_RELEASE_REPOSITORY` | `router-lib` Git repository used when `SAILROUTE_SOURCE_DIR` is unset |
 | `NAVTOOL_NATIVE_BUILD_DIR` | Optional native bridge build directory |
 | `NAVTOOL_APP_DATA_ROOT` | Application data root |

--- a/native/Navtool.RouterBridge/CMakeLists.txt
+++ b/native/Navtool.RouterBridge/CMakeLists.txt
@@ -15,7 +15,7 @@ set(
     "router-lib release repository used when SAILROUTE_SOURCE_DIR is unset")
 set(
     NAVTOOL_ROUTER_LIB_RELEASE_TAG
-    "v0.4.0"
+    "v0.4.1"
     CACHE STRING
     "Immutable router-lib revision used when SAILROUTE_SOURCE_DIR is unset")
 set(_navtool_router_effective_source_dir "")

--- a/native/Navtool.RouterBridge/tests/bridge_tests.cpp
+++ b/native/Navtool.RouterBridge/tests/bridge_tests.cpp
@@ -342,30 +342,21 @@ uint8_t cancel_v6_progress(
 }
 
 navtool_router_options_v6 balanced_options_v6() {
-    return {
-        NAVTOOL_ROUTER_SOLVER_ISOCHRONE_BEAM_V6,
-        3,
-        1,
-        1,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        30,
-        150.0,
-        0.0,
-        2.0,
-        120.0,
-        450.0,
-        3,
-        4,
-        1,
-        2,
-        250,
-        0};
+    navtool_router_options_v6 options{};
+    options.heading_augmentation = 3;
+    options.wind_sampling = 1;
+    options.polar_angle_interpolation = 1;
+    options.lattice_time_bucket_minutes = 30;
+    options.downwind_true_wind_angle_degrees = 150.0;
+    options.pruning_sector_degrees = 2.0;
+    options.destination_front_half_angle_degrees = 120.0;
+    options.lattice_corridor_width_nautical_miles = 450.0;
+    options.destination_front_minimum_secondary_segment_points = 3;
+    options.lattice_subdivision_level = 4;
+    options.lattice_refinement_levels = 1;
+    options.lattice_corridor_widening_retries = 2;
+    options.lattice_progress_every_n_expansions = 250;
+    return options;
 }
 
 std::filesystem::path create_grib_with_missing_v_step() {
@@ -912,7 +903,7 @@ int main() {
         require(
             std::string{route_json}.find("\"latticeDiagnostics\"") ==
                 std::string::npos,
-            "beam route unexpectedly included lattice diagnostics");
+            "defaulted solver unexpectedly selected lattice routing");
         navtool_router_bridge_free_v1(route_json);
 
         route_json = nullptr;
@@ -983,6 +974,12 @@ int main() {
             std::string{route_json}.find("\"latticeDiagnostics\"") !=
                 std::string::npos,
             "lattice route omitted lattice diagnostics");
+        require(
+            std::string{route_json}.find("\"reRelaxedLabels\"") !=
+                std::string::npos &&
+                std::string{route_json}.find("\"fallbackReason\"") !=
+                    std::string::npos,
+            "lattice route omitted Stage 2.5 diagnostics");
         navtool_router_bridge_free_v1(route_json);
         route_json = nullptr;
         route_json_length = 0U;

--- a/scripts/build-native.ps1
+++ b/scripts/build-native.ps1
@@ -10,7 +10,7 @@ if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
     $BuildDirectory = Join-Path $Root "native\Navtool.RouterBridge\build"
 }
 if ([string]::IsNullOrWhiteSpace($RouterRevision)) {
-    $RouterRevision = "v0.4.0"
+    $RouterRevision = "v0.4.1"
 }
 
 if ([string]::IsNullOrWhiteSpace($RouterSource)) {

--- a/scripts/build-native.sh
+++ b/scripts/build-native.sh
@@ -3,7 +3,7 @@ set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 build_dir=${NAVTOOL_NATIVE_BUILD_DIR:-"$root/native/Navtool.RouterBridge/build"}
-router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"v0.4.0"}
+router_revision=${NAVTOOL_ROUTER_LIB_RELEASE_TAG:-"v0.4.1"}
 
 if [ -n "${SAILROUTE_SOURCE_DIR:-}" ]; then
   router_source=$SAILROUTE_SOURCE_DIR

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -231,6 +231,9 @@
                                         <ComboBox x:Name="RouteSolverSelector"
                                                   ItemsSource="{Binding RouteSolverOptions}"
                                                   SelectedItem="{Binding SelectedRouteSolver}" />
+                                        <TextBlock Classes="muted"
+                                                  Text="The lattice solver is opt-in; standard routing always remains on the isochrone beam."
+                                                  TextWrapping="Wrap" />
                                     </StackPanel>
                                     <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
                                         <StackPanel Spacing="4">
@@ -295,7 +298,8 @@
                                                            Value="{Binding PruningSectorDegrees}" />
                                         </StackPanel>
                                     </Grid>
-                                    <StackPanel IsVisible="{Binding IsProfessionalBeamRouting}"
+                                    <StackPanel x:Name="BeamRoutingOptions"
+                                                IsVisible="{Binding IsProfessionalBeamRouting}"
                                                 Spacing="8">
                                         <TextBlock Classes="field-label" Text="Destination front" />
                                         <ComboBox ItemsSource="{Binding DestinationFrontPolicyOptions}"
@@ -307,7 +311,8 @@
                                                            Value="{Binding DestinationFrontMinimumSecondarySegmentPoints}" />
                                         </Grid>
                                     </StackPanel>
-                                    <StackPanel IsVisible="{Binding IsProfessionalLatticeRouting}"
+                                    <StackPanel x:Name="LatticeRoutingOptions"
+                                                IsVisible="{Binding IsProfessionalLatticeRouting}"
                                                 Spacing="8">
                                         <TextBlock Classes="field-label" Text="Lattice search" />
                                         <ComboBox ItemsSource="{Binding LatticeSearchAlgorithmOptions}"

--- a/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
+++ b/tests/Navtool.App.Tests/MainViewModelWorkflowTests.cs
@@ -26,6 +26,7 @@ public sealed class MainViewModelWorkflowTests
             new OsmTileOptions(Enabled: false));
 
         Assert.False(viewModel.EnableProfessionalRouting);
+        Assert.Equal(RouteSolver.IsochroneBeam, viewModel.SelectedRouteSolver);
         Assert.False(viewModel.IsProfessionalBeamRouting);
         Assert.False(viewModel.IsProfessionalLatticeRouting);
 

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -25,7 +25,7 @@ namespace Navtool.App.Tests;
 public sealed class MainWindowLayoutTests
 {
     [AvaloniaFact]
-    public void DrawersAreAlwaysInTheWindowNameScopeAndClosedByDefault()
+    public void DrawersAndRoutingOptionsFollowDefaultAndExplicitSelections()
     {
         var window = CreateWindow();
 
@@ -50,6 +50,27 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
             Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
             Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
+            window.SetPlanningDrawerOpen(true);
+            var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
+            var beamOptions = Assert.IsType<StackPanel>(
+                window.FindControl<StackPanel>("BeamRoutingOptions"));
+            var latticeOptions = Assert.IsType<StackPanel>(
+                window.FindControl<StackPanel>("LatticeRoutingOptions"));
+
+            Assert.Equal(RouteSolver.IsochroneBeam, viewModel.SelectedRouteSolver);
+            Assert.False(viewModel.EnableProfessionalRouting);
+            Assert.False(beamOptions.IsVisible);
+            Assert.False(latticeOptions.IsVisible);
+
+            viewModel.EnableProfessionalRouting = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(beamOptions.IsVisible);
+            Assert.False(latticeOptions.IsVisible);
+
+            viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(beamOptions.IsVisible);
+            Assert.True(latticeOptions.IsVisible);
         }
         finally
         {

--- a/tests/Navtool.Core.Tests/RouteOptimizationOptionsTests.cs
+++ b/tests/Navtool.Core.Tests/RouteOptimizationOptionsTests.cs
@@ -8,6 +8,7 @@ public sealed class RouteOptimizationOptionsTests
         var options = RouteOptimizationOptions.Balanced;
 
         Assert.Equal(RouteSolver.IsochroneBeam, options.Solver);
+        Assert.Equal(RouteSolver.IsochroneBeam, new RouteOptimizationOptions().Solver);
         Assert.Equal(
             RouteHeadingAugmentation.DestinationBearingAndVelocityMadeGood,
             options.HeadingAugmentation);

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -88,8 +88,13 @@ public sealed class RoutingWorkflowTests
             },
             engine);
         var reports = new ConcurrentQueue<RoutingProgress>();
+        var request = CreateWorkflowRequest();
+        Assert.Same(RouteOptimizationOptions.Balanced, request.Optimization);
+        Assert.Equal(RouteSolver.IsochroneBeam, request.Optimization.Solver);
 
-        var execution = workflow.ExecuteAsync(CreateWorkflowRequest(), new InlineProgress<RoutingProgress>(reports.Enqueue));
+        var execution = workflow.ExecuteAsync(
+            request,
+            new InlineProgress<RoutingProgress>(reports.Enqueue));
         await bothEntered.Task.WaitAsync(TimeSpan.FromSeconds(2));
         release.SetResult();
         var result = await execution;

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterBridgeIntegrationTests.cs
@@ -62,6 +62,8 @@ public sealed class NativeRouterBridgeIntegrationTests
             snapshots.Add);
         Assert.NotEmpty(route.Points);
         Assert.True(route.Diagnostics.GeneratedCandidates > 0);
+        Assert.Equal(RouteSolver.IsochroneBeam, route.Solver);
+        Assert.Null(route.LatticeDiagnostics);
         Assert.Equal(LandAvoidanceStatus.NotEvaluated, route.LandAvoidance.Status);
         var eligibilityCalls = 0;
         var rejected = Assert.Throws<NativeRouterException>(() =>
@@ -127,6 +129,14 @@ public sealed class NativeRouterBridgeIntegrationTests
             null);
         Assert.Equal(RouteSolver.TimeDependentLattice, latticeRoute.Solver);
         Assert.NotNull(latticeRoute.LatticeDiagnostics);
+        Assert.True(latticeRoute.LatticeDiagnostics.ActiveCells > 0);
+        Assert.True(latticeRoute.LatticeDiagnostics.ActiveFaces > 0);
+        Assert.Equal(
+            0,
+            latticeRoute.LatticeDiagnostics.AcceptedCorridorWidthNauticalMiles);
+        Assert.Equal(
+            LatticeRefinementFallbackReason.None,
+            latticeRoute.LatticeDiagnostics.FallbackReason);
         Assert.NotEmpty(latticeSnapshots);
         Assert.All(latticeSnapshots, snapshot =>
         {

--- a/tests/Navtool.Infrastructure.Tests/NativeRouterInteropLayoutTests.cs
+++ b/tests/Navtool.Infrastructure.Tests/NativeRouterInteropLayoutTests.cs
@@ -33,5 +33,26 @@ public sealed class NativeRouterInteropLayoutTests
             maximumTrueWindSpeedKnots: 35));
         Assert.Equal(1UL, limited.Flags);
         Assert.Equal(35, limited.MaximumTrueWindSpeedKnots);
+
+        var lattice = NativeRoutingOptions.From(new RouteOptimizationOptions(
+            solver: RouteSolver.TimeDependentLattice,
+            lattice: new RouteLatticeOptions(
+                subdivisionLevel: 5,
+                timeBucket: TimeSpan.FromMinutes(45),
+                refinementLevels: 2,
+                corridorWidthNauticalMiles: 600,
+                corridorWideningRetries: 3,
+                progressEveryExpansions: 75,
+                searchAlgorithm: RouteLatticeSearchAlgorithm.Dijkstra)));
+        Assert.Equal((int)RouteSolver.TimeDependentLattice, lattice.Solver);
+        Assert.Equal(5UL, lattice.LatticeSubdivisionLevel);
+        Assert.Equal(45, lattice.LatticeTimeBucketMinutes);
+        Assert.Equal(2UL, lattice.LatticeRefinementLevels);
+        Assert.Equal(600, lattice.LatticeCorridorWidthNauticalMiles);
+        Assert.Equal(3UL, lattice.LatticeCorridorWideningRetries);
+        Assert.Equal(75UL, lattice.LatticeProgressEveryExpansions);
+        Assert.Equal(
+            (int)RouteLatticeSearchAlgorithm.Dijkstra,
+            lattice.LatticeSearchAlgorithm);
     }
 }


### PR DESCRIPTION
Navtool now consumes the completed Stage 2 release rather than v0.4.0. This follow-up pins the native bridge to the immutable `v0.4.1` tag and adds end-to-end assertions that standard routing remains on the isochrone beam while lattice routing is available only through explicit Professional solver selection.

## Changes

- update native CMake and Unix/Windows build-script defaults to router-lib `v0.4.1`
- clarify the opt-in lattice workflow and expose stable names for solver-specific UI sections
- replace the fragile positional native test initializer with zero-initialized named assignments
- verify default beam behavior, explicit ABI v6 lattice option mapping, solver-specific UI visibility, streaming results, and Stage 2.5 diagnostics

The bridge intentionally leaves destination-front mode unset because ABI v6 has no selector; router-lib keeps its compatibility-safe `retained_frontier` default.

## Validation

- clean native fetch/build against `v0.4.1`: 1/1 CTest passed
- full managed Release suite: 328/328 passed
- focused default/explicit routing matrix: 8/8 passed