### PR TITLE
Reconcile documentation with August merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,108 @@
 # Navtool release notes
 
-## Week of July 27-August 1, 2026 (Draft)
+## Week of August 3-7, 2026 (Draft)
 
-This week adds land-aware routing, persistent multi-point voyage plans,
-sequential per-model calculation, rolling route resume, full-route
-visualization, and reusable NOAA forecast caching. It also modernizes the chart
-controls, adds production ECMWF IFS wind acquisition, and strengthens native
-bridge launch guidance and automated validation.
+This week adds production ECMWF routing, automatic route calculation, anchored
+route-point telemetry, advanced beam and lattice controls, and opt-in Stage 3
+environmental physics. It also improves departure-time handling, forecast
+selection, mapping compliance, and native bridge diagnostics.
 
 > **Release status:** Unreleased draft for editorial review.
 
 ### Highlights
 
-- **Opt-in environmental physics:** The professional routing panel can now
-  enable router-lib's Stage 3 providers: a uniform current field translated into
-  ground-frame motion, sea-state derating of boat speed, router-lib's certified
-  signed-distance landmask as an alternative to the segment callback, and
-  time-varying exclusion zones. Every provider is off by default, and a route
-  with none enabled produces byte-identical output to the previous release.
-  Applied models, sources, revisions, missing-data policies, and diagnostics
-  counters are shown in the route detail view and persisted with the plan.
-  Speed and course over ground are reported alongside the water-relative values
-  rather than replacing them. Navtool consumes environmental data you supply; it
-  does not acquire currents or wave forecasts.
+- **Opt-in environmental physics:** The professional routing panel can enable a
+  uniform current field, sea-state speed derating, router-lib's certified
+  signed-distance landmask, and time-varying exclusion zones. Providers are off
+  by default; enabled providers record their source, revision, missing-data
+  policy, diagnostics, and ground-frame telemetry with the saved route.
+  Navtool consumes environmental data supplied by the user and does not yet
+  acquire current or wave forecasts.
+  ([#69](https://github.com/frye/navtool/pull/69))
+- **Production ECMWF routing:** Navtool can acquire ECMWF IFS 0.25-degree wind
+  from indexed Open Data byte ranges, resume and reuse cached downloads, decode
+  only the route corridor, and use the result for normal routing and overlays.
+  ([#56](https://github.com/frye/navtool/pull/56))
+- **Router-lib v0.4 routing:** The balanced isochrone beam remains the default
+  with destination/VMG heading augmentation, midpoint wind sampling, and
+  monotone-cubic polar interpolation. Professional controls can explicitly
+  select the time-dependent lattice solver and expose its progress and
+  diagnostics.
+  ([#57](https://github.com/frye/navtool/pull/57),
+  [#59](https://github.com/frye/navtool/pull/59),
+  [#64](https://github.com/frye/navtool/pull/64))
+
+### Added
+
+- Automatically starts routing when both endpoints are placed and safely
+  restarts after an endpoint changes. The progress rail now provides a direct
+  cancellation action; the radial Calculate action remains available for forced
+  recalculation.
+  ([#54](https://github.com/frye/navtool/pull/54))
+- Added an anchored route-point telemetry card with arrival time, boat speed,
+  true and apparent wind, heading, and apparent wind angle. Route selection,
+  timeline state, the active forecast model, and wind overlays update together.
+  ([#55](https://github.com/frye/navtool/pull/55),
+  [#60](https://github.com/frye/navtool/pull/60),
+  [#68](https://github.com/frye/navtool/pull/68))
+- Added a one-shot **Refresh weather** radial toggle that requests the newest
+  available forecast for the next calculation.
+  ([#61](https://github.com/frye/navtool/pull/61))
+
+### Improved
+
+- Local departure inputs now stay synchronized with route plans, display their
+  resolved UTC instant, validate daylight-saving transitions, and roll expired
+  active-leg departures forward without changing sailed history.
+  ([#52](https://github.com/frye/navtool/pull/52),
+  [#71](https://github.com/frye/navtool/pull/71))
+- Added ABI-v7 configured beam/lattice dispatch, solver-aware progress, schema-v3
+  result attribution, lattice diagnostics, and the optional Stage 3 environment
+  payload while preserving older bridge entry points and plan migration.
+  ([#62](https://github.com/frye/navtool/pull/62),
+  [#69](https://github.com/frye/navtool/pull/69))
+
+### Fixed
+
+- Fixed route calculation for NOAA forecasts assembled from multiple spatial
+  cache tiles, including corridors crossing tile boundaries.
+  ([#49](https://github.com/frye/navtool/pull/49))
+- Fixed themed control contrast, compact date/time picker clipping, picker-label
+  alignment, and radial-control interaction.
+  ([#58](https://github.com/frye/navtool/pull/58),
+  [#61](https://github.com/frye/navtool/pull/61))
+- Pruned lattice transitions that probe beyond forecast coverage and fall back
+  once to the default beam with a visible warning when the selected professional
+  solver fails.
+  ([#71](https://github.com/frye/navtool/pull/71))
+
+### Maintenance
+
+- Added the mapping stack's required notices, persistent OpenStreetMap tile
+  caching, and application-specific request identification.
+  ([#48](https://github.com/frye/navtool/pull/48))
+
+### Known limitations
+
+- Navtool is planning software, not navigation-certified guidance. Land data is
+  generalized, and traffic, depths, and safety limits are not modeled. Currents,
+  waves, and exclusions affect routing only when explicitly enabled and supplied.
+- Online ECMWF support is wind-only, and global field downloads can be larger
+  than NOAA subsets.
+- The professional lattice solver is serial, does not expose beam-style
+  isochrones, and currently falls back to the beam for known failure modes.
+
+## Week of July 27-August 1, 2026 (Draft)
+
+This week adds land-aware routing, persistent multi-point voyage plans,
+sequential per-model calculation, rolling route resume, full-route
+visualization, and reusable NOAA forecast caching. It also modernizes the chart
+controls and strengthens native bridge launch guidance and automated
+validation.
+
+> **Release status:** Unreleased draft for editorial review.
+
+### Highlights
 
 - **Land-aware routing by default:** Candidate route segments are checked
   against bundled Natural Earth coastline data before retention. An optional
@@ -41,20 +121,8 @@ bridge launch guidance and automated validation.
   together, selected from the list or map, and inspected on a route-wide
   active-model timeline with explicit stopover holds.
   ([#43](https://github.com/frye/navtool/pull/43))
-- **Router-lib v0.4 routing:** Standard routes now use destination/VMG heading
-  augmentation, midpoint wind sampling, and monotone-cubic polar interpolation
-  by default. A temporary professional panel exposes the time-dependent lattice
-  solver and advanced routing controls.
-- **Stage 2.5 lattice integration:** Native builds now use the released
-  router-lib `v0.4.1`, keep the isochrone beam as the standard/default route,
-  and expose lattice routing only after explicit professional solver selection.
-
 ### Added
 
-- Added production ECMWF IFS 0.25-degree wind acquisition from ECMWF Open Data,
-  including rolling-cycle discovery, indexed 10u/10v byte-range downloads,
-  resumable persistent caching, native route-corridor loading, and normal
-  multi-model routing and weather overlays.
 - Added persistent Light, Dark, and **Kind of Blue** themes with a compact
   runtime selector and distinct interactive states.
   ([#22](https://github.com/frye/navtool/pull/22))
@@ -70,9 +138,6 @@ bridge launch guidance and automated validation.
 
 ### Improved
 
-- Added ABI-v6 solver-aware progress, lattice search markers and diagnostics,
-  configured beam/lattice dispatch, and schema-v3 result attribution while
-  preserving legacy bridge exports and route-plan migration.
 - Restored one open, destination-facing isochrone front per routing step,
   retained forecast-limited estimates, softened display-only corners, widened
   the useful destination aperture, and suppressed misleading singleton marks.
@@ -90,10 +155,6 @@ bridge launch guidance and automated validation.
 
 ### Fixed
 
-- Fixed route calculation for NOAA forecasts assembled from multiple spatial
-  cache tiles, including corridors that cross tile latitude or longitude
-  boundaries.
-  ([router-lib v0.3.1](https://github.com/frye/router-lib/releases/tag/v0.3.1))
 - Fixed historical isochrone styles inheriting an opaque fill in CI and
   restored .NET 9 compatibility for radial-action placement.
   ([#35](https://github.com/frye/navtool/pull/35),
@@ -114,11 +175,6 @@ bridge launch guidance and automated validation.
   coastline data is generalized and can omit small or recent hazards; routing
   still does not model currents, waves, traffic, restricted areas, depths, or
   safety limits.
-- Online ECMWF support is wind-only. Routing still does not model waves or
-  currents, and ECMWF global field downloads can be larger than NOAA subsets.
-- Professional lattice routing is serial and does not produce beam-style
-  isochrones or destination fronts; Navtool displays its search point and
-  provisional route instead.
 
 ## Week of July 13-17, 2026 (Draft)
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ It targets macOS, Windows, and Linux.
 - Open on a Salish Sea chart view and use resizable edge drawers plus
   right-click, long-press, or keyboard radial map actions to place endpoints,
   inspect routes, and start calculation without obscuring the chart.
-- Choose a local departure date/time, converted to UTC with DST validation; when calculation
-  starts with a past active-leg departure, Navtool rolls it forward to the current time and warns
-  without changing sailed-leg history.
+- Choose a local departure date/time with a UTC preview and DST validation. When
+  calculation starts with a past active-leg departure, Navtool rolls it forward
+  to the current time and warns without changing sailed-leg history.
 - Set the expected passage duration so only the required forecast times are
   acquired, up to the ten-day planning limit.
 - Download NOAA GFS or ECMWF IFS 0.25-degree 10 m wind fields, or choose an
   existing GRIB through the operating system's native file picker.
 - Calculate routes through the native `router-lib` v0.4 bridge with enhanced
   beam-routing accuracy enabled by default.
+- Start calculation automatically after both endpoints are placed, restart
+  safely when an endpoint changes, or force recalculation from the radial menu.
 - Apply bundled Natural Earth land geometry by default, with an optional
   higher-detail OSM-derived service override.
 - Watch historical destination-facing isochrone fronts, the emphasized latest
@@ -35,6 +37,9 @@ It targets macOS, Windows, and Linux.
   uncalculated, and out-of-window legs.
 - Select a leg from the ordered list or map to emphasize it without hiding the
   rest of the route, then fit the leg or focus an individual route point.
+- Inspect a route point in an anchored map card showing arrival time, boat
+  speed, heading, true and apparent wind, and apparent wind angle. The selected
+  model, timeline, card, and wind overlay remain synchronized.
 - Scrub a route-wide UTC timeline for one active forecast model at a time, move
   among that model's route-point timestamps, and see waypoint stopovers as
   explicit stationary holds.
@@ -129,13 +134,13 @@ interpolation. It intentionally adds no tack or gybe delay, no hard maximum-wind
 cutoff, and clamps wind above the polar's tabulated range.
 
 Enable **Professional routing features** in the planning drawer to reveal the
-temporary `router-lib` Stage 2.5 controls. Professional mode can select either the
-isochrone beam or deterministic time-dependent lattice solver and configure
-maneuver penalties, heading augmentation, wind sampling, polar interpolation,
-wind limits, pruning, and solver-specific settings. The toggle and edited values
-reset when Navtool exits and are never stored as application preferences or route
-plan inputs. Completed results do retain solver attribution and lattice
-diagnostics.
+advanced `router-lib` controls. Professional mode can select either the isochrone
+beam or deterministic time-dependent lattice solver and configure maneuver
+penalties, heading augmentation, wind sampling, polar interpolation, wind limits,
+pruning, solver-specific settings, and the opt-in Stage 3 providers described
+below. The toggle and edited values reset when Navtool exits and are never stored
+as application preferences or route plan inputs. Completed results retain solver
+attribution, lattice diagnostics, and applied environment attribution.
 
 ## Multi-point routes and visualization
 
@@ -192,13 +197,14 @@ the final provisional route to a selectable forecast-limited estimate, retains
 the solver-appropriate search overlay, and displays an amber warning. Complete
 final routes remain authoritative and may differ from the last provisional route.
 
-The ABI-v6 bridge preserves the existing final-route and v1-v5 streaming
+The ABI-v7 bridge preserves the existing final-route and v1-v6 streaming
 functions. The v6 entry point adds fixed-layout routing options, solver identity,
-search points, and lattice counters while retaining optional pre-retention
-segment eligibility. Callback array and coordinate pointers are valid only for
-the duration of the synchronous callback and must be copied by consumers.
-Navtool rejects stale bridges so missing configuration or land-constraint
-support cannot silently degrade routing safety.
+search points, and lattice counters; v7 adds configured solver dispatch and the
+optional environment payload while retaining pre-retention segment eligibility.
+Callback array and coordinate pointers are valid only for the duration of the
+synchronous callback and must be copied by consumers. Navtool rejects stale
+bridges so missing configuration or land-constraint support cannot silently
+degrade routing safety.
 
 ## Publish
 
@@ -424,10 +430,10 @@ avoidance depends on the bundled generalized dataset or configured OSM-derived
 service, cached data freshness, and router-lib capability. Any degraded route
 is explicitly marked as not checked for land. Even a land-aware route can omit
 recent, small, generalized, or inaccurately mapped hazards and must be verified
-independently. The routing engine models currents, waves, and exclusion zones only when
-you explicitly enable and supply them (see "Environmental physics"); it never
-models traffic, depths, or safety limits. The built-in vessel polar is an
-approximate demonstration model.
+independently. The routing engine models currents, waves, and exclusion zones
+only when you explicitly enable and supply them (see "Environmental physics");
+it never models traffic, depths, or safety limits. The built-in vessel polar is
+an approximate demonstration model.
 
 The professional lattice solver reports search points and counters, not
 isochrones or destination-front geometry. It is currently serial and intended


### PR DESCRIPTION
## Summary

- add August 3-7 release notes covering merged user-facing changes since the prior documentation audit
- update README feature descriptions for automatic routing, route-point telemetry, local-time handling, and synchronized weather selection
- replace stale Stage 2.5 / ABI v6 wording with the current Stage 3 / ABI v7 behavior and clarify opt-in environmental limitations

## Validation

- `git diff --check`
- verified changelog references for all user-facing PRs in the audit window