### PR TITLE
Deduplicate focused routing tests

### DIFF
--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -25,7 +25,7 @@ namespace Navtool.App.Tests;
 public sealed class MainWindowLayoutTests
 {
     [AvaloniaFact]
-    public void DrawersAndRoutingOptionsFollowDefaultAndExplicitSelections()
+    public void DrawersAreAlwaysInTheWindowNameScopeAndClosedByDefault()
     {
         var window = CreateWindow();
 
@@ -50,27 +50,6 @@ public sealed class MainWindowLayoutTests
             Assert.NotNull(window.FindControl<RadioButton>("DownloadForecastSource"));
             Assert.NotNull(window.FindControl<RadioButton>("LocalForecastSource"));
             Assert.NotNull(window.FindControl<Button>("ChooseGribFileButton"));
-            window.SetPlanningDrawerOpen(true);
-            var viewModel = Assert.IsType<MainViewModel>(window.DataContext);
-            var beamOptions = Assert.IsType<StackPanel>(
-                window.FindControl<StackPanel>("BeamRoutingOptions"));
-            var latticeOptions = Assert.IsType<StackPanel>(
-                window.FindControl<StackPanel>("LatticeRoutingOptions"));
-
-            Assert.Equal(RouteSolver.IsochroneBeam, viewModel.SelectedRouteSolver);
-            Assert.False(viewModel.EnableProfessionalRouting);
-            Assert.False(beamOptions.IsVisible);
-            Assert.False(latticeOptions.IsVisible);
-
-            viewModel.EnableProfessionalRouting = true;
-            Dispatcher.UIThread.RunJobs();
-            Assert.True(beamOptions.IsVisible);
-            Assert.False(latticeOptions.IsVisible);
-
-            viewModel.SelectedRouteSolver = RouteSolver.TimeDependentLattice;
-            Dispatcher.UIThread.RunJobs();
-            Assert.False(beamOptions.IsVisible);
-            Assert.True(latticeOptions.IsVisible);
         }
         finally
         {

--- a/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
+++ b/tests/Navtool.Core.Tests/RoutingWorkflowTests.cs
@@ -100,8 +100,6 @@ public sealed class RoutingWorkflowTests
             engine);
         var reports = new ConcurrentQueue<RoutingProgress>();
         var request = CreateWorkflowRequest();
-        Assert.Same(RouteOptimizationOptions.Balanced, request.Optimization);
-        Assert.Equal(RouteSolver.IsochroneBeam, request.Optimization.Solver);
 
         var execution = workflow.ExecuteAsync(
             request,


### PR DESCRIPTION
The sub-session merge audit found that the focused default-beam and explicit-lattice tests were merged successfully, but their assertions remained duplicated inside broader drawer and concurrency tests. This test-only cleanup restores those broader tests to their original responsibilities while retaining the focused regression methods unchanged.

No production behavior or coverage changes.

## Validation

- retained focused tests: 2/2 passed
- full managed Release suite: 330/330 passed
- formatting and diff checks passed