### PR TITLE
Separate default routing regression coverage

### DIFF
--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -78,6 +78,42 @@ public sealed class MainWindowLayoutTests
         }
     }
 
+    [AvaloniaFact]
+    public void Lattice_controls_require_explicit_professional_solver_selection()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
+            window.SetPlanningDrawerOpen(true);
+            var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
+            var beamOptions = Assert.IsType<StackPanel>(
+                window.FindControl<StackPanel>("BeamRoutingOptions"));
+            var latticeOptions = Assert.IsType<StackPanel>(
+                window.FindControl<StackPanel>("LatticeRoutingOptions"));
+
+            Assert.Equal(RouteSolver.IsochroneBeam, viewModel.SelectedRouteSolver);
+            Assert.False(viewModel.EnableProfessionalRouting);
+            Assert.False(beamOptions.IsVisible);
+            Assert.False(latticeOptions.IsVisible);
+
+            viewModel.EnableProfessionalRouting = true;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(beamOptions.IsVisible);
+            Assert.False(latticeOptions.IsVisible);
+
+            viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(beamOptions.IsVisible);
+            Assert.True(latticeOptions.IsVisible);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
     [Fact]
     public void SizingPolicyPreservesTheMapFloorAndUsesTheRequestedBreakpoint()
     {

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -5,6 +5,17 @@ namespace Navtool.Core.Tests;
 public sealed class RoutingWorkflowTests
 {
     [Fact]
+    public void Workflow_request_without_solver_selection_uses_balanced_beam()
+    {
+        var request = new RoutingWorkflowRequest(
+            CreateRouteRequest(),
+            new[] { ForecastModel.NoaaGfs });
+
+        Assert.Same(RouteOptimizationOptions.Balanced, request.Optimization);
+        Assert.Equal(RouteSolver.IsochroneBeam, request.Optimization.Solver);
+    }
+
+    [Fact]
     public async Task Workflow_runs_models_concurrently_and_keeps_success_and_failure_separate()
     {
         var entered = 0;


### PR DESCRIPTION
The v0.4.1 integration already verifies default and explicit solver behavior, but two assertions were embedded in broader tests. This follow-up isolates them so failures identify the compatibility contract directly.

- verify omitted optimization uses the exact Balanced beam profile
- verify Professional controls remain hidden by default and lattice controls require explicit lattice selection

No production, documentation, build, or dependency behavior changes.

## Validation

- focused tests: 2/2 passed
- full managed Release suite: 330/330 passed
- formatting and diff checks passed