### PR TITLE
Add apparent wind angle to route-point popup

### DIFF
--- a/src/Navtool.App/Models/RouteMapSelection.cs
+++ b/src/Navtool.App/Models/RouteMapSelection.cs
@@ -54,4 +54,25 @@ public sealed record RouteMapSelection
     public DateTimeOffset TimelineTimestamp => Point.Timestamp;
 
     public Coordinate FocusCoordinate => Point.Location;
+
+    public string ApparentWindAngleText =>
+        FormatApparentWindAngle(Point.ApparentWindAngleSignedDegrees);
+
+    internal static string FormatApparentWindAngle(double signedAngleDegrees)
+    {
+        var angle = (int)Math.Round(
+            Math.Abs(signedAngleDegrees),
+            MidpointRounding.AwayFromZero);
+        if (angle <= 0)
+        {
+            return "0°";
+        }
+
+        if (angle >= 180)
+        {
+            return "180°";
+        }
+
+        return $"{angle}° {(signedAngleDegrees > 0d ? "S" : "P")}";
+    }
 }

--- a/src/Navtool.App/Views/MainWindow.axaml
+++ b/src/Navtool.App/Views/MainWindow.axaml
@@ -801,7 +801,7 @@
                          IsHitTestVisible="False" />
                 <Button x:Name="RouteTelemetryCard"
                         Classes="route-telemetry"
-                        Width="296"
+                        Width="344"
                         Height="132"
                         Click="OnRouteTelemetryCardClicked"
                         AutomationProperties.Name="Route point telemetry"
@@ -826,7 +826,7 @@
                         <Border Grid.Row="1"
                                 Background="{DynamicResource OverlayBorderColor}" />
                         <Grid Grid.Row="2"
-                              ColumnDefinitions="*,*,*,*,*"
+                              ColumnDefinitions="*,*,*,*,*,*"
                               ColumnSpacing="6">
                             <StackPanel>
                                 <TextBlock Text="BOAT"
@@ -857,6 +857,13 @@
                                            Classes="telemetry-value" />
                             </StackPanel>
                             <StackPanel Grid.Column="4">
+                                <TextBlock Text="AWA"
+                                           Classes="telemetry-label" />
+                                <TextBlock x:Name="RouteTelemetryApparentWindAngle"
+                                           Text="{Binding SelectedRoutePoint.ApparentWindAngleText}"
+                                           Classes="telemetry-value" />
+                            </StackPanel>
+                            <StackPanel Grid.Column="5">
                                 <TextBlock Text="HDG"
                                            Classes="telemetry-label" />
                                 <TextBlock x:Name="RouteTelemetryHeading"

--- a/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
+++ b/tests/Navtool.App.Tests/MainWindowLayoutTests.cs
@@ -561,6 +561,10 @@ public sealed class MainWindowLayoutTests
                 Assert.IsType<TextBlock>(
                     window.FindControl<TextBlock>("RouteTelemetryApparentWind")).Text);
             Assert.Equal(
+                "68° S",
+                Assert.IsType<TextBlock>(
+                    window.FindControl<TextBlock>("RouteTelemetryApparentWindAngle")).Text);
+            Assert.Equal(
                 "90°",
                 Assert.IsType<TextBlock>(
                     window.FindControl<TextBlock>("RouteTelemetryHeading")).Text);

--- a/tests/Navtool.App.Tests/RouteMapSelectionTests.cs
+++ b/tests/Navtool.App.Tests/RouteMapSelectionTests.cs
@@ -1,0 +1,21 @@
+using Navtool.App.Models;
+
+namespace Navtool.App.Tests;
+
+public sealed class RouteMapSelectionTests
+{
+    [Theory]
+    [InlineData(68.198, "68° S")]
+    [InlineData(-68.198, "68° P")]
+    [InlineData(0, "0°")]
+    [InlineData(180, "180°")]
+    [InlineData(-180, "180°")]
+    public void FormatsApparentWindAngleWithCompactSideMarker(
+        double signedAngleDegrees,
+        string expected)
+    {
+        Assert.Equal(
+            expected,
+            RouteMapSelection.FormatApparentWindAngle(signedAngleDegrees));
+    }
+}


### PR DESCRIPTION
Route-point telemetry showed apparent wind speed but not the corresponding angle, making it harder to interpret the selected sailing conditions at a glance.

## Summary

- add an `AWA` metric to the route-point telemetry popup
- display compact whole-degree values with `S` or `P` side markers
- omit the side marker for directly ahead (`0°`) and astern (`180°`) values
- reuse the existing core apparent-wind calculation and keep long-form route details unchanged

## Testing

- targeted headless UI coverage for the telemetry popup
- formatting coverage for port, starboard, ahead, and astern values