### PR TITLE
Remove duplicate routing regression assertions

### DIFF
--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -50,6 +50,21 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
             Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
             Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Lattice_controls_require_explicit_professional_solver_selection()
+    {
+        var window = CreateWindow();
+
+        try
+        {
+            window.Show();
             window.SetPlanningDrawerOpen(true);
             var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
             var beamOptions = Assert.IsType<StackPanel>(

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -89,8 +89,6 @@ public sealed class RoutingWorkflowTests
             engine);
         var reports = new ConcurrentQueue<RoutingProgress>();
         var request = CreateWorkflowRequest();
-        Assert.Same(RouteOptimizationOptions.Balanced, request.Optimization);
-        Assert.Equal(RouteSolver.IsochroneBeam, request.Optimization.Solver);
 
         var execution = workflow.ExecuteAsync(
             request,
@@ -122,6 +120,15 @@ public sealed class RoutingWorkflowTests
         Assert.Contains(reports, report =>
             report.Model == ForecastModel.EcmwfIfs &&
             report.Stage == RoutingProgressStage.Failed);
+    }
+
+    [Fact]
+    public void Workflow_request_without_solver_selection_uses_balanced_beam()
+    {
+        var request = CreateWorkflowRequest();
+
+        Assert.Same(RouteOptimizationOptions.Balanced, request.Optimization);
+        Assert.Equal(RouteSolver.IsochroneBeam, request.Optimization.Solver);
     }
 
     [Fact]


### PR DESCRIPTION
The focused default-beam and explicit-lattice tests are merged, but their assertions also remain embedded in unrelated broader tests. This test-only cleanup keeps the dedicated coverage while restoring the original drawer and concurrent-workflow tests to their narrower responsibilities.

No production behavior or coverage is removed.

## Validation

- focused tests: 2/2 passed
- full managed Release suite: 330/330 passed
- formatting check passed